### PR TITLE
[NCL-7867] Improve logging with MDC

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/client/SBOMerClient.java
@@ -22,6 +22,7 @@ import javax.validation.Valid;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -52,7 +53,10 @@ public interface SBOMerClient {
      */
     @POST
     @Path("/{id}/bom")
-    String updateSbom(@PathParam("id") String sbomId, JsonNode bom);
+    String updateSbom(
+            @HeaderParam("log-process-context") String processContext,
+            @PathParam("id") String sbomId,
+            JsonNode bom);
 
     /**
      * Retrieves SBOM based on the ID.
@@ -62,7 +66,7 @@ public interface SBOMerClient {
      */
     @GET
     @Path("/{id}")
-    Sbom getById(@PathParam("id") String id);
+    Sbom getById(@HeaderParam("log-process-context") String processContext, @PathParam("id") String id);
 
     /**
      * Search the base SBOM based on the build ID via RSQL search and pagination.
@@ -73,6 +77,7 @@ public interface SBOMerClient {
      */
     @GET
     Page<Sbom> searchSboms(
+            @HeaderParam("log-process-context") String processContext,
             @Valid @BeanParam PaginationParameters paginationParams,
             @QueryParam("query") String rsqlQuery);
 }

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -36,6 +36,8 @@ quarkus:
     category:
       "org.jboss.sbomer":
         level: DEBUG
