### PR TITLE
feat: add more tests and label adjustments on generation request

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -159,7 +159,7 @@ public class GenerationRequest extends ConfigMap {
         }
 
         getData().put(KEY_STATUS, status.name());
-        getMetadata().getLabels().put(Labels.LABEL_PHASE, status.name());
+        getMetadata().getLabels().put(Labels.LABEL_STATUS, status.name());
     }
 
     @JsonIgnore

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
@@ -165,6 +165,18 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
             GenerationResult result,
             String reason) {
 
+        if (generationRequest.getStatus() != null) {
+            String label = switch (generationRequest.getStatus()) {
+                case INITIALIZING -> SbomGenerationPhase.INIT.name().toLowerCase();
+                case GENERATING -> SbomGenerationPhase.GENERATE.name().toLowerCase();
+                default -> null;
+            };
+
+            if (label != null) {
+                generationRequest.getMetadata().getLabels().put(Labels.LABEL_PHASE, label);
+            }
+        }
+
         generationRequest.setStatus(status);
         generationRequest.setResult(result);
         generationRequest.setReason(reason);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/Labels.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/Labels.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
  * Labels used by Tekton resources within the SBOM feature.
  */
 public class Labels {
+    public static final String LABEL_STATUS = "sbomer.jboss.org/status";
     public static final String LABEL_PHASE = "sbomer.jboss.org/phase";
     public static final String LABEL_BUILD_ID = "sbomer.jboss.org/build-id";
     public static final String LABEL_GENERATION_REQUEST_ID = "sbomer.jboss.org/generation-request-id";


### PR DESCRIPTION
This fixes the sbomer.jboss.org/phase setting on the GenerationRequest as well adds new label sbomer.jboss.org/phase.

Previously the status was set to phase, but in order to unify labels with depednent resources this was adjusted to align with them.

And more tests!