### PR TITLE
Implement new Sbom enricher using pedigree fields

### DIFF
--- a/k8s/base/tekton/resources/pipeline-cyclonedx.yaml
+++ b/k8s/base/tekton/resources/pipeline-cyclonedx.yaml
@@ -31,6 +31,12 @@ spec:
     - name: build-id
       type: string
       description: "PNC build id for the project"
+    - name: build-env-jdk
+      type: string
+      description: "The JDK version defined in the build environment attributes"
+    - name: build-env-mvn
+      type: string
+      description: "The Maven version defined in the build environment attributes"
     - name: additional-cyclonedx-args
       type: string
       default: "--batch-mode --no-transfer-progress --quiet"
@@ -43,10 +49,10 @@ spec:
       type: string
       default: "no"
       description: "Whether an existing SBOM should be replaced"
-    - name: sbom-spec
+    - name: sbom-processor
       type: string
-      default: "properties"
-      description: "The sbom-spec to use when inserting additional information inside the base SBOM"
+      default: "SBOM_PEDIGREE"
+      description: "The sbom-processor to use when inserting additional information inside the base SBOM"
 
   tasks:
     # TODO: Ged rid of this dependency
@@ -75,6 +81,10 @@ spec:
       params:
         - name: build-id
           value: $(params.build-id)
+        - name: build-env-jdk
+          value: $(params.build-env-jdk)
+        - name: build-env-mvn
+          value: $(params.build-env-mvn)
     - name: generate-sbom-cyclonedx
       runAfter:
         - fetch-source
@@ -101,9 +111,8 @@ spec:
         # - name: override
         #   value: $(params.override)
           # Not used yet, to be added as a param to the REST API http://${SBOMER_SERVICE_HOST}:${SBOMER_SERVICE_PORT}/api/v1alpha1/sboms
-          # mgoldman / Not specified params cannot be passed, commenting out
-        # - name: sbom-spec
-        #   value: $(params.sbom-spec)
+        - name: sbom-processor
+          value: $(params.sbom-processor)
 
   workspaces:
     - name: data

--- a/k8s/base/tekton/resources/task-build-env.yaml
+++ b/k8s/base/tekton/resources/task-build-env.yaml
@@ -24,6 +24,10 @@ spec:
   params:
     - name: build-id
       type: string
+    - name: build-env-jdk
+      type: string
+    - name: build-env-mvn
+      type: string
   steps:
     - name: prepare
       image: sbomer-generator
@@ -54,15 +58,19 @@ spec:
         MVN_3_8 = re.compile(r"(3\.8)(\.*)")
         MVN_3_9 = re.compile(r"(3\.9)(\.*)")
 
-        url = urljoin(BUILD_API_ENDPOINT, BUILD_ID)
-        req = urllib.request.Request(url)
-        req.add_header("Content-Type", "application/json")
-        response = urllib.request.urlopen(req)
-        body = response.read()
-        build_info = json.loads(body.decode("utf-8"))
-        build_env_attr = build_info["environment"]["attributes"]
-
-        jdk_version = build_env_attr["JDK"]
+        if (not "$(params.build-env-jdk)" or not "$(params.build-env-mvn)"):
+            url = urljoin(BUILD_API_ENDPOINT, BUILD_ID)
+            req = urllib.request.Request(url)
+            req.add_header("Content-Type", "application/json")
+            response = urllib.request.urlopen(req)
+            body = response.read()
+            build_info = json.loads(body.decode("utf-8"))
+            build_env_attr = build_info["environment"]["attributes"]
+            jdk_version = build_env_attr["JDK"]
+            mvn_version = build_env_attr["MAVEN"]
+        else:
+            jdk_version = "$(params.build-env-jdk)"
+            mvn_version = "$(params.build-env-mvn)"
 
         if re.match(JDK_8, jdk_version):
             sdk_jdk_ver = 8
@@ -76,8 +84,6 @@ spec:
         print(f"Setting JDK {sdk_jdk_ver} for the current pipeline!")
         with open(JDK_RESULTS_FILE, "w") as f:
             f.write(str(sdk_jdk_ver))
