### PR TITLE
[NCL-7695] - Setup UMB sender

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/RedHatProductProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/commands/processor/RedHatProductProcessCommand.java
@@ -32,6 +32,10 @@ import org.jboss.sbomer.core.utils.SbomUtils;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine.Command;
 
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_NAME;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VERSION;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VARIANT;
+
 /**
  * <p>
  * Processor to add the Red Hat Product information to the main {@link Component} within the {@link Bom}.
@@ -43,10 +47,6 @@ import picocli.CommandLine.Command;
         name = "redhat-product",
         description = "Process the SBOM with Red Hat product enrichment")
 public class RedHatProductProcessCommand extends AbstractProcessCommand {
-
-    public final static String PROPERTY_ERRATA_PRODUCT_NAME = "errata-tool-product-name";
-    public final static String PROPERTY_ERRATA_PRODUCT_VERSION = "errata-tool-product-version";
-    public final static String PROPERTY_ERRATA_PRODUCT_VARIANT = "errata-tool-product-variant";
 
     @Inject
     ProductVersionMapper productVersionMapper;

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/command/processor/RedHatProductProcessCommandTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/command/processor/RedHatProductProcessCommandTest.java
@@ -43,6 +43,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_NAME;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VERSION;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VARIANT;
+
 @QuarkusTest
 @QuarkusTestResource(PncWireMock.class)
 public class RedHatProductProcessCommandTest {
@@ -87,18 +91,9 @@ public class RedHatProductProcessCommandTest {
 
         Bom bom = SbomUtils.fromJsonNode(sbom.getSbom());
 
-        assertFalse(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_NAME));
-        assertFalse(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VERSION));
-        assertFalse(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VARIANT));
+        assertFalse(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_NAME));
+        assertFalse(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_VERSION));
+        assertFalse(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_VARIANT));
     }
 
     @Test
@@ -134,32 +129,21 @@ public class RedHatProductProcessCommandTest {
         sbom.setBuildId("QUARKUS");
         Bom bom = command.doProcess(sbom, SbomUtils.fromJsonNode(sbom.getSbom()));
 
-        assertTrue(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_NAME));
-        assertTrue(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VERSION));
-        assertTrue(
-                SbomUtils.hasProperty(
-                        bom.getMetadata().getComponent(),
-                        RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VARIANT));
+        assertTrue(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_NAME));
+        assertTrue(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_VERSION));
+        assertTrue(SbomUtils.hasProperty(bom.getMetadata().getComponent(), PROPERTY_ERRATA_PRODUCT_VARIANT));
 
         assertEquals(
                 "RHBQ",
                 SbomUtils
-                        .findPropertyWithNameInComponent(
-                                RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_NAME,
-                                bom.getMetadata().getComponent())
+                        .findPropertyWithNameInComponent(PROPERTY_ERRATA_PRODUCT_NAME, bom.getMetadata().getComponent())
                         .get()
                         .getValue());
         assertEquals(
                 "RHEL-8-RHBQ-2.13",
                 SbomUtils
                         .findPropertyWithNameInComponent(
-                                RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VERSION,
+                                PROPERTY_ERRATA_PRODUCT_VERSION,
                                 bom.getMetadata().getComponent())
                         .get()
                         .getValue());
@@ -167,7 +151,7 @@ public class RedHatProductProcessCommandTest {
                 "8Base-RHBQ-2.13",
                 SbomUtils
                         .findPropertyWithNameInComponent(
-                                RedHatProductProcessCommand.PROPERTY_ERRATA_PRODUCT_VARIANT,
+                                PROPERTY_ERRATA_PRODUCT_VARIANT,
                                 bom.getMetadata().getComponent())
                         .get()
                         .getValue());

--- a/core/src/main/java/org/jboss/sbomer/core/utils/Constants.java
+++ b/core/src/main/java/org/jboss/sbomer/core/utils/Constants.java
@@ -38,6 +38,10 @@ public class Constants {
     public static final String SUPPLIER_URL = "https://www.redhat.com";
     public static final String MRRC_URL = "https://maven.repository.redhat.com/ga/";
 
+    public final static String PROPERTY_ERRATA_PRODUCT_NAME = "errata-tool-product-name";
+    public final static String PROPERTY_ERRATA_PRODUCT_VERSION = "errata-tool-product-version";
+    public final static String PROPERTY_ERRATA_PRODUCT_VARIANT = "errata-tool-product-variant";
+
     /**
      * The Service Account used to run the TaskRun.
      */

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -47,6 +47,18 @@ patches:
         value:
           name: SBOMER_PRODUCT_MAPPING_ENV
           value: "production"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SBOMER_ROUTE_HOST
