### PR TITLE
Handle builds with status BUILD_NOT_REQUIRED

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
@@ -57,4 +57,14 @@ public interface SBOMerClient {
     @GET
     @Path("/{id}")
     Sbom getById(@PathParam("id") String id);
+
+    /**
+     * Retrieves the base SBOM based on the build ID.
+     *
+     * @param buildId
+     * @return {@link Sbom}
+     */
+    @GET
+    @Path("/build/{buildId}")
+    Sbom getBaseSbomWithPncBuildId(@PathParam("buildId") String buildId);
 }

--- a/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/v1alpha1/SBOMResource.java
@@ -217,27 +217,28 @@ public class SBOMResource {
     // return sbomService.listAllSbomsWithBuildId(buildId);
     // }
 
-    // @GET
-    // @Path("/build/{buildId}/base")
-    // @Operation(summary = "Get the base SBOM related to a PNC build")
-    // @Parameter(name = "buildId", description = "PNC build identifier", example = "ARYT3LBXDVYAC")
-    // @APIResponses({
-    // @APIResponse(
-    // responseCode = "200",
-    // description = "The base SBOM",
-    // content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-    // @APIResponse(
-    // responseCode = "404",
-    // description = "Requested base SBOM could not be found",
-    // content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-    // @APIResponse(
-    // responseCode = "500",
-    // description = "Internal server error",
-    // content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    // public Sbom getBaseSbomWithPncBuildId(@PathParam("buildId") String buildId) {
+    // TODO extend the endpoint with a query string, to handle base and enriched flavours of sbom to retrieve
+    @GET
+    @Path("/build/{buildId}")
+    @Operation(summary = "Get the base SBOM related to a PNC build")
+    @Parameter(name = "buildId", description = "PNC build identifier", example = "ARYT3LBXDVYAC")
+    @APIResponses({
+            @APIResponse(
+                    responseCode = "200",
+                    description = "The base SBOM",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested base SBOM could not be found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
+    public Sbom getBaseSbomWithPncBuildId(@PathParam("buildId") String buildId) {
 
-    // return sbomService.getBaseSbomByBuildId(buildId);
-    // }
+        return sbomService.getBaseSbomByBuildId(buildId);
+    }
 
     // @GET
     // @Path("/build/{buildId}/base/bom")

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -126,6 +126,6 @@ sbomer:
         enabled: true
         consumer:
           enabled: true
-          topic: "Consumer.pncsbomer.testing.VirtualTopic.eng.pnc.>"
+          topic: "Consumer.pncsbomer.testing.VirtualTopic.eng.pnc.builds"
         producer:
           enabled: false

--- a/service/src/test/java/org/jboss/sbomer/test/messaging/GenerationFinishedMessageBodyTest.java
+++ b/service/src/test/java/org/jboss/sbomer/test/messaging/GenerationFinishedMessageBodyTest.java
@@ -40,8 +40,10 @@ import org.jboss.sbomer.features.umb.producer.model.Sbom.BomFormat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 
 @QuarkusTest
+@WithKubernetesTestServer
 public class GenerationFinishedMessageBodyTest {
 
     @Inject

--- a/service/src/test/java/org/jboss/sbomer/test/messaging/PncBuildTest.java
+++ b/service/src/test/java/org/jboss/sbomer/test/messaging/PncBuildTest.java
@@ -73,7 +73,7 @@ public class PncBuildTest {
         try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
             TextMessage txgMsg = preparePNCBuildMsg(context);
             context.createProducer()
-                    .send(context.createQueue("Consumer.pncsbomer.testing.VirtualTopic.eng.pnc.>"), txgMsg);
+                    .send(context.createQueue("Consumer.pncsbomer.testing.VirtualTopic.eng.pnc.builds"), txgMsg);
         }
     }
 


### PR DESCRIPTION
The idea behind this is to be able to handle builds which have status BUILD_NOT_REQUIRED. Such builds need to handle differently the way they retrieve the scmUrl and scmTag. Also, in case the original builds has been already generated, we can reuse the same original SBOM instead of regenerating it again (which would give the same result because the code ha not changed). It is correct to process again the SBOM with enrichments, because in the meantime more builds could be available and provide more metadata for the enrichments.
The uncommented endpoint will get some query API in the future, so to reduce the number of endpoints to re-expose.