-
-        mvn_version = build_env_attr["MAVEN"]
 
         if re.match(MVN_3_6, mvn_version):
             sdk_mvn_ver = 3.6

--- a/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
+++ b/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
@@ -76,7 +76,7 @@ spec:
       script: |
         #!/usr/bin/env bash
 
-        jq -s '{buildId: "$(params.build-id)", generator: "CYCLONEDX", sbom: .[0]}' $(workspaces.data.path)/$(params.workdir)/source/target/$(params.workdir).json > $(workspaces.data.path)/$(params.workdir)/source/target/payload.json
+        jq -s '{buildId: "$(params.build-id)", type: "BUILD_TIME", generator: "CYCLONEDX", sbom: .[0]}' $(workspaces.data.path)/$(params.workdir)/source/target/$(params.workdir).json > $(workspaces.data.path)/$(params.workdir)/source/target/payload.json
 
         [[ -z "${SBOMER_SERVICE_URL}" ]] && SBOMER_SERVICE_URL="http://${SBOMER_SERVICE_HOST}:${SBOMER_SERVICE_PORT}"
 

--- a/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
+++ b/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
@@ -36,6 +36,8 @@ spec:
       default: "2.7.5"
     - name: build-id
       type: string
+    - name: sbom-processor
+      type: string
   steps:
     - name: generate-cyclonedx-sbom
       image: sbomer-generator
@@ -78,7 +80,7 @@ spec:
 
         [[ -z "${SBOMER_SERVICE_URL}" ]] && SBOMER_SERVICE_URL="http://${SBOMER_SERVICE_HOST}:${SBOMER_SERVICE_PORT}"
 
-        curl -vX POST -H "Content-Type: application/json" -d @$(workspaces.data.path)/$(params.workdir)/source/target/payload.json ${SBOMER_SERVICE_URL}/api/v1alpha1/sboms/enrich
+        curl -vX POST -H "Content-Type: application/json" -d @$(workspaces.data.path)/$(params.workdir)/source/target/payload.json ${SBOMER_SERVICE_URL}/api/v1alpha1/sboms/enrich?$(params.sbom-processor)
 
   results:
     - name: "bom"

--- a/k8s/base/tekton/resources/task-generate-domino.yaml
+++ b/k8s/base/tekton/resources/task-generate-domino.yaml
@@ -74,7 +74,7 @@ spec:
       script: |
         #!/usr/bin/env bash
 
-        jq -s '{buildId: "$(params.build-id)", generator: "DOMINO", sbom: .[0]}' $(workspaces.data.path)/$(params.workdir)/bom.json > $(workspaces.data.path)/$(params.workdir)/payload.json
+        jq -s '{buildId: "$(params.build-id)", type: "BUILD_TIME", generator: "DOMINO", sbom: .[0]}' $(workspaces.data.path)/$(params.workdir)/bom.json > $(workspaces.data.path)/$(params.workdir)/payload.json
 
         [[ -z "${SBOMER_SERVICE_URL}" ]] && SBOMER_SERVICE_URL="http://${SBOMER_SERVICE_HOST}:${SBOMER_SERVICE_PORT}"
 

--- a/src/main/java/org/redhat/sbomer/generator/SbomGenerator.java
+++ b/src/main/java/org/redhat/sbomer/generator/SbomGenerator.java
@@ -18,6 +18,7 @@
 package org.redhat.sbomer.generator;
 
 import org.redhat.sbomer.errors.ApplicationException;
+import org.redhat.sbomer.utils.enums.Processors;
 
 /**
  * High-level interaction with the SBOM generator.
@@ -30,6 +31,6 @@ public interface SbomGenerator {
      *
      * @param buildId PNC build id
      */
-    public void generate(String buildId) throws ApplicationException;
+    public void generate(String buildId, Processors processor) throws ApplicationException;
 
 }

--- a/src/main/java/org/redhat/sbomer/generator/TektonDominoSbomGenerator.java
+++ b/src/main/java/org/redhat/sbomer/generator/TektonDominoSbomGenerator.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.jboss.pnc.dto.Build;
 import org.redhat.sbomer.errors.ApplicationException;
 import org.redhat.sbomer.service.PNCService;