+          value: "sbomer.apps.ocp-c1.prod.psi.redhat.com"
+  - target:
+      kind: Route
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: "sbomer.apps.ocp-c1.prod.psi.redhat.com"
+
 
 # List of images used in production
 # TODO: Currently happily using :latest tag but this will be changed in the future

--- a/k8s/overlays/production/patches/route.yaml
+++ b/k8s/overlays/production/patches/route.yaml
@@ -23,4 +23,4 @@ metadata:
   labels:
     app.kubernetes.io/component: service
 spec:
-  host: sbomer.apps.ocp-c1.prod.psi.redhat.com
+  host: ${SBOMER_ROUTE_HOST}

--- a/k8s/overlays/production/patches/service.yaml
+++ b/k8s/overlays/production/patches/service.yaml
@@ -30,3 +30,5 @@ spec:
               $patch: delete
             - name: SBOMER_PRODUCT_MAPPING_ENV
               $patch: delete
+            - name: SBOMER_ROUTE_HOST
+              $patch: delete

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -150,6 +150,11 @@ patches:
         value:
           name: SBOMER_PRODUCT_MAPPING_ENV
           value: "staging"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SBOMER_ROUTE_HOST
+          value: "sbomer-stage.apps.ocp-c1.prod.psi.redhat.com"
 
   - target:
       kind: StatefulSet
@@ -164,6 +169,12 @@ patches:
         path: /spec/steps/0/imagePullPolicy
         value: Always
 
+  - target:
+      kind: Route
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: "sbomer-stage.apps.ocp-c1.prod.psi.redhat.com"
 
 # List of images used in staging
 # TODO: Currently happily using :latest tag but this will be changed in the future

--- a/k8s/overlays/staging/service/route.yaml
+++ b/k8s/overlays/staging/service/route.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     app.kubernetes.io/component: service
 spec:
-  host: sbomer-stage.apps.ocp-c1.prod.psi.redhat.com
+  host: ${SBOMER_ROUTE_HOST}
   to:
     kind: Service
     name: sbomer

--- a/service/src/main/java/org/jboss/sbomer/features/umb/UmbConfig.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/UmbConfig.java
@@ -68,6 +68,21 @@ public interface UmbConfig {
          * The topic that should be used to send messages to.
          */
         Optional<String> topic();
+
+        /**
+         * The number of retries when sending notification via UMB
+         *
+         */
+        @WithDefault("15")
+        int retries();
+
+        /**
+         * The maximum number of seconds to back-off the retry
+         *
+         */
+        @WithDefault("30")
+        int maxBackOff();
+
     }
 
     @WithDefault("true")

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/MessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/MessageProducer.java
@@ -17,8 +17,6 @@
  */
 package org.jboss.sbomer.features.umb.producer;
 
-import java.util.Map;
-
 import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
 
 import io.quarkus.runtime.ShutdownEvent;
