### PR TITLE
Implement resource statuses

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/CLI.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/CLI.java
@@ -44,11 +44,6 @@ public class CLI implements QuarkusApplication {
     @Option(names = { "-v", "--verbose" }, scope = ScopeType.INHERIT)
     boolean verbose = false;
 
-    // public int usage(Class<?> command) {
-    // new CommandLine(command, factory).usage(System.out);
-    // return CommandLine.ExitCode.USAGE;
-    // }
-
     @Override
     public int run(String... args) throws Exception {
         return new CommandLine(this, factory).setExecutionExceptionHandler(new ExceptionHandler()).execute(args);

--- a/cli/src/main/java/org/jboss/sbomer/cli/client/ClientExceptionMapper.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/client/ClientExceptionMapper.java
@@ -40,8 +40,6 @@ public class ClientExceptionMapper implements ResponseExceptionMapper<Throwable>
 
         ErrorResponse error = null;
 
-        System.out.println(response);
-
         try {
             error = objectMapper.readValue((ByteArrayInputStream) response.getEntity(), ErrorResponse.class);
         } catch (IOException e) {

--- a/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
@@ -29,6 +29,8 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.sbomer.cli.model.Sbom;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * Client used to interact with the SBOMer REST API.
  */
@@ -43,7 +45,8 @@ public interface SBOMerClient {
      * Saves the SBOM in the service.
      */
     @POST
-    String save(Sbom sbom);
+    @Path("/{id}/bom")
+    String updateSbom(@PathParam("id") String sbomId, JsonNode bom);
 
     /**
      * Retrieves SBOM based on the ID.
@@ -53,5 +56,5 @@ public interface SBOMerClient {
      */
     @GET
     @Path("/{id}")
-    Sbom getById(@PathParam("id") long id);
+    Sbom getById(@PathParam("id") String id);
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/AbstractMavenBaseGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/AbstractMavenBaseGenerateCommand.java
@@ -77,7 +77,7 @@ public abstract class AbstractMavenBaseGenerateCommand implements Callable<Integ
         Build build = pncService.getBuild(sbom.getBuildId());
 
         if (build == null) {
-            log.error("Could not fetch the PNC build with id '{}'", parent.getParent().getSbomId());
+            log.error("Could not fetch the PNC build with id '{}'", sbom.getBuildId());
             return CommandLine.ExitCode.SOFTWARE;
         }
 
@@ -88,8 +88,9 @@ public abstract class AbstractMavenBaseGenerateCommand implements Callable<Integ
         Path bomPath = generate();
 
         log.info(
-                "Preparing to upload SBOM for build '{}' from path '{}' to the service...",
-                parent.getParent().getSbomId(),
+                "Preparing to update SBOM id: '{}' (PNC build '{}') with generated SBOM content from path '{}'...",
+                sbom.getId(),
+                sbom.getBuildId(),
                 bomPath);
 
         log.debug("Reading generated SBOM from '{}' path", bomPath);

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/DominoMavenGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/DominoMavenGenerateCommand.java
@@ -92,8 +92,6 @@ public class DominoMavenGenerateCommand extends AbstractMavenBaseGenerateCommand
                 "--include-non-managed",
                 "--warn-on-missing-scm");
 
-        System.out.println(processBuilder.command());
-
         if (parent.getSettingsXmlPath() != null) {
             log.debug(
                     "Using provided Maven settings.xml configuration file located at '{}'",
@@ -101,9 +99,6 @@ public class DominoMavenGenerateCommand extends AbstractMavenBaseGenerateCommand
             processBuilder.command().add("-s");
             processBuilder.command().add(parent.getSettingsXmlPath().toString());
         }
-
-        // log.info("Working directory: '{}'", parent.getParent().getTargetDir());
-        // processBuilder.directory(parent.getParent().getTargetDir().toFile());
 
         Process process = null;
 

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/GenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/generator/GenerateCommand.java
@@ -57,11 +57,11 @@ public class GenerateCommand implements Callable<Integer> {
 
     @Getter
     @Option(
-            names = { "-b", "--build-id" },
+            names = { "--sbom-id" },
             required = true,
-            description = "The PNC build id for which we should fetch the source code, example: AABBCCDD",
+            description = "The SBOM identifier in the SBOMer, example: 1234566",
             scope = ScopeType.INHERIT)
-    String buildId;
+    String sbomId;
 
     @Getter
     @Option(

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/AbstractBaseProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/AbstractBaseProcessCommand.java
@@ -65,24 +65,9 @@ public abstract class AbstractBaseProcessCommand implements Callable<Integer> {
         // Run the actual processing
         Bom processedBom = doProcess(bom);
 
-        // Create the new SBOM based on the old one with updated fields.
-        Sbom newSbom = processed(sbom, processedBom);
-
-        // Save the SBOM in the service
-        sbomerClient.save(newSbom);
+        sbomerClient.updateSbom(parent.getSbomId(), SbomUtils.toJsonNode(processedBom));
 
         return CommandLine.ExitCode.OK;
-    }
-
-    private Sbom processed(Sbom originalSbom, Bom bom) {
-        Sbom processed = new Sbom();
-        processed.setBuildId(originalSbom.getBuildId());
-        processed.setGenerator(originalSbom.getGenerator());
-        processed.setProcessor(getImplementationType());
-        processed.setType(originalSbom.getType());
-        processed.setSbom(SbomUtils.toJsonNode(bom));
-
-        return processed;
     }
 
     protected abstract ProcessorImplementation getImplementationType();

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/AbstractBaseProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/AbstractBaseProcessCommand.java
@@ -80,10 +80,7 @@ public abstract class AbstractBaseProcessCommand implements Callable<Integer> {
     protected abstract ProcessorImplementation getImplementationType();
 
     protected Bom doProcess(Bom bom) {
-        log.info(
-                "Applying {} processing to the SBOM: '{}'",
-                getImplementationType(),
-                bom.getMetadata().getComponent().getPurl());
+        log.info("Applying {} processing...", getImplementationType());
 
         if (bom.getMetadata() != null && bom.getMetadata().getComponent() != null) {
             processComponent(bom.getMetadata().getComponent());

--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/ProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/ProcessCommand.java
@@ -47,7 +47,7 @@ public class ProcessCommand implements Callable<Integer> {
             required = true,
             description = "The SBOM identifier to fetch the SBOM for processing.",
             scope = ScopeType.INHERIT)
-    Long sbomId;
+    String sbomId;
 
     @Spec
     CommandSpec spec;

--- a/cli/src/main/java/org/jboss/sbomer/cli/model/Sbom.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/model/Sbom.java
@@ -41,4 +41,5 @@ public class Sbom {
     private GeneratorImplementation generator;
     private ProcessorImplementation processor;
     private SbomType type;
+    private Sbom parentSbom;
 }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/client/SBOMerClientTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/client/SBOMerClientTest.java
@@ -43,7 +43,7 @@ public class SBOMerClientTest {
 
     @Test
     void testGetValidSbom() {
-        Sbom sbom = client.getById(123);
+        Sbom sbom = client.getById("123");
         assertNotNull(sbom);
         assertEquals(123, sbom.getId());
         assertEquals("AABBCC", sbom.getBuildId());
@@ -52,7 +52,7 @@ public class SBOMerClientTest {
     @Test
     void testNotFoundSbom() {
         ApiException ex = assertThrows(ApiException.class, () -> {
-            client.getById(1234);
+            client.getById("1234");
         });
 
         assertEquals(404, ex.getCode());

--- a/core/src/main/java/org/jboss/sbomer/core/enums/SbomStatus.java
+++ b/core/src/main/java/org/jboss/sbomer/core/enums/SbomStatus.java
@@ -15,19 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.processor;
+package org.jboss.sbomer.core.enums;
 
 /**
- * High-level interaction with the SBOM processor.
- *
+ * Enum representing the status of the Sbom.
  */
-public interface SbomProcessor {
-
-    /**
-     * Processes a given SBOM.
-     *
-     * @param sbomId The SBOM id.
-     */
-    public void process(Long sbomId);
-
+public enum SbomStatus {
+    NEW, GENERATING, GENERATION_FAILED, PROCESSING, PROCESSING_FAILED, READY;
 }

--- a/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
+++ b/k8s/base/tekton/resources/task-generate-cyclonedx.yaml
@@ -85,6 +85,6 @@ spec:
 
         [[ -z "${SBOMER_SERVICE_URL}" ]] && SBOMER_SERVICE_URL="http://${SBOMER_SERVICE_HOST}:${SBOMER_SERVICE_PORT}"
 
-        /workdir/.sdkman/candidates/java/17/bin/java -jar ./generator/quarkus-run.jar -v generate --build-id=$(params.id) maven cyclonedx --plugin-version=$TOOL_VERSION --target=$(workspaces.data.path)/source --settings=~/settings.xml
+        /workdir/.sdkman/candidates/java/17/bin/java -jar ./generator/quarkus-run.jar -v generate --sbom-id=$(params.id) maven cyclonedx --plugin-version=$TOOL_VERSION --target=$(workspaces.data.path)/source --settings=~/settings.xml
   workspaces:
     - name: data

--- a/service/src/main/java/org/jboss/sbomer/generator/SbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/generator/SbomGenerator.java
@@ -28,6 +28,6 @@ public interface SbomGenerator {
      *
      * @param buildId PNC build id
      */
-    public void generate(String buildId);
+    public void generate(Long sbomId);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/messaging/PNCMessageParser.java
+++ b/service/src/main/java/org/jboss/sbomer/messaging/PNCMessageParser.java
@@ -106,7 +106,7 @@ public class PNCMessageParser implements Runnable {
                         String buildId = msgBody.path("build").path("id").asText();
                         if (!Strings.isEmpty(buildId)) {
                             log.info("I SHOULD REALLY GENERATE AN SBOM FOR BUILD {}", buildId);
-                            sbomService.generateSbomFromPncBuild(buildId, GeneratorImplementation.CYCLONEDX);
+                            sbomService.generate(buildId, GeneratorImplementation.CYCLONEDX);
                         }
                     }
                 } catch (JMSException | IOException e) {

--- a/service/src/main/java/org/jboss/sbomer/model/Sbom.java
+++ b/service/src/main/java/org/jboss/sbomer/model/Sbom.java
@@ -109,7 +109,6 @@ public class Sbom extends PanacheEntityBase {
 
     @Id
     @Column(nullable = false, updatable = false)
-    @ToString.Exclude
     private Long id;
 
     @Column(name = "build_id", nullable = false, updatable = false)
@@ -141,7 +140,7 @@ public class Sbom extends PanacheEntityBase {
     @Enumerated(EnumType.STRING)
     private ProcessorImplementation processor;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(
             name = "parent_sbom_id",
             foreignKey = @ForeignKey(name = "fk_sbom_parent_sbom"),

--- a/service/src/main/java/org/jboss/sbomer/model/Sbom.java
+++ b/service/src/main/java/org/jboss/sbomer/model/Sbom.java
@@ -116,7 +116,6 @@ public class Sbom extends PanacheEntityBase {
     private String buildId;
 
     @Column(name = "root_purl")
-    // @NotBlank(message = "Root purl identifier missing") // TODO
     private String rootPurl;
 
     // TODO: rename this field? Is it covering the creation of the entity, started generation process time or finished

--- a/service/src/main/java/org/jboss/sbomer/rest/errors/SbomerExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/errors/SbomerExceptionMapper.java
@@ -45,11 +45,14 @@ public class SbomerExceptionMapper implements ExceptionMapper<Throwable> {
         if (ex instanceof WebApplicationException) {
             WebApplicationException wex = (WebApplicationException) ex;
 
-            if (wex.getCause() instanceof JsonParseException) {
-                status = 400;
-                message = "An error occurred while parsing the request";
-                errors = Collections.singletonList(((JsonParseException) wex.getCause()).getOriginalMessage());
-            }
+            status = wex.getResponse().getStatus();
+            message = wex.getResponse().getStatusInfo().getReasonPhrase();
+
+            // if (wex.getCause() instanceof JsonParseException) {
+            // // status = 400;
+            // // message = "An error occurred while parsing the request";
+            // errors = Collections.singletonList(((JsonParseException) wex.getCause()).getOriginalMessage());
+            // }
         }
 
         ErrorResponse error = ErrorResponse.builder()

--- a/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
@@ -45,6 +45,7 @@ import org.jboss.pnc.common.Strings;
 import org.jboss.pnc.rest.api.parameters.PaginationParameters;
 import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.core.enums.ProcessorImplementation;
+import org.jboss.sbomer.core.enums.SbomStatus;
 import org.jboss.sbomer.core.errors.ApiException;
 import org.jboss.sbomer.core.errors.NotFoundException;
 import org.jboss.sbomer.core.utils.UrlUtils;
@@ -129,7 +130,7 @@ public class SBOMResource {
     @Parameter(name = "sbom", description = "The SBOM to save")
     @APIResponses({
             @APIResponse(
-                    responseCode = "202",
+                    responseCode = "200",
                     description = "The SBOM was successfully saved",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)),
             @APIResponse(
@@ -156,7 +157,7 @@ public class SBOMResource {
 
         Sbom sbom = sbomService.updateBom(id, bom);
 
-        return Response.status(Status.ACCEPTED).entity(sbom).build();
+        return Response.status(Status.OK).entity(sbom).build();
     }
 
     @GET
@@ -456,6 +457,14 @@ public class SBOMResource {
 
         if (sbom == null) {
             throw new NotFoundException("Sbom with id '{}' not found", sbomId);
+        }
+
+        if (sbom.getStatus() != SbomStatus.READY) {
+            throw new ApiException(
+                    400,
+                    "Sbom with id '{}' is not ready yet, current status: {}",
+                    sbomId,
+                    sbom.getStatus());
         }
 
         ProcessorImplementation proc = ProcessorImplementation.DEFAULT;

--- a/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
@@ -52,6 +52,8 @@ import org.jboss.sbomer.model.Sbom;
 import org.jboss.sbomer.rest.dto.Page;
 import org.jboss.sbomer.service.SbomService;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 @Path("/api/v1alpha1/sboms")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -61,38 +63,6 @@ public class SBOMResource {
 
     @Inject
     SbomService sbomService;
-
-    /**
-     * Make it possible to create a {@link Sbom} resource directly from the endpoint.
-     *
-     * TODO: Add authentication. It should be possible to create new SBOM's this way only from trusted places.
-     *
-     * @param sbom {@link Sbom}
-     * @return
-     */
-    @POST
-    @Operation(
-            summary = "Save SBOM",
-            description = "Save submitted SBOM. This endpoint expects a SBOM in the CycloneDX format encapsulated in the structure.")
-    @Parameter(name = "sbom", description = "The SBOM to save")
-    @APIResponses({
-            @APIResponse(
-                    responseCode = "201",
-                    description = "The SBOM was successfully saved",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "422",
-                    description = "Provided SBOM couldn't be saved because of validation failures",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "500",
-                    description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response save(final Sbom sbom) {
-        // Save the SBOM in the database
-        sbomService.saveSbom(sbom);
-        return Response.status(Status.CREATED).entity(sbom).build();
-    }
 
     @GET
     @Operation(summary = "List SBOMs", description = "List SBOMs available in the system, paginated.")
@@ -106,7 +76,7 @@ public class SBOMResource {
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
     public Page<Sbom> list(@Valid @BeanParam PaginationParameters paginationParams) {
-        return sbomService.listSboms(paginationParams.getPageIndex(), paginationParams.getPageSize());
+        return sbomService.list(paginationParams.getPageIndex(), paginationParams.getPageSize());
     }
 
     @GET
@@ -119,6 +89,10 @@ public class SBOMResource {
                     description = "The SBOM",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)),
             @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
                     responseCode = "404",
                     description = "Requested SBOM could not be found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)),
@@ -126,21 +100,63 @@ public class SBOMResource {
                     responseCode = "500",
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Sbom getById(@PathParam("id") String id) {
-
+    public Sbom getById(@PathParam("id") String sbomId) {
         Sbom sbom = null;
 
         try {
-            sbom = sbomService.getSbomById(Long.valueOf(id));
+            sbom = sbomService.get(Long.valueOf(sbomId));
         } catch (NumberFormatException e) {
-            throw new ApiException(400, "Invalid SBOM id provided: '{}', a number was expected", id);
+            throw new ApiException(400, "Invalid SBOM id provided: '{}', a number was expected", sbomId);
         }
 
         if (sbom == null) {
-            throw new NotFoundException("Sbom with id '{}' not found", String.valueOf(id));
+            throw new NotFoundException("Sbom with id '{}' not found", sbomId);
         }
 
         return sbom;
+    }
+
+    /**
+     * Update the Bom within the {@link Sbom} resource.
+     *
+     * @param sbom {@link Sbom}
+     * @return
+     */
+    @POST
+    @Operation(
+            summary = "Update Bom for specified SBOM",
+            description = "Save submitted SBOM. This endpoint expects a SBOM in the CycloneDX format encapsulated in the structure.")
+    @Parameter(name = "sbom", description = "The SBOM to save")
+    @APIResponses({
+            @APIResponse(
+                    responseCode = "202",
+                    description = "The SBOM was successfully saved",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "422",
+                    description = "Provided SBOM couldn't be saved because of validation failures",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
+    @Path("{id}/bom")
+    public Response updateSbom(@PathParam("id") String sbomId, final JsonNode bom) {
+        Long id = null;
+
+        try {
+            id = Long.valueOf(sbomId);
+        } catch (NumberFormatException e) {
+            throw new ApiException(400, "Invalid SBOM id provided: '{}', a number was expected", sbomId);
+        }
+
+        Sbom sbom = sbomService.updateBom(id, bom);
+
+        return Response.status(Status.ACCEPTED).entity(sbom).build();
     }
 
     @GET
@@ -352,6 +368,13 @@ public class SBOMResource {
     public Bom getBomOfEnrichedSbomWithRootPurl(@PathParam("rootPurl") String rootPurl) {
 
         return sbomService.getEnrichedSbomByRootPurl(UrlUtils.urldecode(rootPurl)).getCycloneDxBom();
+
+    }
+
+    public Page<Sbom> listAllWithPncBuildId(
+            @PathParam("id") String buildId,
+            @Valid @BeanParam PaginationParameters paginationParams) {
+        return sbomService.list(buildId, paginationParams.getPageIndex(), paginationParams.getPageSize());
     }
 
     @POST
@@ -365,7 +388,7 @@ public class SBOMResource {
             example = "CYCLONEDX")
     @Path("/generate/build/{id}")
     @APIResponses({ @APIResponse(
-            responseCode = "201",
+            responseCode = "202",
             description = "Schedules generation of a SBOM for a particular PNC buildId. This is an asynchronous call. It does execute the generation behind the scenes.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON)),
             @APIResponse(
@@ -388,9 +411,9 @@ public class SBOMResource {
             }
         }
 
-        sbomService.generateSbomFromPncBuild(buildId, gen);
+        Sbom sbom = sbomService.generate(buildId, gen);
 
-        return Response.status(Status.ACCEPTED).build();
+        return Response.status(Status.ACCEPTED).entity(sbom).build();
     }
 
     @POST
@@ -408,17 +431,35 @@ public class SBOMResource {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)),
             @APIResponse(
                     responseCode = "400",
-                    description = "Provided SBOM couldn't be saved, probably due to validation failures",
+                    description = "Could not parse provided arguments",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested SBOM could not be found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)),
             @APIResponse(
                     responseCode = "500",
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
     public Response processEnrichmentOfBaseSbom(
-            @PathParam("id") final Long sbomId,
+            @PathParam("id") final String sbomId,
             @QueryParam("processor") String processor) throws Exception {
 
+        Sbom sbom = null;
+
+        // TODO share this code
+        try {
+            sbom = sbomService.get(Long.valueOf(sbomId));
+        } catch (NumberFormatException e) {
+            throw new ApiException(400, "Invalid SBOM id provided: '{}', a number was expected", sbomId);
+        }
+
+        if (sbom == null) {
+            throw new NotFoundException("Sbom with id '{}' not found", sbomId);
+        }
+
         ProcessorImplementation proc = ProcessorImplementation.DEFAULT;
+
         if (!Strings.isEmpty(processor)) {
             try {
                 proc = ProcessorImplementation.valueOf(processor);
@@ -427,13 +468,12 @@ public class SBOMResource {
                         Status.BAD_REQUEST.getStatusCode(),
                         "The specified processor does not exist, allowed values are `PROPERTIES`, `DEFAULT`. Leave empty to use `DEFAULT`",
                         iae);
-
             }
         }
 
-        sbomService.processSbom(sbomId, proc);
+        sbom = sbomService.process(sbom, proc);
 
-        return Response.status(Status.ACCEPTED).build();
+        return Response.status(Status.ACCEPTED).entity(sbom).build();
     }
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/SbomRepository.java
+++ b/service/src/main/java/org/jboss/sbomer/service/SbomRepository.java
@@ -17,12 +17,16 @@
  */
 package org.jboss.sbomer.service;
 
+import java.util.Optional;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 
 import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.core.enums.ProcessorImplementation;
 import org.jboss.sbomer.model.Sbom;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;

--- a/service/src/main/java/org/jboss/sbomer/service/SbomRepository.java
+++ b/service/src/main/java/org/jboss/sbomer/service/SbomRepository.java
@@ -17,16 +17,12 @@
  */
 package org.jboss.sbomer.service;
 
-import java.util.Optional;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 
 import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.core.enums.ProcessorImplementation;
 import org.jboss.sbomer.model.Sbom;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;

--- a/service/src/main/java/org/jboss/sbomer/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/SbomService.java
@@ -29,7 +29,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.transaction.Transactional;
 import javax.validation.ConstraintViolation;
@@ -53,7 +52,6 @@ import org.jboss.sbomer.rest.dto.Page;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.quarkus.hibernate.orm.panache.Panache;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -188,20 +186,6 @@ public class SbomService {
 
         return new Page<Sbom>(pageIndex, pageSize, totalPages, totalHits, content);
     }
-
-    // /**
-    // * Get list of {@link Sbom}s for a given PNC build ID in a paginated way.
-    // */
-    // public Sbom get(String buildId, GeneratorImplementation generator, ProcessorImplementation processor) {
-    // log.info("Getting SBOM with buildId: {} and generator: {} and processor: {}", buildId, generator, processor);
-    // try {
-    // return sbomRepository.getSbom(buildId, generator, processor);
-    // } catch (NoResultException nre) {
-    // throw new NotFoundException(
-    // "SBOM for build id " + buildId + " and generator " + generator + " and processor " + processor
-    // + " not found.");
-    // }
-    // }
 
     /**
      * Get base {@link Sbom} for a given PNC build ID.

--- a/service/src/main/java/org/jboss/sbomer/tekton/AbstractTektonTaskRunner.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/AbstractTektonTaskRunner.java
@@ -38,7 +38,7 @@ public abstract class AbstractTektonTaskRunner {
     @Inject
     TektonClient tektonClient;
 
-    protected TaskRun runTektonTask(final String tektonTaskName, final String id) {
+    protected TaskRun runTektonTask(final String tektonTaskName, final Long id) {
         return runTektonTask(tektonTaskName, id, Json.createObjectBuilder().build());
     }
 
@@ -50,9 +50,9 @@ public abstract class AbstractTektonTaskRunner {
      * @param config Additional configuration passed as a {@link JsonObject}.
      * @return A {@link TaskRun} object representing the execution.
      */
-    protected TaskRun runTektonTask(final String tektonTaskName, final String id, final JsonObject config) {
+    protected TaskRun runTektonTask(final String tektonTaskName, final Long id, final JsonObject config) {
         TaskRun taskRun = new TaskRunBuilder().withNewMetadata()
-                .withGenerateName(toTaskRunNamePrefix(tektonTaskName, id))
+                .withGenerateName(toTaskRunNamePrefix(tektonTaskName, String.valueOf(id)))
                 .endMetadata()
                 .withNewSpec()
                 .withServiceAccountName(SERVICE_ACCOUNT_NAME)
@@ -67,7 +67,7 @@ public abstract class AbstractTektonTaskRunner {
                                 .build())
                 .endPodTemplate()
                 .withParams(
-                        new Param("id", new ArrayOrString(id)),
+                        new Param("id", new ArrayOrString(String.valueOf(id))),
                         new Param("config", new ArrayOrString(config.toString())))
                 .withWorkspaces(
                         new WorkspaceBindingBuilder().withName("data").withEmptyDir(new EmptyDirVolumeSource()).build())

--- a/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonCycloneDXSbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonCycloneDXSbomGenerator.java
@@ -41,12 +41,12 @@ public class TektonCycloneDXSbomGenerator extends AbstractTektonTaskRunner imple
     String cyclonedxAdditionalArgs;
 
     @Override
-    public void generate(String buildId) {
+    public void generate(Long sbomId) {
         var config = Json.createObjectBuilder()
                 .add("version", cyclonedxDefaultVersion)
                 .add("additional-args", cyclonedxAdditionalArgs)
                 .build();
 
-        runTektonTask("sbomer-generate-cyclonedx", buildId, config);
+        runTektonTask("sbomer-generate-cyclonedx", sbomId, config);
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonDominoSbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonDominoSbomGenerator.java
@@ -42,12 +42,12 @@ public class TektonDominoSbomGenerator extends AbstractTektonTaskRunner implemen
     String dominoAdditionalArgs;
 
     @Override
-    public void generate(String buildId) throws ApplicationException {
+    public void generate(Long sbomId) throws ApplicationException {
         var config = Json.createObjectBuilder()
                 .add("version", dominoDefaultVersion)
                 .add("additional-args", dominoAdditionalArgs)
                 .build();
-        runTektonTask("sbomer-generate-domino", buildId, config);
+        runTektonTask("sbomer-generate-domino", sbomId, config);
     }
 
 }

--- a/service/src/main/java/org/jboss/sbomer/tekton/processor/TektonDefaultSbomProcessor.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/processor/TektonDefaultSbomProcessor.java
@@ -33,9 +33,9 @@ import org.jboss.sbomer.tekton.AbstractTektonTaskRunner;
 public class TektonDefaultSbomProcessor extends AbstractTektonTaskRunner implements SbomProcessor {
 
     @Override
-    public void process(long sbomId) {
+    public void process(Long sbomId) {
         var config = Json.createObjectBuilder().add("processor", "default").build();
 
-        runTektonTask("sbomer-process", String.valueOf(sbomId), config);
+        runTektonTask("sbomer-process", sbomId, config);
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/tekton/processor/TektonPropertiesSbomProcessor.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/processor/TektonPropertiesSbomProcessor.java
@@ -33,9 +33,9 @@ import org.jboss.sbomer.tekton.AbstractTektonTaskRunner;
 public class TektonPropertiesSbomProcessor extends AbstractTektonTaskRunner implements SbomProcessor {
 
     @Override
-    public void process(long sbomId) {
+    public void process(Long sbomId) {
         var config = Json.createObjectBuilder().add("processor", "properties").build();
 
-        runTektonTask("sbomer-process", String.valueOf(sbomId), config);
+        runTektonTask("sbomer-process", sbomId, config);
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/validation/CycloneDxBomValidator.java
+++ b/service/src/main/java/org/jboss/sbomer/validation/CycloneDxBomValidator.java
@@ -39,8 +39,7 @@ public class CycloneDxBomValidator implements ConstraintValidator<CycloneDxBom, 
     @Override
     public boolean isValid(JsonNode value, ConstraintValidatorContext context) {
         if (value == null) {
-            setPayload(context, Collections.singletonList("sbom: no SBOM provided"));
-            return false;
+            return true;
         }
 
         List<ParseException> exceptions = Collections.emptyList();

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -48,6 +48,8 @@ sbomer:
 
 "%dev":
   quarkus:
+    devservices:
+      enabled: false
     # class-loading:
     #  parent-first-artifacts: io.quarkus:quarkus-bootstrap-maven-resolver
     datasource:
@@ -59,6 +61,12 @@ sbomer:
       database:
         generation: drop-and-create
       log:
+        level: INFO
+        console:
+          format: "%m%n"
+        category:
+          "org.jboss.sbomer":
+            level: DEBUG
         sql: true
     smallrye-openapi:
       info-title: SBOMer service (development)

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -29,6 +29,12 @@ quarkus:
       generation: update # TODO: This is for now, so that we can work on stage, remove this once we maintain the DB properly
   qpid-jms:
     url: amqps://umb.api.redhat.com:5671
+  
+  log:
+    level: INFO
+    category:
+      "org.jboss.sbomer":
+        level: DEBUG
 
 sbomer:
   domino:
@@ -61,12 +67,6 @@ sbomer:
       database:
         generation: drop-and-create
       log:
-        level: INFO
-        console:
-          format: "%m%n"
-        category:
-          "org.jboss.sbomer":
-            level: DEBUG
         sql: true
     smallrye-openapi:
       info-title: SBOMer service (development)

--- a/service/src/test/java/org/jboss/sbomer/test/SBOMResourceTest.java
+++ b/service/src/test/java/org/jboss/sbomer/test/SBOMResourceTest.java
@@ -55,79 +55,14 @@ public class SBOMResourceTest {
 
     @Test
     public void testExistenceOfSbomsEndpoint() {
-        Mockito.when(sbomService.listSboms(0, 50)).thenReturn(new Page<>());
+        Mockito.when(sbomService.list(0, 50)).thenReturn(new Page<>());
         given().when().get("/api/v1alpha1/sboms").then().statusCode(200);
     }
 
     @Test
     public void testListSbomsPageParams() {
-        Mockito.when(sbomService.listSboms(1, 20)).thenReturn(new Page<>());
+        Mockito.when(sbomService.list(1, 20)).thenReturn(new Page<>());
         given().when().get("/api/v1alpha1/sboms?pageIndex=1&pageSize=20").then().statusCode(200);
-    }
-
-    @Test
-    public void testShouldAcceptValidSbom() throws IOException {
-        ArgumentCaptor<Sbom> sbomCapture = ArgumentCaptor.forClass(Sbom.class);
-
-        Mockito.doNothing().when(sbomService).processSbom(sbomCapture.capture(), eq(ProcessorImplementation.DEFAULT));
-
-        with().body(TestResources.asString("payloads/payload-valid.json"))
-                .when()
-                .contentType(ContentType.JSON)
-                .request("POST", "/api/v1alpha1/sboms")
-                .then()
-                .statusCode(201);
-
-        assertEquals("AWI7P3EJ23YAA", sbomCapture.getValue().getBuildId());
-        assertEquals(GeneratorImplementation.CYCLONEDX, sbomCapture.getValue().getGenerator());
-
-        verify(sbomService, times(1)).processSbom(sbomCapture.getValue(), ProcessorImplementation.DEFAULT);
-    }
-
-    @Test
-    public void testInvalidJson() throws IOException {
-        with().body(TestResources.asString("payloads/payload-invalid-json.json"))
-                .when()
-                .contentType(ContentType.JSON)
-                .request("POST", "/api/v1alpha1/sboms")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
-    public void testShouldNotAcceptMissingSbom() throws IOException {
-        with().body(TestResources.asString("payloads/payload-invalid-bom.json"))
-                .when()
-                .contentType(ContentType.JSON)
-                .request("POST", "/api/v1alpha1/sboms")
-                .then()
-                .statusCode(422)
-                .body("message", CoreMatchers.equalTo("SBOM validation error"))
-                .and()
-                .body(
-                        "errors",
-                        CoreMatchers.hasItems(
-                                CoreMatchers.is(
-                                        "Invalid CycloneDX object: sbom.specVersion: is missing but it is required"),
-                                CoreMatchers.is(
-                                        "Invalid CycloneDX object: sbom.specVdersion: is not defined in the schema and the schema does not allow additional properties")));
-    }
-
-    @Test
-    public void testShouldNotAcceptMissingBuildId() throws IOException {
-        with().body(TestResources.asString("payloads/payload-invalid-missing-buildid.json"))
-                .when()
-                .contentType(ContentType.JSON)
-                .request("POST", "/api/v1alpha1/sboms")
-                .then()
-                .statusCode(422)
-                .body("message", CoreMatchers.equalTo("SBOM validation error"))
-                .and()
-                .body(
-                        "errors",
-                        CoreMatchers.hasItems(
-                                CoreMatchers.is("rootPurl: Root purl identifier missing"),
-                                CoreMatchers.is("buildId: Build identifier missing")));
     }
 
     @Test
@@ -148,7 +83,7 @@ public class SBOMResourceTest {
         sbom.setBuildId("AAAABBBB");
         sbom.setId(12345L);
 
-        Mockito.when(sbomService.getSbomById(12345)).thenReturn(sbom);
+        Mockito.when(sbomService.get(12345l)).thenReturn(sbom);
 
         given().when()
                 .contentType(ContentType.JSON)
@@ -284,5 +219,28 @@ public class SBOMResourceTest {
                 .body(
                         "components.properties.name",
                         CoreMatchers.hasItem(CoreMatchers.hasItem(CoreMatchers.is("pnc-build-id"))));
+    }
+
+    /**
+     * It should return a stub for the {@link Sbom} object, where the sbom field is empty.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void shouldStartGenerationForAGivenPncBuild() throws IOException {
+        given().when()
+                .contentType(ContentType.JSON)
+                .request("POST", "/api/v1alpha1/sboms/generate/build/AABBCC")
+                .then()
+                .statusCode(202)
+                .body("id", CoreMatchers.any(Long.class))
+                .and()
+                .body("buildId", CoreMatchers.equalTo("AABBCC"))
+                .and()
+                .body("sbom", CoreMatchers.nullValue())
+                .and()
+                .body("generator", CoreMatchers.is("CYCLONEDX"))
+                .and()
+                .body("processor", CoreMatchers.nullValue());
     }
 }

--- a/service/src/test/java/org/jboss/sbomer/test/TestSBOMService.java
+++ b/service/src/test/java/org/jboss/sbomer/test/TestSBOMService.java
@@ -20,7 +20,6 @@ package org.jboss.sbomer.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -28,9 +27,7 @@ import java.util.Iterator;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
 
-import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.model.Sbom;
 import org.jboss.sbomer.processor.SbomProcessor;
 import org.jboss.sbomer.rest.dto.Page;
@@ -47,9 +44,6 @@ public class TestSBOMService {
     @Inject
     SbomService sbomService;
 
-    // @Inject
-    // PncServiceMock pncServiceMock;
-
     @Any
     @Inject
     Instance<SbomProcessor> processors;
@@ -59,7 +53,7 @@ public class TestSBOMService {
     @Test
     public void testGetBaseSbom() throws IOException {
         log.info("testGetBaseSbom ...");
-        Sbom baseSBOM = sbomService.getSbom(INITIAL_BUILD_ID, GeneratorImplementation.CYCLONEDX, null);
+        Sbom baseSBOM = sbomService.getBaseSbomByBuildId(INITIAL_BUILD_ID);
         assertNotNull(baseSBOM);
     }
 
@@ -67,7 +61,7 @@ public class TestSBOMService {
     public void testListBaseSboms() throws IOException {
         log.info("testListBaseSboms ...");
 
-        Page<Sbom> page = sbomService.listSboms(0, 50);
+        Page<Sbom> page = sbomService.list(0, 50);
         assertEquals(0, page.getPageIndex());
         assertEquals(50, page.getPageSize());
         assertTrue(page.getTotalHits() > 0);
@@ -85,15 +79,5 @@ public class TestSBOMService {
         }
 
         assertNotNull(foundSbom);
-    }
-
-    @Test
-    public void testBaseSbomNotFound() throws IOException {
-        log.info("testBaseSbomNotFound ...");
-        try {
-            sbomService.getSbom("I_DO_NOT_EXIST", GeneratorImplementation.CYCLONEDX, null);
-            fail("It should have thrown a 404 exception");
-        } catch (NotFoundException nfe) {
-        }
     }
 }

--- a/service/src/test/java/org/jboss/sbomer/test/TestSbomRepository.java
+++ b/service/src/test/java/org/jboss/sbomer/test/TestSbomRepository.java
@@ -39,6 +39,7 @@ import org.cyclonedx.model.Component;
 import org.jboss.pnc.common.json.JsonUtils;
 import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.core.enums.ProcessorImplementation;
+import org.jboss.sbomer.core.enums.SbomStatus;
 import org.jboss.sbomer.core.enums.SbomType;
 import org.jboss.sbomer.core.test.TestResources;
 import org.jboss.sbomer.model.Sbom;
@@ -69,6 +70,7 @@ public class TestSbomRepository extends SbomRepository {
         Sbom parentSBOM = new Sbom();
         parentSBOM.setBuildId("ARYT3LBXDVYAC");
         parentSBOM.setId(416640206274228224L);
+        parentSBOM.setStatus(SbomStatus.READY);
         parentSBOM.setType(SbomType.BUILD_TIME);
         parentSBOM.setGenerationTime(Instant.now());
         parentSBOM.setSbom(sbom);
@@ -85,6 +87,7 @@ public class TestSbomRepository extends SbomRepository {
         Sbom enrichedSBOM = new Sbom();
         enrichedSBOM.setBuildId("ARYT3LBXDVYAC");
         enrichedSBOM.setId(416640206274228225L);
+        enrichedSBOM.setStatus(SbomStatus.READY);
         enrichedSBOM.setType(SbomType.BUILD_TIME);
         enrichedSBOM.setGenerationTime(Instant.now());
         enrichedSBOM.setSbom(sbom);

--- a/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonCycloneDxSbomGenerator.java
+++ b/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonCycloneDxSbomGenerator.java
@@ -81,14 +81,14 @@ public class TestTektonCycloneDxSbomGenerator {
         Mockito.when(v1beta1.taskRuns()).thenReturn(taskRuns);
         Mockito.when(tektonClient.v1beta1()).thenReturn(v1beta1);
 
-        generator.generate("AAABBBB");
+        generator.generate(12345l);
 
         Mockito.verify(tektonClient.v1beta1().taskRuns(), Mockito.times(1)).resource(argThat(taskRun -> {
             assertNotNull(taskRun);
-            assertEquals("sbomer-cyclonedx-aaabbbb-", taskRun.getMetadata().getGenerateName());
+            assertEquals("sbomer-cyclonedx-12345-", taskRun.getMetadata().getGenerateName());
             assertEquals("sbomer-generate-cyclonedx", taskRun.getSpec().getTaskRef().getName());
             assertEquals("sbomer-sa", taskRun.getSpec().getServiceAccountName());
-            assertEquals("AAABBBB", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
+            assertEquals("12345", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
             try {
                 JsonNode config = mapper.readTree(taskRun.getSpec().getParams().get(1).getValue().getStringVal());
                 String version = config.get("version").asText().toString();

--- a/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonDominoSbomGenerator.java
+++ b/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonDominoSbomGenerator.java
@@ -81,14 +81,14 @@ public class TestTektonDominoSbomGenerator {
         Mockito.when(v1beta1.taskRuns()).thenReturn(taskRuns);
         Mockito.when(tektonClient.v1beta1()).thenReturn(v1beta1);
 
-        generator.generate("AAABBBB");
+        generator.generate(123456l);
 
         Mockito.verify(tektonClient.v1beta1().taskRuns(), Mockito.times(1)).resource(argThat(taskRun -> {
             assertNotNull(taskRun);
-            assertEquals("sbomer-domino-aaabbbb-", taskRun.getMetadata().getGenerateName());
+            assertEquals("sbomer-domino-123456-", taskRun.getMetadata().getGenerateName());
             assertEquals("sbomer-generate-domino", taskRun.getSpec().getTaskRef().getName());
             assertEquals("sbomer-sa", taskRun.getSpec().getServiceAccountName());
-            assertEquals("AAABBBB", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
+            assertEquals("123456", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
             try {
                 JsonNode config = mapper.readTree(taskRun.getSpec().getParams().get(1).getValue().getStringVal());
                 String version = config.get("version").asText().toString();


### PR DESCRIPTION
Main change in this PR is that **resources have now statuses**.

## Generating

Now, when a generation is requested, an `Sbom` object is created and proper status set. Below is an example response returned to the requester when :

```json
HTTP/1.1 202 Accepted
Content-Type: application/json;charset=UTF-8
content-length: 230

{
    "buildId": "ARYT3LBXDVYAC",
    "generationTime": "2023-04-17T09:10:52.753561090Z",
    "generator": "CYCLONEDX",
    "id": 435728847752626176,
    "parentSbom": null,
    "processor": null,
    "rootPurl": null,
    "sbom": null,
    "status": "GENERATING",
    "type": "BUILD_TIME"
}
```

Things to note:

1. `sbom` is null -- obviosly, we haven't generated it yet.
2. `status` is `GENERATING`
3. HTTP code is `202`, accepted.

This lets the client understand the status and at the same time have a pointer to the resource: id: `435728847752626176`, so the status (and resource) can be queried by using this path: `/api/v1alpha1/sboms/435728847752626176`.

Underneath, when the generation process finishes, we are just updating the `sbom` field in the resource. Additionally the `rootPurl` is updated as well.

## Processing

Another change is that currently we are NOT triggering automatically the processing of the generated SBOM.

Similarly to generation, processing returns a similar response:

```json
HTTP/1.1 202 Accepted
Content-Type: application/json;charset=UTF-8
transfer-encoding: chunked

{
    "buildId": "ARYT3LBXDVYAC",
    "generationTime": "2023-04-17T09:16:38.909539596Z",
    "generator": "CYCLONEDX",
    "id": 435730299631927296,
    "parentSbom": { ... }
    "processor": "DEFAULT",
    "rootPurl": null,
    "sbom": null,
    "status": "PROCESSING",
    "type": "BUILD_TIME"
}
```