### PR TITLE
Add annotations to resolve secret name env var

### DIFF
--- a/images/sbomer-service/run.sh
+++ b/images/sbomer-service/run.sh
@@ -28,4 +28,7 @@ if [ -f "/mnt/secrets/env.sh" ]; then
     source /mnt/secrets/env.sh
 fi
 
+KEYSTORE_PASSWORD="$(cat /mnt/secrets/$SBOMER_SECRET_NAME-$APP_ENV/$APP_ENV-pnc-sbomer.password)"
+export JAVA_TOOL_OPTIONS="-Djavax.net.ssl.keyStore=/mnt/secrets/$SBOMER_SECRET_NAME-$APP_ENV/$APP_ENV-pnc-sbomer.pkcs12 -Djavax.net.ssl.keyStorePassword=$KEYSTORE_PASSWORD -Djavax.net.ssl.keyStoreType=PKCS12 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap-dump.hprof -XX:OnOutOfMemoryError='python /mnt/thread-heap-dump-script/thread_heap_dump_email.py'"
+
 exec /usr/local/s2i/run

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -105,10 +105,8 @@ patches:
         path: /spec/template/metadata/annotations/environment
         value: prod
       - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: JAVA_TOOL_OPTIONS
-          value: "-Djavax.net.ssl.keyStore=/mnt/secrets/sbomer-secrets-prod/pnc-sbomer.pkcs12 -Djavax.net.ssl.keyStorePassword=$(cat /mnt/secrets/sbomer-secrets-prod/pnc-sbomer.password) -Djavax.net.ssl.keyStoreType=PKCS12 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap-dump.hprof -XX:OnOutOfMemoryError='python /mnt/thread-heap-dump-script/thread_heap_dump_email.py'"
+        path: /spec/template/metadata/annotations/sbomer-secret
+        value: sbomer-secrets
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -92,10 +92,8 @@ patches:
         path: /spec/template/metadata/annotations/environment
         value: stage
       - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: JAVA_TOOL_OPTIONS
-          value: "-Djavax.net.ssl.keyStore=/mnt/secrets/sbomer-secrets-stage/nonprod-pnc-sbomer.pkcs12 -Djavax.net.ssl.keyStorePassword=$(cat /mnt/secrets/sbomer-secrets-stage/pnc-sbomer.password) -Djavax.net.ssl.keyStoreType=PKCS12 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap-dump.hprof -XX:OnOutOfMemoryError='python /mnt/thread-heap-dump-script/thread_heap_dump_email.py'"
+        path: /spec/template/metadata/annotations/sbomer-secret
+        value: sbomer-secrets
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:


### PR DESCRIPTION
I updated secrets names in Hashicorp Vault & added env vars to match new naming. Added secret-name annotation to `kustomization.yaml` as well.