@@ -33,7 +31,5 @@ public interface MessageProducer {
     String getMessageSenderId();
 
     void sendToTopic(GenerationFinishedMessageBody message);
-
-    void sendToTopic(GenerationFinishedMessageBody message, Map<String, String> headers);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/MessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/MessageProducer.java
@@ -1,0 +1,39 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.features.umb.producer;
+
+import java.util.Map;
+
+import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+public interface MessageProducer {
+
+    void init(StartupEvent ev);
+
+    void destroy(ShutdownEvent ev);
+
+    String getMessageSenderId();
+
+    void sendToTopic(GenerationFinishedMessageBody message);
+
+    void sendToTopic(GenerationFinishedMessageBody message, Map<String, String> headers);
+
+}

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/NotificationService.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service;
+package org.jboss.sbomer.features.umb.producer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -26,14 +26,13 @@ import org.cyclonedx.model.Property;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.utils.SbomUtils;
 import org.jboss.sbomer.features.umb.UmbConfig;
-import org.jboss.sbomer.features.umb.producer.GenerationFinishedMessageBodyValidator;
-import org.jboss.sbomer.features.umb.producer.UmbMessageProducer;
 import org.jboss.sbomer.features.umb.producer.model.Build;
 import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
 import org.jboss.sbomer.features.umb.producer.model.ProductConfig;
 import org.jboss.sbomer.features.umb.producer.model.Sbom;
 import org.jboss.sbomer.features.umb.producer.model.Build.BuildSystem;
 import org.jboss.sbomer.features.umb.producer.model.Sbom.BomFormat;
+import org.jboss.sbomer.service.SbomRepository;
 
 import lombok.extern.slf4j.Slf4j;
 import java.util.List;
@@ -90,27 +89,27 @@ public class NotificationService {
         try {
             sbomIdLong = Long.valueOf(sbomId);
         } catch (NumberFormatException nfe) {
-            log.error("Could not parse to long the Sbom id '{}' provided", sbomId);
+            log.error("Could not parse to long the SBOM id '{}' provided", sbomId);
             return;
         }
 
         org.jboss.sbomer.model.Sbom sbom = sbomRepository.findById(sbomIdLong);
 
         if (sbom == null) {
-            log.warn("Could not find Sbom id '{}', skipping sending UMB notification", sbomId);
+            log.warn("Could not find SBOM id '{}', skipping sending UMB notification", sbomId);
             return;
         }
 
         org.cyclonedx.model.Bom bom = fromJsonNode(sbom.getSbom());
         if (bom == null) {
-            log.warn("Could not find a valid bom for Sbom id '{}', skipping sending UMB notification", sbom.getId());
+            log.warn("Could not find a valid bom for SBOM id '{}', skipping sending UMB notification", sbom.getId());
             return;
         }
 
         Component component = bom.getMetadata().getComponent();
         if (component == null) {
             log.warn(
-                    "Could not find root metadata component for Sbom id '{}', skipping sending UMB notification",
+                    "Could not find root metadata component for SBOM id '{}', skipping sending UMB notification",
                     sbom.getId());
             return;
         }
@@ -132,7 +131,7 @@ public class NotificationService {
             bomFormat = BomFormat.valueOf(bom.getBomFormat().toUpperCase());
         } catch (IllegalArgumentException exc) {
             log.warn(
-                    "Could not find compatible bom format for Sbom id '{}', found '{}', skipping sending UMB notification",
+                    "Could not find compatible bom format for SBOM id '{}', found '{}', skipping sending UMB notification",
                     sbom.getId(),
                     bom.getBomFormat());
         }

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
@@ -1,0 +1,207 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.features.umb.producer;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.sbomer.features.umb.UmbConfig;
+import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import lombok.extern.slf4j.Slf4j;
+
+@Unremovable
+@ApplicationScoped
+@Slf4j
+public class UmbMessageProducer implements MessageProducer {
+
+    @ConfigProperty(name = "quarkus.qpid-jms.url")
+    String amqpConnection;
+
+    @Inject
+    UmbConfig umbConfig;
+
+    @Inject
+    ConnectionFactory cf;
+
+    Connection connection;
+
+    @Override
+    public void init(@Observes StartupEvent ev) {
+        if (!umbConfig.isEnabled()) {
+            log.info("UMB feature disabled");
+            return;
+        }
+
+        if (!umbConfig.producer().isEnabled()) {
+            log.info("UMB feature to produce notification messages disabled");
+            return;
+        }
+
+        if (!umbConfig.producer().topic().isPresent()) {
+            log.info("UMB producer topic not specified");
+            return;
+        }
+
+        initConnection();
+    }
+
+    @Override
+    public void destroy(@Observes ShutdownEvent ev) {
+        closeConnection();
+    }
+
+    @Override
+    public String getMessageSenderId() {
+        return UmbMessageProducer.class.getName();
+    }
+
+    @Override
+    public void sendToTopic(GenerationFinishedMessageBody message) {
+        sendMessageWithRetries(message.toJson(), Collections.EMPTY_MAP, umbConfig.producer().retries());
+    }
+
+    @Override
+    public void sendToTopic(GenerationFinishedMessageBody message, Map<String, String> headers) {
+        sendMessageWithRetries(message.toJson(), headers, umbConfig.producer().retries());
+    }
+
+    private void sendMessageWithRetries(String message, Map<String, String> headers, int retries) {
+        Session session = null;
+        javax.jms.MessageProducer messageProducer = null;
+        try {
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            messageProducer = session.createProducer(session.createQueue(umbConfig.producer().topic().get()));
+            sendMessage(message, headers, session, messageProducer);
+        } catch (Exception e) {
+            if (retries <= 1) {
+                // give up
+                throw new RuntimeException(
+                        "Cannot send the message: " + message + "; with headers: " + headers + ".",
+                        e);
+            } else {
+                sleep(retries);
+                // try to set up a new connection on exception for the next message
+                initConnection();
+                sendMessageWithRetries(message, headers, retries - 1);
+            }
+        } finally {
+            closeSession(session);
+            closeMsgProducer(messageProducer);
+        }
+    }
+
+    private void sendMessage(
+            String message,
+            Map<String, String> headers,
+            Session session,
+            javax.jms.MessageProducer messageProducer) {
+
+        TextMessage textMessage;
+        try {
+            textMessage = session.createTextMessage(message);
+            textMessage.setStringProperty("producer", "SBOMER");
+        } catch (JMSException e) {
+            log.error("Unable to create textMessage.");
+            throw new RuntimeException("Unable to create textMessage.", e);
+        }
+
+        StringBuilder headerBuilder = new StringBuilder();
+        headers.forEach((k, v) -> {
+            try {
+                textMessage.setStringProperty(k, v);
+                headerBuilder.append(k + ":" + v + "; ");
+            } catch (JMSException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        try {
+            log.debug("Sending message with headers: {}.", headerBuilder.toString());
+            messageProducer.send(textMessage);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sleep exponentially as the number of retries decrease, up till max back-off time of configured seconds
+     *
+     * @param retries
+     */
+    private void sleep(int retries) {
+        int sleepMilli = (int) Math.min(Math.pow(2, (double) 10 / retries) * 10, umbConfig.producer().maxBackOff());
+        try {
+            Thread.sleep(sleepMilli);
+        } catch (InterruptedException e) {
+            log.warn("Sleeping was interrupted", e);
+        }
+    }
+
+    private void initConnection() {
+        try {
+            connection = cf.createConnection();
+            log.info("JMS client ID {}.", connection.getClientID());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize JMS.", e);
+        }
+    }
+
+    private void closeConnection() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception e) {
+                log.error("Failed to close JMS connection.", e);
+            }
+        }
+    }
+
+    private void closeSession(Session session) {
+        if (session != null) {
+            try {
+                session.close();
+            } catch (JMSException e) {
+                log.error("Cannot close JMS session.");
+            }
+        }
+    }
+
+    private void closeMsgProducer(javax.jms.MessageProducer messageProducer) {
+        if (messageProducer != null) {
+            try {
+                messageProducer.close();
+            } catch (JMSException e) {
+                log.error("Cannot close JMS messageProducer.");
+            }
+        }
+    }
+
+}

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
@@ -18,6 +18,7 @@
 package org.jboss.sbomer.features.umb.producer;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -30,6 +31,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.sbomer.core.utils.Constants;
 import org.jboss.sbomer.features.umb.UmbConfig;
 import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
 
@@ -86,11 +88,11 @@ public class UmbMessageProducer implements MessageProducer {
 
     @Override
     public void sendToTopic(GenerationFinishedMessageBody message) {
-        sendMessageWithRetries(message.toJson(), Collections.EMPTY_MAP, umbConfig.producer().retries());
-    }
-
-    @Override
-    public void sendToTopic(GenerationFinishedMessageBody message, Map<String, String> headers) {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("purl", message.getPurl());
+        headers.put(Constants.SBOM_RED_HAT_BUILD_ID, message.getBuild().getId());
+        headers.put("producer", "PNC Sbomer");
+        headers.put("type", "GenerationFinishedMessage");
         sendMessageWithRetries(message.toJson(), headers, umbConfig.producer().retries());
     }
 
@@ -128,7 +130,6 @@ public class UmbMessageProducer implements MessageProducer {
         TextMessage textMessage;
         try {
             textMessage = session.createTextMessage(message);
-            textMessage.setStringProperty("producer", "SBOMER");
         } catch (JMSException e) {
             log.error("Unable to create textMessage.");
             throw new RuntimeException("Unable to create textMessage.", e);

--- a/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/features/umb/producer/UmbMessageProducer.java
@@ -45,6 +45,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class UmbMessageProducer implements MessageProducer {
 
+    public static final String MESSAGE_HEADER_PURL_KEY = "purl";
+    public static final String MESSAGE_HEADER_BUILD_ID_KEY = Constants.SBOM_RED_HAT_BUILD_ID;
+    public static final String MESSAGE_HEADER_SBOM_ID_KEY = "sbom-id";
+    public static final String MESSAGE_HEADER_PRODUCER_KEY = "producer";
+    public static final String MESSAGE_HEADER_TYPE_KEY = "type";
+
     @ConfigProperty(name = "quarkus.qpid-jms.url")
     String amqpConnection;
 
@@ -89,10 +95,11 @@ public class UmbMessageProducer implements MessageProducer {
     @Override
     public void sendToTopic(GenerationFinishedMessageBody message) {
         Map<String, String> headers = new HashMap<String, String>();
-        headers.put("purl", message.getPurl());
-        headers.put(Constants.SBOM_RED_HAT_BUILD_ID, message.getBuild().getId());
-        headers.put("producer", "PNC Sbomer");
-        headers.put("type", "GenerationFinishedMessage");
+        headers.put(MESSAGE_HEADER_PURL_KEY, message.getPurl());
+        headers.put(MESSAGE_HEADER_BUILD_ID_KEY, message.getBuild().getId());
+        headers.put(MESSAGE_HEADER_SBOM_ID_KEY, message.getSbom().getId());
+        headers.put(MESSAGE_HEADER_PRODUCER_KEY, "PNC SBOMer");
+        headers.put(MESSAGE_HEADER_TYPE_KEY, "GenerationFinishedMessage");
         sendMessageWithRetries(message.toJson(), headers, umbConfig.producer().retries());
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/NotificationService.java
@@ -1,0 +1,182 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.Property;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.sbomer.core.utils.SbomUtils;
+import org.jboss.sbomer.features.umb.UmbConfig;
+import org.jboss.sbomer.features.umb.producer.GenerationFinishedMessageBodyValidator;
+import org.jboss.sbomer.features.umb.producer.UmbMessageProducer;
+import org.jboss.sbomer.features.umb.producer.model.Build;
+import org.jboss.sbomer.features.umb.producer.model.GenerationFinishedMessageBody;
+import org.jboss.sbomer.features.umb.producer.model.ProductConfig;
+import org.jboss.sbomer.features.umb.producer.model.Sbom;
+import org.jboss.sbomer.features.umb.producer.model.Build.BuildSystem;
+import org.jboss.sbomer.features.umb.producer.model.Sbom.BomFormat;
+
+import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Optional;
+
+import static org.jboss.sbomer.core.utils.SbomUtils.findPropertyWithNameInComponent;
+import static org.jboss.sbomer.core.utils.SbomUtils.hasProperty;
+import static org.jboss.sbomer.core.utils.SbomUtils.getExternalReferences;
+import static org.jboss.sbomer.core.utils.SbomUtils.fromJsonNode;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_NAME;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VERSION;
+import static org.jboss.sbomer.core.utils.Constants.PROPERTY_ERRATA_PRODUCT_VARIANT;
+import static org.jboss.sbomer.core.utils.Constants.SBOM_RED_HAT_BUILD_ID;
+
+/**
+ * Service implementation responsible for the notification of completed SBOMs.
+ *
+ * @author Marek Goldmann
+ */
+@ApplicationScoped
+@Slf4j
+public class NotificationService {
+
+    @ConfigProperty(name = "sbomer.api-url")
+    String sbomerApiUrl;
+
+    @Inject
+    SbomRepository sbomRepository;
+
+    @Inject
+    UmbConfig umbConfig;
+
+    @Inject
+    UmbMessageProducer messageProducer;
+
+    public void notifyCompleted(String sbomId) {
+
+        if (!umbConfig.isEnabled()) {
+            log.info("UMB feature disabled");
+            return;
+        }
+
+        if (!umbConfig.producer().isEnabled()) {
+            log.info("UMB feature to produce notification messages disabled");
+            return;
+        }
+
+        if (!umbConfig.producer().topic().isPresent()) {
+            log.info("UMB produce topic not specified");
+            return;
+        }
+
+        Long sbomIdLong = null;
+        try {
+            sbomIdLong = Long.valueOf(sbomId);
+        } catch (NumberFormatException nfe) {
+            log.error("Could not parse to long the Sbom id '{}' provided", sbomId);
+            return;
+        }
+
+        org.jboss.sbomer.model.Sbom sbom = sbomRepository.findById(sbomIdLong);
+
+        if (sbom == null) {
+            log.warn("Could not find Sbom id '{}', skipping sending UMB notification", sbomId);
+            return;
+        }
+
+        org.cyclonedx.model.Bom bom = fromJsonNode(sbom.getSbom());
+        if (bom == null) {
+            log.warn("Could not find a valid bom for Sbom id '{}', skipping sending UMB notification", sbom.getId());
+            return;
+        }
+
+        Component component = bom.getMetadata().getComponent();
+        if (component == null) {
+            log.warn(
+                    "Could not find root metadata component for Sbom id '{}', skipping sending UMB notification",
+                    sbom.getId());
+            return;
+        }
+
+        GenerationFinishedMessageBody msg = createGenerationFinishedMessage(sbom, bom);
+        if (GenerationFinishedMessageBodyValidator.validate(msg).isValid()) {
+            messageProducer.sendToTopic(msg);
+        }
+    }
+
+    private GenerationFinishedMessageBody createGenerationFinishedMessage(
+            org.jboss.sbomer.model.Sbom sbom,
+            org.cyclonedx.model.Bom bom) {
+
+        Component component = bom.getMetadata().getComponent();
+        BomFormat bomFormat = null;
+
+        try {
+            bomFormat = BomFormat.valueOf(bom.getBomFormat().toUpperCase());
+        } catch (IllegalArgumentException exc) {
+            log.warn(
+                    "Could not find compatible bom format for Sbom id '{}', found '{}', skipping sending UMB notification",
+                    sbom.getId(),
+                    bom.getBomFormat());
+        }
+
+        Sbom.Bom bomPayload = Sbom.Bom.builder()
+                .format(bomFormat)
+                .version(bom.getSpecVersion())
+                .link(sbomerApiUrl + "sboms/" + sbom.getId() + "/bom")
+                .build();
+
+        Sbom sbomPayload = Sbom.builder()
+                .id(String.valueOf(sbom.getId()))
+                .link(sbomerApiUrl + "sboms/" + sbom.getId())
+                .bom(bomPayload)
+                .build();
+
+        Optional<ExternalReference> pncBuildSystemRef = getExternalReferences(
+                component,
+                ExternalReference.Type.BUILD_SYSTEM).stream()
+                .filter(r -> r.getComment().equals(SBOM_RED_HAT_BUILD_ID))
+                .findFirst();
+
+        Build buildPayload = Build.builder()
+                .id(sbom.getBuildId())
+                .buildSystem(pncBuildSystemRef.isPresent() ? BuildSystem.PNC : null)
+                .link(pncBuildSystemRef.isPresent() ? pncBuildSystemRef.get().getUrl() : null)
+                .build();
+
+        Optional<Property> productName = findPropertyWithNameInComponent(PROPERTY_ERRATA_PRODUCT_NAME, component);
+        Optional<Property> productVersion = findPropertyWithNameInComponent(PROPERTY_ERRATA_PRODUCT_VERSION, component);
+        Optional<Property> productVariant = findPropertyWithNameInComponent(PROPERTY_ERRATA_PRODUCT_VARIANT, component);
+
+        ProductConfig.ErrataProductConfig errataProductConfigPayload = ProductConfig.ErrataProductConfig.builder()
+                .productName(productName.isPresent() ? productName.get().getValue() : null)
+                .productVersion(productVersion.isPresent() ? productVersion.get().getValue() : null)
+                .productVariant(productVariant.isPresent() ? productVariant.get().getValue() : null)
+                .build();
+        ProductConfig productConfigPayload = ProductConfig.builder().errataTool(errataProductConfigPayload).build();
+
+        return GenerationFinishedMessageBody.builder()
+                .purl(sbom.getRootPurl())
+                .sbom(sbomPayload)
+                .build(buildPayload)
+                .productConfig(productConfigPayload)
+                .build();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/ProcessingService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/ProcessingService.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.sbomer.service;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -36,6 +36,7 @@ quarkus:
         level: DEBUG
 
 sbomer:
+  api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha1/"
   # See documentation about features and feature flags
   features:
     umb:
@@ -45,8 +46,10 @@ sbomer:
         topic: "${CONSUMER_TOPIC}"
         trigger: product
       producer:
-        enabled: false
+        enabled: true
         topic: "${PRODUCER_TOPIC}"
+        retries: 15
+        max-back-off: 30
 
   generation:
     enabled: true


### PR DESCRIPTION
- Move errata product names properties to the other constants
- Add retries configuration properties for the Umb producer
- Implement the UMB sender
- Implement a Notification service to send sbom creation events via UMB
- Expose the public route to be used when sending notification UMB messages