### PR TITLE
Inside the initContainer export all the secrets to a file and source the file when running the main container

### DIFF
--- a/images/sbomer-service/Containerfile
+++ b/images/sbomer-service/Containerfile
@@ -86,8 +86,14 @@ COPY --chown=185 service/target/quarkus-app/*.jar /deployments/
 COPY --chown=185 service/target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 service/target/quarkus-app/quarkus/ /deployments/quarkus/
 
+# Source the file containing additional environment variables, if it exists
+RUN if [ -f /mnt/secrets/env.sh ]; then \
+      source /mnt/secrets/env.sh; \
+    fi
+
 EXPOSE 8080
 USER 185
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
 

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -47,13 +47,61 @@ patches:
       name: sbomer
     patch: |-
       - op: add
+        path: /spec/template/spec/initContainers/-
+        value:
+          image: quay.io/rh-newcastle/pnc-vault-secrets:1.0.0
+          name: get-vault-secrets
+          resources:
+            limits:
+              cpu: 0.2
+              memory: 200Mi
+            requests:
+              cpu: 0.2
+              memory: 200Mi
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - cd /mnt/secrets;
+              pnc-vault-secrets dump $(SBOMER_SECRET_NAME)-$(APP_ENV);
+              echo 'export CONSUMER_TOPIC=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/consumer.topic)' >> /mnt/secrets/env.sh;
+              echo 'export PRODUCER_TOPIC=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/producer.topic)' >> /mnt/secrets/env.sh;
+              echo 'export UMB_BROKER_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/qpid-jms.url)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_OIDC_AUTH_SERVER_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/auth-server-url.txt)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_USERNAME=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.user)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_PASSWORD=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.password)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_JDBC_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.connection)' >> /mnt/secrets/env.sh;
+              echo 'export KEYSTORE_PASSWORD=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/pnc-sbomer.password)' >> /mnt/secrets/env.sh;
+          env:
+            - name: VAULT_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-address
+            - name: VAULT_APP_ROLE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-app-role-id
+            - name: VAULT_APP_SECRET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-app-secret-id
+            - name: SBOMER_SECRET_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['sbomer-secret']
+            - name: APP_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['environment']
+          volumeMounts:
+            - name: secrets-workdir
+              mountPath: /mnt/secrets
+      - op: add
         path: /spec/template/metadata/annotations/environment
         value: prod
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: KEYSTORE_PASSWORD
-          value: '$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/pnc-sbomer.password)'
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -34,13 +34,61 @@ patches:
       name: sbomer
     patch: |-
       - op: add
+        path: /spec/template/spec/initContainers/-
+        value:
+          image: quay.io/rh-newcastle/pnc-vault-secrets:1.0.0
+          name: get-vault-secrets
+          resources:
+            limits:
+              cpu: 0.2
+              memory: 200Mi
+            requests:
+              cpu: 0.2
+              memory: 200Mi
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - cd /mnt/secrets;
+              pnc-vault-secrets dump $(SBOMER_SECRET_NAME)-$(APP_ENV);
+              echo 'export CONSUMER_TOPIC=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/consumer.topic)' >> /mnt/secrets/env.sh;
+              echo 'export PRODUCER_TOPIC=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/producer.topic)' >> /mnt/secrets/env.sh;
+              echo 'export UMB_BROKER_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/qpid-jms.url)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_OIDC_AUTH_SERVER_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/auth-server-url.txt)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_USERNAME=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.user)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_PASSWORD=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.password)' >> /mnt/secrets/env.sh;
+              echo 'export QUARKUS_DATASOURCE_JDBC_URL=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.connection)' >> /mnt/secrets/env.sh;
+              echo 'export KEYSTORE_PASSWORD=$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/nonprod-pnc-sbomer.password)' >> /mnt/secrets/env.sh;
+          env:
+            - name: VAULT_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-address
+            - name: VAULT_APP_ROLE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-app-role-id
+            - name: VAULT_APP_SECRET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vault-connection-info
+                  key: vault-app-secret-id
+            - name: SBOMER_SECRET_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['sbomer-secret']
+            - name: APP_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['environment']
+          volumeMounts:
+            - name: secrets-workdir
+              mountPath: /mnt/secrets
+      - op: add
         path: /spec/template/metadata/annotations/environment
         value: stage
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: KEYSTORE_PASSWORD
-          value: '$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/nonprod-pnc-sbomer.password)'
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/k8s/overlays/targets/ocp/kustomization.yaml
+++ b/k8s/overlays/targets/ocp/kustomization.yaml
@@ -55,51 +55,6 @@ patches:
       name: sbomer
     patch: |-
       - op: add
-        path: /spec/template/spec/initContainers/-
-        value:
-          image: quay.io/rh-newcastle/pnc-vault-secrets:1.0.0
-          name: get-vault-secrets
-          resources:
-            limits:
-              cpu: 0.2
-              memory: 200Mi
-            requests:
-              cpu: 0.2
-              memory: 200Mi
-          command:
-            - /bin/bash
-          args:
-            - -c
-            - cd /mnt/secrets;
-              pnc-vault-secrets dump $(SBOMER_SECRET_NAME)-$(APP_ENV);
-          env:
-            - name: VAULT_ADDR
-              valueFrom:
-                secretKeyRef:
-                  name: vault-connection-info
-                  key: vault-address
-            - name: VAULT_APP_ROLE_ID
-              valueFrom:
-                secretKeyRef:
-                  name: vault-connection-info
-                  key: vault-app-role-id
-            - name: VAULT_APP_SECRET_ID
-              valueFrom:
-                secretKeyRef:
-                  name: vault-connection-info
-                  key: vault-app-secret-id
-            - name: SBOMER_SECRET_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.annotations['sbomer-secret']
-            - name: APP_ENV
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.annotations['environment']
-          volumeMounts:
-            - name: secrets-workdir
-              mountPath: /mnt/secrets
-      - op: add
         path: /spec/template/spec/containers/0/volumeMounts/-
         value:
           name: secrets-workdir
@@ -181,25 +136,4 @@ patches:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['environment']
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: CONSUMER_TOPIC
-          value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/consumer.topic)"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: PRODUCER_TOPIC
-          value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/producer.topic)"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: UMB_BROKER_URL
-          value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/qpid-jms.url)"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: QUARKUS_OIDC_AUTH_SERVER_URL
-          value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/auth-server-url.txt)"
-
 

--- a/k8s/overlays/targets/ocp/patches/sbomer-database-connection.yaml
+++ b/k8s/overlays/targets/ocp/patches/sbomer-database-connection.yaml
@@ -27,10 +27,8 @@ spec:
         - name: sbomer
           env:
             - name: QUARKUS_DATASOURCE_USERNAME
-              value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.user)"
-              valueFrom: null
+              $patch: delete
             - name: QUARKUS_DATASOURCE_PASSWORD
-              value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.password)"
-              valueFrom: null
+              $patch: delete
             - name: QUARKUS_DATASOURCE_JDBC_URL
-              value: "$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.connection)"
+              $patch: delete


### PR DESCRIPTION
Ok so the thing here is that we are not using anymore OCP secrets but we are fetching them from an external system.
Inside an initContainer, we import all the secrets from the external system into different files, inside a shared mounted volume.
We then need to read the content of the files, and use them as env variables inside the main container.
I created an utility file inside the initContainer script, which contains the env variables definitions. I then source this utility file from the main container (if if exists), at the startup. 