### PR TITLE
feat: support for cleaning up resources when generation is finished

### DIFF
--- a/cli/src/test/java/org/jboss/sbomer/cli/test/feature/sbom/command/CycloneDXPluginMavenGenerateCommandTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/feature/sbom/command/CycloneDXPluginMavenGenerateCommandTest.java
@@ -34,6 +34,7 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
 @TestProfile(CustomPncServiceProfile.class)
 public class CycloneDXPluginMavenGenerateCommandTest {
     public static class CustomPncServiceProfile implements QuarkusTestProfile {
+
         @Override
         public Set<Class<?>> getEnabledAlternatives() {
             return Set.of(AlternativePncService.class);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/SbomConfig.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/SbomConfig.java
@@ -1,0 +1,35 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.config;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * @author Marek Goldmann
+ */
+@ApplicationScoped
+@ConfigMapping(prefix = "sbomer.sbom")
+public interface SbomConfig {
+    String sbomDir();
+
+    @WithDefault("true")
+    boolean cleanup();
+}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -78,26 +78,12 @@ sbomer:
 
   sbom:
     sbom-dir: "${SBOMER_SBOM_DIR}"
+    # Defines whether resources related to a generation should be automatically removed from the system
+    # This includes removing the generation request kubernetes resource as well as any leftovers on the filesystem
+    # located in the sbomer.sbom-dir directory.
+    cleanup: true
 
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha1/"
-  # generation:
-  #   enabled: true
-  #   default-generator: maven-cyclonedx
-  #   generators:
-  #     maven-domino:
-  #       default-version: "0.0.90"
-  #       default-args: "--include-non-managed --warn-on-missing-scm"
-  #     maven-cyclonedx:
-  #       default-version: "2.7.9"
-  #       default-args: "--batch-mode"
-
-  # processing:
-  #   enabled: true
-  #   auto-process: true
-  #   # List of default processors that will be run on every generated SBOM
-  #   default-processors:
-  #     - name: "default"
-  #     - name: "redhat-product"
 
 "%dev":
   quarkus:
@@ -139,6 +125,8 @@ sbomer:
           enabled: false
         producer:
           enabled: false
+    sbom:
+      cleanup: false
 
 "%test":
   quarkus:


### PR DESCRIPTION
Cleanup is controlled in application (service) settings. When enabled the Kubernetes resource as well as all dependent resources are removed from the cluster. Additionally any leftovers on the volume are cleaned too.

Removal is done no matter if the status is FINISED or FAILED. Resources are synced with the DB earlier, plus we have logs available in a separate system so we can debug everything at any time.

https://issues.redhat.com/browse/NCL-7964