### PR TITLE
Remove 'from-maven' domino subcommand

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenDominoGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenDominoGenerateCommand.java
@@ -92,7 +92,6 @@ public class MavenDominoGenerateCommand extends AbstractMavenGenerateCommand {
                 "-Dquarkus.args=\"\"",
                 "-jar",
                 dominoPath.toAbsolutePath().toString(),
-                "from-maven",
                 "report",
                 String.format("--project-dir=%s", parent.getWorkdir().toAbsolutePath().toString()),
                 String.format("--output-file=%s", BOM_FILE_NAME),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,7 +136,7 @@ Below you can see the static and default parameters set for the Domino generator
 **Static**
 
 ```
-java -jar domino.jar from-maven report --project-dir=[DIR] --output-file=[OUTPUT_DIR]/bom.json --manifest -s [PATH_TO_SETTINGS_XML_FILE]
+java -jar domino.jar report --project-dir=[DIR] --output-file=[OUTPUT_DIR]/bom.json --manifest -s [PATH_TO_SETTINGS_XML_FILE]
 ```
 
 **Defaults**
@@ -147,7 +147,7 @@ java -jar domino.jar from-maven report --project-dir=[DIR] --output-file=[OUTPUT
 
 **Custom arguments**
 
-Run the `java -jar domino.jar from-maven report --help` command to get a list of all possible options for Domino.
+Run the `java -jar domino.jar report --help` command to get a list of all possible options for Domino.
 
 #### CycloneDX Maven Plugin generator
 


### PR DESCRIPTION
This subcommand has been deprecated a long time ago. Domino figures out whether it's pointed at a Maven or Gradle project and proceeds with the dependency analysis accordingly.