+import org.redhat.sbomer.utils.enums.Processors;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
@@ -44,7 +45,7 @@ public class TektonDominoSbomGenerator implements SbomGenerator {
     TektonClient tektonClient;
 
     @Override
-    public void generate(String buildId) throws ApplicationException {
+    public void generate(String buildId, Processors processor) throws ApplicationException {
         Build build = pncService.getBuild(buildId);
 
         PipelineRun pipelineRun = new PipelineRunBuilder().withNewMetadata()

--- a/src/main/java/org/redhat/sbomer/model/Sbom.java
+++ b/src/main/java/org/redhat/sbomer/model/Sbom.java
@@ -45,6 +45,7 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.redhat.sbomer.utils.enums.Generators;
 import org.redhat.sbomer.utils.enums.Processors;
+import org.redhat.sbomer.utils.enums.SbomType;
 import org.redhat.sbomer.validation.CycloneDxBom;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -96,6 +97,10 @@ public class Sbom extends PanacheEntityBase {
 
     @Column(name = "generation_time", nullable = false, updatable = false)
     private Instant generationTime;
+
+    @Column(name = "type", nullable = false, updatable = false)
+    @Enumerated(EnumType.STRING)
+    private SbomType type;
 
     @Column(name = "generator", nullable = false, updatable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/redhat/sbomer/processor/PncArtifactsToSbomPedigreeProcessor.java
+++ b/src/main/java/org/redhat/sbomer/processor/PncArtifactsToSbomPedigreeProcessor.java
@@ -1,0 +1,103 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redhat.sbomer.processor;
+
+import static org.redhat.sbomer.utils.Constants.SBOM_RED_HAT_BUILD_ID;
+import static org.redhat.sbomer.utils.Constants.DISTRIBUTION;
+import static org.redhat.sbomer.utils.Constants.SBOM_RED_HAT_ENVIRONMENT_IMAGE;
+import static org.redhat.sbomer.utils.SbomUtils.addExternalReference;
+import static org.redhat.sbomer.utils.SbomUtils.hasExternalReference;
+import static org.redhat.sbomer.utils.SbomUtils.setPublisher;
+import static org.redhat.sbomer.utils.SbomUtils.setSupplier;
+import static org.redhat.sbomer.utils.SbomUtils.addPedigreeCommit;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.jboss.util.Strings;
+import org.redhat.sbomer.utils.Constants;
+import org.redhat.sbomer.utils.RhVersionPattern;
+import org.redhat.sbomer.dto.ArtifactInfo;
+import org.redhat.sbomer.model.ArtifactCache;
+import org.redhat.sbomer.service.SBOMService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@PncToSbomPedigree
+@ApplicationScoped
+public class PncArtifactsToSbomPedigreeProcessor implements SbomProcessor {
+
+    @Inject
+    SBOMService sbomService;
+
+    @Override
+    public Bom process(Bom originalBom) {
+        log.info("Adding PNC cached build info to the SBOM properties");
+
+        if (originalBom.getMetadata() != null && originalBom.getMetadata().getComponent() != null) {
+            processComponent(originalBom.getMetadata().getComponent());
+        }
+        if (originalBom.getComponents() != null) {
+            for (Component c : originalBom.getComponents()) {
+                processComponent(c);
+            }
+        }
+
+        return originalBom;
+    }
+
+    private void processComponent(Component component) {
+        if (RhVersionPattern.isRhVersion(component.getVersion())) {
+            log.info("SBOM component with Red Hat version found, purl: {}", component.getPurl());
+            try {
+                final ArtifactCache artifact = sbomService.fetchArtifact(component.getPurl());
+                final ArtifactInfo info = artifact.getArtifactInfo();
+
+                // TODO: make url configurable
+                addExternalReference(
+                        component,
+                        ExternalReference.Type.BUILD_SYSTEM,
+                        "https://orch.psi.redhat.com/pnc-rest/v2/builds/" + info.getBuildId(),
+                        SBOM_RED_HAT_BUILD_ID);
+                addExternalReference(component, ExternalReference.Type.DISTRIBUTION, Constants.MRRC_URL, DISTRIBUTION);
+                addExternalReference(
+                        component,
+                        ExternalReference.Type.BUILD_META,
+                        info.getEnvironmentImage(),
+                        SBOM_RED_HAT_ENVIRONMENT_IMAGE);
+                if (!hasExternalReference(component, ExternalReference.Type.VCS)
+                        && !Strings.isEmpty(info.getScmExternalUrl())) {
+                    addExternalReference(component, ExternalReference.Type.VCS, info.getScmExternalUrl(), "");
+                }
+
+                setPublisher(component);
+                setSupplier(component);
+                addPedigreeCommit(component, info.getScmUrl() + "#" + info.getScmTag(), info.getScmRevision());
+
+            } catch (NotFoundException nfe) {
+                log.warn(nfe.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/redhat/sbomer/processor/PncToSbomPedigree.java
+++ b/src/main/java/org/redhat/sbomer/processor/PncToSbomPedigree.java
@@ -15,24 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.redhat.sbomer.utils.enums;
+package org.redhat.sbomer.processor;
 
 import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-import org.redhat.sbomer.processor.PncToSbomPedigree;
-import org.redhat.sbomer.processor.PncToSbomProperties;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-public enum Processors {
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
+public @interface PncToSbomPedigree {
 
-    SBOM_PROPERTIES(PncToSbomProperties.Literal.INSTANCE), SBOM_PEDIGREE(PncToSbomPedigree.Literal.INSTANCE);
-
-    private AnnotationLiteral selector;
-
-    private Processors(AnnotationLiteral selector) {
-        this.selector = selector;
-    }
-
-    public AnnotationLiteral getSelector() {
-        return this.selector;
+    final class Literal extends AnnotationLiteral<PncToSbomPedigree> implements PncToSbomPedigree {
+        public static final Literal INSTANCE = new Literal();
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/src/main/java/org/redhat/sbomer/service/SBOMService.java
+++ b/src/main/java/org/redhat/sbomer/service/SBOMService.java
@@ -44,6 +44,7 @@ import org.redhat.sbomer.repositories.ArtifactCacheRepository;
 import org.redhat.sbomer.repositories.SbomRepository;
 import org.redhat.sbomer.utils.enums.Generators;
 import org.redhat.sbomer.utils.enums.Processors;
+import org.redhat.sbomer.utils.enums.SbomType;
 import org.redhat.sbomer.validation.exceptions.ValidationException;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -216,6 +217,7 @@ public class SBOMService {
                 enrichedSbom.setProcessor(processor);
                 enrichedSbom.setSbom(bomGenerator.toJsonNode());
                 enrichedSbom.setParentSbom(baseSbom);
+                enrichedSbom.setType(SbomType.BUILD_TIME);
                 return saveSbom(enrichedSbom);
             }
         }

--- a/src/main/java/org/redhat/sbomer/service/SBOMService.java
+++ b/src/main/java/org/redhat/sbomer/service/SBOMService.java
@@ -99,9 +99,9 @@ public class SBOMService {
      *
      * @param buildId
      */
-    public Response generateSbomFromPncBuild(String buildId, Generators generator) {
+    public Response generateSbomFromPncBuild(String buildId, Generators generator, Processors processor) {
 
-        generators.select(generator.getSelector()).get().generate(buildId);
+        generators.select(generator.getSelector()).get().generate(buildId, processor);
         return Response.status(Status.ACCEPTED).build();
     }
 

--- a/src/main/java/org/redhat/sbomer/utils/Constants.java
+++ b/src/main/java/org/redhat/sbomer/utils/Constants.java
@@ -19,7 +19,7 @@ package org.redhat.sbomer.utils;
 
 public class Constants {
 
-    public static final String SBOM_RED_HAT_BUILD_ID = "build-id";
+    public static final String SBOM_RED_HAT_BUILD_ID = "pnc-build-id";
     public static final String SBOM_RED_HAT_PUBLIC_URL = "public-url";
     public static final String SBOM_RED_HAT_ORIGIN_URL = "origin-url";
     public static final String SBOM_RED_HAT_BUILD_SYSTEM = "build-system";
@@ -27,12 +27,15 @@ public class Constants {
     public static final String SBOM_RED_HAT_SCM_REVISION = "scm-revision";
     public static final String SBOM_RED_HAT_SCM_TAG = "scm-tag";
     public static final String SBOM_RED_HAT_SCM_EXTERNAL_URL = "scm-external-url";
-    public static final String SBOM_RED_HAT_ENVIRONMENT_IMAGE = "environment-image";
+    public static final String SBOM_RED_HAT_ENVIRONMENT_IMAGE = "pnc-environment-image";
 
     public static final String PNC_BUILD_SYSTEM = "PNC";
     public static final String BREW_BUILD_SYSTEM = "BREW";
 
+    public static final String DISTRIBUTION = "Red Hat distribution";
     public static final String PUBLISHER = "Red Hat";
+    public static final String SUPPLIER_NAME = "Red Hat";
+    public static final String SUPPLIER_URL = "https://www.redhat.com";
     public static final String MRRC_URL = "https://maven.repository.redhat.com/ga/";
 
 }

--- a/src/main/java/org/redhat/sbomer/utils/enums/SbomType.java
+++ b/src/main/java/org/redhat/sbomer/utils/enums/SbomType.java
@@ -1,0 +1,22 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.redhat.sbomer.utils.enums;
+
+public enum SbomType {
+    BUILD_TIME, PRODUCT_RELEASE;
+}

--- a/src/test/java/org/redhat/sbomer/test/TestSbomRepository.java
+++ b/src/test/java/org/redhat/sbomer/test/TestSbomRepository.java
@@ -37,6 +37,7 @@ import org.redhat.sbomer.model.Sbom;
 import org.redhat.sbomer.repositories.SbomRepository;
 import org.redhat.sbomer.utils.enums.Generators;
 import org.redhat.sbomer.utils.enums.Processors;
+import org.redhat.sbomer.utils.enums.SbomType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -64,6 +65,7 @@ public class TestSbomRepository extends SbomRepository {
         Sbom parentSBOM = new Sbom();
         parentSBOM.setBuildId("ARYT3LBXDVYAC");
         parentSBOM.setId(416640206274228224L);
+        parentSBOM.setType(SbomType.BUILD_TIME);
         parentSBOM.setGenerationTime(Instant.now());
         parentSBOM.setSbom(sbom);
         parentSBOM.setGenerator(Generators.CYCLONEDX);
@@ -78,6 +80,7 @@ public class TestSbomRepository extends SbomRepository {
         Sbom enrichedSBOM = new Sbom();
         enrichedSBOM.setBuildId("ARYT3LBXDVYAC");
         enrichedSBOM.setId(416640206274228225L);
+        enrichedSBOM.setType(SbomType.BUILD_TIME);
         enrichedSBOM.setGenerationTime(Instant.now());
         enrichedSBOM.setSbom(sbom);
         enrichedSBOM.setGenerator(parentSbom.getGenerator());
@@ -107,6 +110,7 @@ public class TestSbomRepository extends SbomRepository {
         assertEquals(416640206274228224L, baseSBOM.getId());
         assertEquals("ARYT3LBXDVYAC", baseSBOM.getBuildId());
         assertEquals(Generators.CYCLONEDX, baseSBOM.getGenerator());
+        assertEquals(SbomType.BUILD_TIME, baseSBOM.getType());
         assertEquals("CycloneDX", bom.getBomFormat());
         Component firstComponent = bom.getComponents().get(0);
         assertEquals("jcommander", firstComponent.getName());
@@ -130,6 +134,7 @@ public class TestSbomRepository extends SbomRepository {
         assertEquals(416640206274228224L, sbom.getId());
         assertEquals("ARYT3LBXDVYAC", sbom.getBuildId());
         assertEquals(Generators.CYCLONEDX, sbom.getGenerator());
+        assertEquals(SbomType.BUILD_TIME, sbom.getType());
         assertNull(sbom.getProcessor());
         assertEquals("CycloneDX", bom.getBomFormat());
         Component firstComponent = bom.getComponents().get(0);
@@ -155,6 +160,7 @@ public class TestSbomRepository extends SbomRepository {
         assertEquals("ARYT3LBXDVYAC", enrichedSbom.getBuildId());
         assertEquals(Generators.CYCLONEDX, enrichedSbom.getGenerator());
         assertEquals(Processors.SBOM_PROPERTIES, enrichedSbom.getProcessor());
+        assertEquals(SbomType.BUILD_TIME, enrichedSbom.getType());
         assertEquals("CycloneDX", bom.getBomFormat());
         Component firstComponent = bom.getComponents().get(0);
         assertEquals("cpaas-test-pnc-maven", firstComponent.getName());
@@ -175,6 +181,7 @@ public class TestSbomRepository extends SbomRepository {
         assertEquals(416640206274228224L, parentSBOM.getId());
         assertEquals("ARYT3LBXDVYAC", parentSBOM.getBuildId());
         assertEquals(Generators.CYCLONEDX, parentSBOM.getGenerator());
+        assertEquals(SbomType.BUILD_TIME, parentSBOM.getType());
         assertNull(parentSBOM.getProcessor());
         assertEquals("CycloneDX", parentBom.getBomFormat());
         Component firstParentComponent = parentBom.getComponents().get(0);

--- a/src/test/resources/payloads/payload-invalid-bom.json
+++ b/src/test/resources/payloads/payload-invalid-bom.json
@@ -1,5 +1,6 @@
 {
   "buildId": "AWI7P3EJ23YAA",
+  "type": "BUILD_TIME",
   "sbom": {
     "bomFormat": "CycloneDX",
     "specVdersion": "1.4",

--- a/src/test/resources/payloads/payload-valid.json
+++ b/src/test/resources/payloads/payload-valid.json
@@ -1,6 +1,7 @@
 {
   "buildId": "AWI7P3EJ23YAA",
   "generator": "CYCLONEDX",
+  "type": "BUILD_TIME",
   "sbom": {
     "bomFormat": "CycloneDX",
     "specVersion": "1.4",

--- a/src/test/resources/sboms/sbom-valid-enriched-v10.json
+++ b/src/test/resources/sboms/sbom-valid-enriched-v10.json
@@ -64,7 +64,7 @@
           "value": "java"
         },
         {
-          "name": "build-id",
+          "name": "pnc-build-id",
           "value": "AXQIDEW26SYAC"
         },
         {
@@ -96,7 +96,7 @@
           "value": "https://gitlab.cee.redhat.com/ncross/cpaas-test-pnc-maven.git"
         },
         {
-          "name": "environment-image",
+          "name": "pnc-environment-image",
           "value": "quay.io/rh-newcastle/builder-rhel-7-j8-mvn3.6.0-gradle5.6.2:1.0.8"
         }
       ],

--- a/src/test/resources/sboms/sbom-valid-parent.json
+++ b/src/test/resources/sboms/sbom-valid-parent.json
@@ -1120,7 +1120,7 @@
           "value": "java"
         },
         {
-          "name": "build-id",
+          "name": "pnc-build-id",
           "value": "32374"
         },
         {
@@ -1341,7 +1341,7 @@
           "value": "java"
         },
         {
-          "name": "build-id",
+          "name": "pnc-build-id",
           "value": "ARYT3LBXDVYAC"
         },
         {
@@ -1407,7 +1407,7 @@
           "value": "java"
         },
         {
-          "name": "build-id",
+          "name": "pnc-build-id",
           "value": "ARYT3LBXDVYAC"
         },
         {


### PR DESCRIPTION
- Add new processor to put additional PNC properties into SBOM pedigree section
- Add SbomType to the model
- Pass environment attributes to task-build-env task to avoid another fetching from PNC; propagate the processor through generate and enrich endpoints inside the pipeline
- Add the type to SBOM
- Add type to the new enriched Sbom