+    console:
+      format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
 
 "%dev":
   quarkus:

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/client/SBOMerClientTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/client/SBOMerClientTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.pnc.rest.api.parameters.PaginationParameters;
@@ -46,7 +45,7 @@ public class SBOMerClientTest {
 
     @Test
     void testGetValidSbom() {
-        Sbom sbom = client.getById("123");
+        Sbom sbom = client.getById("123", "123");
         assertNotNull(sbom);
         assertEquals(123, sbom.getId());
         assertEquals("QUARKUS", sbom.getBuildId());
@@ -55,7 +54,7 @@ public class SBOMerClientTest {
     @Test
     void testNotFoundSbom() {
         ClientException ex = assertThrows(ClientException.class, () -> {
-            client.getById("1234");
+            client.getById("1234", "1234");
         });
 
         assertEquals(404, ex.getCode());
@@ -72,7 +71,7 @@ public class SBOMerClientTest {
         pagParams.setPageIndex(0);
         pagParams.setPageSize(1);
         String rsqlQuery = "id==123";
-        Page<Sbom> sboms = client.searchSboms(pagParams, rsqlQuery);
+        Page<Sbom> sboms = client.searchSboms("123", pagParams, rsqlQuery);
 
         assertNotNull(sboms);
         assertEquals(123, sboms.getContent().iterator().next().getId());

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,6 +39,10 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-logging-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
@@ -52,11 +56,16 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>common</artifactId>
-      <version>${version.pnc-api}</version>
+      <version>${version.pnc-rest}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client</artifactId>
+      <version>${version.pnc-rest}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-api</artifactId>
       <version>${version.pnc-api}</version>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/jboss/sbomer/core/utils/Constants.java
+++ b/core/src/main/java/org/jboss/sbomer/core/utils/Constants.java
@@ -53,6 +53,11 @@ public class Constants {
     public static String TEKTON_LABEL_SBOM_ID = "sbomer.jboss.org/sbom-id";
 
     /**
+     * The label name that identifies the particular Sbom build id.
+     */
+    public static String TEKTON_LABEL_SBOM_BUILD_ID = "sbomer.jboss.org/sbom-build-id";
+
+    /**
      * Default Kubernetes label: app.kubernetes.io/part-of
      */
     public static String TEKTON_LABEL_NAME_APP_PART_OF = "app.kubernetes.io/part-of";

--- a/core/src/main/java/org/jboss/sbomer/core/utils/MDCUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/utils/MDCUtils.java
@@ -1,0 +1,63 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.core.utils;
+
+import org.jboss.pnc.api.constants.MDCKeys;
+import org.jboss.pnc.common.Strings;
+import org.slf4j.MDC;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MDCUtils {
+
+    public static void addProcessContext(String processContext) {
+        String current = MDC.get(MDCKeys.PROCESS_CONTEXT_KEY);
+        if (Strings.isEmpty(current)) {
+            if (!Strings.isEmpty(processContext)) {
+                MDC.put(MDCKeys.PROCESS_CONTEXT_KEY, processContext);
+            }
+        } else {
+            log.warn("Did not set new processContext [{}] as value already exists [{}].", processContext, current);
+        }
+    }
+
+    public static void addBuildContext(String buildContext) {
+        String current = MDC.get(MDCKeys.BUILD_ID_KEY);
+        if (Strings.isEmpty(current)) {
+            if (!Strings.isEmpty(buildContext)) {
+                MDC.put(MDCKeys.BUILD_ID_KEY, buildContext);
+            }
+        } else {
+            log.warn("Did not set new buildContext [{}] as value already exists [{}].", buildContext, current);
+        }
+    }
+
+    public static void removeProcessContext() {
+        MDC.remove(MDCKeys.PROCESS_CONTEXT_KEY);
+    }
+
+    public static void removeBuildContext() {
+        MDC.remove(MDCKeys.BUILD_ID_KEY);
+    }
+
+    public static void removeContext() {
+        removeProcessContext();
+        removeBuildContext();
+    }
+}

--- a/core/src/main/resources/production/product-mapping.json
+++ b/core/src/main/resources/production/product-mapping.json
@@ -1,4 +1,11 @@
 {
+  "15": {
+    "errata": {
+      "productName": "RHTESTPRODUCT",
+      "productVersion": "RHEL-8-RHTESTPRODUCT-1.1",
+      "productVariant": "8Base-RHTESTPRODUCT-1.1"
+    }
+  },
   "382": {
     "generator": "DOMINO",
     "errata": {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,9 @@
         <version.hibernatetypes>1.0.1</version.hibernatetypes>
         <version.lombok>1.18.26</version.lombok>
         <version.mapstruct>1.4.2.Final</version.mapstruct>
-        <version.pnc-api>2.4.3</version.pnc-api>
+        <version.pnc-rest>2.4.3</version.pnc-rest>
+        <version.pnc-api>2.4.5</version.pnc-api>
+        <version.pnc-common>2.2.1</version.pnc-common>
         <version.quarkus-jgit>2.3.1</version.quarkus-jgit>
         <version.tekton-client>0.6.0</version.tekton-client>
         <version.rsql-parser>2.1.0</version.rsql-parser>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -93,7 +93,12 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client</artifactId>
-      <version>${version.pnc-api}</version>
+      <version>${version.pnc-rest}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-common</artifactId>
+      <version>${version.pnc-common}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/service/src/main/java/org/jboss/sbomer/generator/SbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/generator/SbomGenerator.java
@@ -28,28 +28,31 @@ public interface SbomGenerator {
      * Generates the SBOM in CycloneDX format referenced by the SBOM sbomId.
      *
      * @param sbomId SBOM identifier.
+     * @param buildId The build identifier.
      */
-    default public void generate(Long sbomId) {
-        generate(sbomId, null, null);
+    default public void generate(Long sbomId, String buildId) {
+        generate(sbomId, buildId, null, null);
     }
 
     /**
      * Generates the SBOM in CycloneDX format referenced by the SBOM sbomId.
      *
      * @param sbomId SBOM identifier.
+     * @param buildId The build identifier.
      * @param generatorVersion Generator version.
      */
-    default public void generate(Long sbomId, String generatorVersion) {
-        generate(sbomId, generatorVersion, null);
+    default public void generate(Long sbomId, String buildId, String generatorVersion) {
+        generate(sbomId, buildId, generatorVersion, null);
     }
 
     /**
      * Generates the SBOM in CycloneDX format referenced by the SBOM sbomId.
      *
      * @param sbomId SBOM identifier.
+     * @param buildId The build identifier.
      * @param generatorVersion Generator version.
      * @param generatorArgs Generator arguments.
      */
-    public void generate(Long sbomId, String generatorVersion, String generatorArgs);
+    public void generate(Long sbomId, String buildId, String generatorVersion, String generatorArgs);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/rest/rsql/CustomPredicateBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/rsql/CustomPredicateBuilder.java
@@ -45,7 +45,7 @@ public class CustomPredicateBuilder<T> {
             Class<T> entity,
             EntityManager manager,
             BuilderTools misc) {
-        log.info("Creating Predicate for: {}", node);
+        log.debug("Creating Predicate for: {}", node);
 
         if (node instanceof LogicalNode) {
             return createPredicate((LogicalNode) node, root, entity, manager, misc);
@@ -64,13 +64,13 @@ public class CustomPredicateBuilder<T> {
             Class<T> entity,
             EntityManager entityManager,
             BuilderTools misc) {
-        log.info("Creating Predicate for logical node: {}", logical);
+        log.debug("Creating Predicate for logical node: {}", logical);
 
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 
         List<Predicate> predicates = new ArrayList<Predicate>();
 
-        log.info("Creating Predicates from all children nodes.");
+        log.debug("Creating Predicates from all children nodes.");
         for (Node node : logical.getChildren()) {
             predicates.add(createPredicate(node, root, entity, entityManager, misc));
         }
@@ -122,7 +122,7 @@ public class CustomPredicateBuilder<T> {
                 && (Enum.class.isAssignableFrom(propertyPath.getJavaType())
                         || propertyPath instanceof PluralAttributePath)) {
 
-            log.info(
+            log.debug(
                     "Detected type {} for selector {} with custom comparison operator {}. Delegating to custom PredicateBuilderStrategy!",
                     propertyPath.getJavaType(),
                     comparison.getSelector(),

--- a/service/src/main/java/org/jboss/sbomer/rest/rsql/CustomizedJpaPredicateVisitor.java
+++ b/service/src/main/java/org/jboss/sbomer/rest/rsql/CustomizedJpaPredicateVisitor.java
@@ -62,19 +62,19 @@ public class CustomizedJpaPredicateVisitor<T> extends AbstractJpaVisitor<Predica
 
     @Override
     public Predicate visit(AndNode node, EntityManager em) {
-        log.info("visit: AndNode {}", node);
+        log.trace("visit: AndNode {}", node);
         return customizedPredicateBuilder.createPredicate(node, root, entityClass, em, getBuilderTools());
     }
 
     @Override
     public Predicate visit(OrNode node, EntityManager em) {
-        log.info("visit: OrNode {}", node);
+        log.trace("visit: OrNode {}", node);
         return customizedPredicateBuilder.createPredicate(node, root, entityClass, em, getBuilderTools());
     }
 
     @Override
     public Predicate visit(ComparisonNode node, EntityManager em) {
-        log.info("visit: ComparisonNode {}", node);
+        log.trace("visit: ComparisonNode {}", node);
         return customizedPredicateBuilder.createPredicate(node, root, entityClass, em, getBuilderTools());
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/GenerationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/GenerationService.java
@@ -23,15 +23,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.persistence.NoResultException;
 import javax.transaction.Transactional;
 
-import org.jboss.pnc.rest.api.parameters.PaginationParameters;
 import org.jboss.sbomer.config.GenerationConfig;
 import org.jboss.sbomer.core.enums.GeneratorImplementation;
 import org.jboss.sbomer.core.enums.SbomStatus;
 import org.jboss.sbomer.core.enums.SbomType;
 import org.jboss.sbomer.core.errors.ApplicationException;
+import org.jboss.sbomer.core.utils.MDCUtils;
 import org.jboss.sbomer.generator.Generator.GeneratorLiteral;
 import org.jboss.sbomer.generator.SbomGenerator;
 import org.jboss.sbomer.model.Sbom;
@@ -78,56 +77,66 @@ public class GenerationService {
             GeneratorImplementation generator,
             String generatorVersion,
             String generatorArgs) {
-        if (!generationConfig.isEnabled()) {
-            throw new ApplicationException(
-                    "Generation is disabled in the configuration, skipping generation for PNC Build '{}'",
-                    buildId);
-        }
 
-        // Retrieve any base sbom for this build
-        String rsqlQuery = "buildId=eq=" + buildId + ";generator=isnull=false;processors=isnull=true";
-        List<Sbom> sboms = sbomRepository.searchByQuery(0, 1, rsqlQuery);
-        if (sboms.size() > 0) {
-            Sbom sbom = sboms.get(0);
-            if (sbom.getStatus() == SbomStatus.READY) {
-                if (sbom.getGenerator() == generator) {
-                    log.info(
-                            "An Sbom has been already generated for build: {} with generator: {}",
-                            buildId,
-                            sbom.getGenerator());
-                } else {
-                    log.info(
-                            "An Sbom has been already generated for build: {} but with a different generator: {}",
-                            buildId,
-                            sbom.getGenerator());
-                }
-            } else if (sbom.getStatus() == SbomStatus.IN_PROGRESS || sbom.getStatus() == SbomStatus.NEW) {
-                log.info(
-                        "An Sbom is already being generated for build: {} with generator: {}",
-                        buildId,
-                        sbom.getGenerator());
-            } else if (sbom.getStatus() == SbomStatus.FAILED) {
-                log.info(
-                        "An Sbom generation was already attempted for build: {} with generator: {} but FAILED with error: {}",
-                        buildId,
-                        sbom.getGenerator(),
-                        sbom.getStatusMessage());
+        try {
+
+            MDCUtils.addBuildContext(buildId);
+
+            if (!generationConfig.isEnabled()) {
+                throw new ApplicationException(
+                        "Generation is disabled in the configuration, skipping generation for PNC Build '{}'",
+                        buildId);
             }
+
+            // Retrieve any base sbom for this build
+            String rsqlQuery = "buildId=eq=" + buildId + ";generator=isnull=false;processors=isnull=true";
+            List<Sbom> sboms = sbomRepository.searchByQuery(0, 1, rsqlQuery);
+            if (sboms.size() > 0) {
+                Sbom sbom = sboms.get(0);
+                if (sbom.getStatus() == SbomStatus.READY) {
+                    if (sbom.getGenerator() == generator) {
+                        log.info(
+                                "An Sbom has been already generated for build: {} with generator: {}",
+                                buildId,
+                                sbom.getGenerator());
+                    } else {
+                        log.info(
+                                "An Sbom has been already generated for build: {} but with a different generator: {}",
+                                buildId,
+                                sbom.getGenerator());
+                    }
+                } else if (sbom.getStatus() == SbomStatus.IN_PROGRESS || sbom.getStatus() == SbomStatus.NEW) {
+                    log.info(
+                            "An Sbom is already being generated for build: {} with generator: {}",
+                            buildId,
+                            sbom.getGenerator());
+                } else if (sbom.getStatus() == SbomStatus.FAILED) {
+                    log.info(
+                            "An Sbom generation was already attempted for build: {} with generator: {} but FAILED with error: {}",
+                            buildId,
+                            sbom.getGenerator(),
+                            sbom.getStatusMessage());
+                }
+                return sbom;
+            }
+
+            Sbom sbom = new Sbom();
+            sbom.setType(SbomType.BUILD_TIME); // TODO Is it always the case?
+            sbom.setBuildId(buildId);
+            sbom.setGenerator(generator);
+
+            // Store it in database
+            sbom = sbomService.save(sbom);
+
+            // Schedule the generation
+            generators.select(GeneratorLiteral.of(generator))
+                    .get()
+                    .generate(sbom.getId(), buildId, generatorVersion, generatorArgs);
+
             return sbom;
+        } finally {
+            MDCUtils.removeBuildContext();
         }
-
-        Sbom sbom = new Sbom();
-        sbom.setType(SbomType.BUILD_TIME); // TODO Is it always the case?
-        sbom.setBuildId(buildId);
-        sbom.setGenerator(generator);
-
-        // Store it in database
-        sbom = sbomService.save(sbom);
-
-        // Schedule the generation
-        generators.select(GeneratorLiteral.of(generator)).get().generate(sbom.getId(), generatorVersion, generatorArgs);
-
-        return sbom;
     }
 
     /**

--- a/service/src/main/java/org/jboss/sbomer/tekton/generator/AbstractGeneratorTektonTaskRunner.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/generator/AbstractGeneratorTektonTaskRunner.java
@@ -44,6 +44,7 @@ public abstract class AbstractGeneratorTektonTaskRunner extends AbstractTektonTa
      *
      * @param tektonTaskName The name of the Tekton Task to run.
      * @param sbomId The SBOM identifier to run the Task for.
+     * @param buildId The build identifier to run the Task for.
      * @param generator The {@link GeneratorImplementation}
      * @param generatorVersion Version of the generator, can be {@code null} if default version should be used, see
      *        {@link GenerationConfig}.
@@ -54,6 +55,7 @@ public abstract class AbstractGeneratorTektonTaskRunner extends AbstractTektonTa
     protected TaskRun runTektonTask(
             String tektonTaskName,
             Long sbomId,
+            String buildId,
             GeneratorImplementation generator,
             String generatorVersion,
             String generatorArgs) {
@@ -65,6 +67,6 @@ public abstract class AbstractGeneratorTektonTaskRunner extends AbstractTektonTa
                 .add("additional-args", generatorConfig.args(generatorArgs))
                 .build();
 
-        return runTektonTask(tektonTaskName, sbomId, config);
+        return runTektonTask(tektonTaskName, sbomId, buildId, config);
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonCycloneDXSbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonCycloneDXSbomGenerator.java
@@ -34,7 +34,7 @@ import org.jboss.sbomer.generator.SbomGenerator;
 public class TektonCycloneDXSbomGenerator extends AbstractGeneratorTektonTaskRunner implements SbomGenerator {
 
     @Override
-    public void generate(Long sbomId, String generatorVersion, String generatorArgs) {
-        runTektonTask("sbomer-generate-cyclonedx", sbomId, CYCLONEDX, generatorVersion, generatorArgs);
+    public void generate(Long sbomId, String buildId, String generatorVersion, String generatorArgs) {
+        runTektonTask("sbomer-generate-cyclonedx", sbomId, buildId, CYCLONEDX, generatorVersion, generatorArgs);
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonDominoSbomGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/tekton/generator/TektonDominoSbomGenerator.java
@@ -34,8 +34,8 @@ import org.jboss.sbomer.generator.SbomGenerator;
 public class TektonDominoSbomGenerator extends AbstractGeneratorTektonTaskRunner implements SbomGenerator {
 
     @Override
-    public void generate(Long sbomId, String version, String args) {
-        runTektonTask("sbomer-generate-domino", sbomId, DOMINO, version, args);
+    public void generate(Long sbomId, String buildId, String version, String args) {
+        runTektonTask("sbomer-generate-domino", sbomId, buildId, DOMINO, version, args);
     }
 
 }

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -34,6 +34,10 @@ quarkus:
     category:
       "org.jboss.sbomer":
         level: DEBUG
+      "com.github.tennaito.rsql":
+        level: WARN
+    console:
+      format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
 
 sbomer:
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha1/"

--- a/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonCycloneDxSbomGenerator.java
+++ b/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonCycloneDxSbomGenerator.java
@@ -77,7 +77,7 @@ public class TestTektonCycloneDxSbomGenerator {
         Mockito.when(v1beta1.taskRuns()).thenReturn(taskRuns);
         Mockito.when(tektonClient.v1beta1()).thenReturn(v1beta1);
 
-        generator.generate(12345l);
+        generator.generate(12345l, "AABBCCDD");
 
         Mockito.verify(tektonClient.v1beta1().taskRuns(), Mockito.times(1)).resource(argThat(taskRun -> {
             assertNotNull(taskRun);
@@ -85,6 +85,7 @@ public class TestTektonCycloneDxSbomGenerator {
             assertEquals("sbomer-generate-cyclonedx", taskRun.getSpec().getTaskRef().getName());
             assertEquals("sbomer-sa", taskRun.getSpec().getServiceAccountName());
             assertEquals("12345", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
+
             try {
                 JsonNode config = mapper.readTree(taskRun.getSpec().getParams().get(1).getValue().getStringVal());
                 String version = config.get("version").asText().toString();
@@ -97,6 +98,7 @@ public class TestTektonCycloneDxSbomGenerator {
 
             assertEquals("sbomer", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_NAME_APP_PART_OF));
             assertEquals("12345", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_SBOM_ID));
+            assertEquals("AABBCCDD", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_SBOM_BUILD_ID));
             assertEquals(1, taskRun.getSpec().getWorkspaces().size());
             assertEquals("data", taskRun.getSpec().getWorkspaces().get(0).getName());
             return true;

--- a/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonDominoSbomGenerator.java
+++ b/service/src/test/java/org/jboss/sbomer/test/generator/TestTektonDominoSbomGenerator.java
@@ -78,7 +78,7 @@ public class TestTektonDominoSbomGenerator {
         Mockito.when(v1beta1.taskRuns()).thenReturn(taskRuns);
         Mockito.when(tektonClient.v1beta1()).thenReturn(v1beta1);
 
-        generator.generate(123456l);
+        generator.generate(123456l, "AABBCCDD");
 
         Mockito.verify(tektonClient.v1beta1().taskRuns(), Mockito.times(1)).resource(argThat(taskRun -> {
             assertNotNull(taskRun);
@@ -86,6 +86,7 @@ public class TestTektonDominoSbomGenerator {
             assertEquals("sbomer-generate-domino", taskRun.getSpec().getTaskRef().getName());
             assertEquals("sbomer-sa", taskRun.getSpec().getServiceAccountName());
             assertEquals("123456", taskRun.getSpec().getParams().get(0).getValue().getStringVal());
+
             try {
                 JsonNode config = mapper.readTree(taskRun.getSpec().getParams().get(1).getValue().getStringVal());
                 String version = config.get("version").asText().toString();
@@ -98,6 +99,7 @@ public class TestTektonDominoSbomGenerator {
 
             assertEquals("sbomer", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_NAME_APP_PART_OF));
             assertEquals("123456", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_SBOM_ID));
+            assertEquals("AABBCCDD", taskRun.getMetadata().getLabels().get(Constants.TEKTON_LABEL_SBOM_BUILD_ID));
             assertEquals(1, taskRun.getSpec().getWorkspaces().size());
             assertEquals("data", taskRun.getSpec().getWorkspaces().get(0).getName());
             return true;

--- a/service/src/test/java/org/jboss/sbomer/test/k8s/TaskRunStatusHandlerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/test/k8s/TaskRunStatusHandlerTest.java
@@ -91,7 +91,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "123456"))
+                                "123456",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "AABBCCDD"))
                 .endMetadata()
                 .build();
         assertFalse(statusHandler.isUpdateable(taskRun));
@@ -109,7 +111,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "123456"))
+                                "123456",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "AABBCCDD"))
                 .endMetadata()
                 .withStatus(new TaskRunStatusBuilder().build())
                 .build();
@@ -128,7 +132,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "123456"))
+                                "123456",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "AABBCCDD"))
                 .endMetadata()
                 .withStatus(new TaskRunStatusBuilder().withConditions(Collections.emptyList()).build())
                 .build();
@@ -147,7 +153,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "123456"))
+                                "123456",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "AABBCCDD"))
                 .endMetadata()
                 .withStatus(
                         new TaskRunStatusBuilder().withConditions(new ConditionBuilder().withStatus("True").build())
@@ -287,7 +295,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "13131313"))
+                                "13131313",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "EEFFGGHH"))
                 .endMetadata()
                 .withStatus(
                         new TaskRunStatusBuilder().withConditions(new ConditionBuilder().withStatus("Unknown").build())
@@ -347,7 +357,9 @@ public class TaskRunStatusHandlerTest {
                                 Constants.TEKTON_LABEL_NAME_APP_PART_OF,
                                 Constants.TEKTON_LABEL_VALUE_APP_PART_OF,
                                 Constants.TEKTON_LABEL_SBOM_ID,
-                                "17171717"))
+                                "17171717",
+                                Constants.TEKTON_LABEL_SBOM_BUILD_ID,
+                                "JJKKLLMM"))
                 .endMetadata()
                 .withStatus(
                         new TaskRunStatusBuilder().withConditions(new ConditionBuilder().withStatus("Unknown").build())


### PR DESCRIPTION
1. Lower log level of RSQL operations
2. Add MDCUtil class and add required header to the generated REST client (the header name is "fixed" because it is automatically handled by existing utilities)
3. Add required dependencies for JSON logging and MDC utilities
4. Handle the addition and removal of MDC in the code
5. Add Tekton Metadata label to keep the buildId information with the ability to add it to the MDC

@goldmann : 

- Because of 2, I know that the signature of the PNC Client is not that clean anymore, but it is the only way I found to add headers with the generated REST client
- Because of 3, log is not beautiful anymore but the json formatting is required on all our services to be ingested properly by our internal logging systems
- Because of 5, I had to alter the method signature of the AbstractTektonTaskRunner class and implementations. If you prefer to keep the same method signature, I can keep it unchanged but fetch the `buildId` information with a call to the DB.