### PR TITLE
fix(cli): pass the path to settings.xml file

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -99,17 +99,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.github.hakky54</groupId>
-      <artifactId>logcaptor</artifactId>
-      <version>2.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>2.0.7</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>3.0.0-beta-7</version>
@@ -123,14 +112,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <classpathDependencyExcludes>
-            <classpathDependencyExclude>org.jboss.slf4j:slf4j-jboss-logmanager</classpathDependencyExclude>
-          </classpathDependencyExcludes>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenDominoGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenDominoGenerateCommand.java
@@ -54,6 +54,7 @@ public class MavenDominoGenerateCommand extends AbstractMavenGenerateCommand {
         MavenDominoGenerator generator = MavenDominoGenerator.builder()
                 .withDominoDir(dominoDir)
                 .withDominoVersion(toolVersion())
+                .withSettingsXmlPath(settingsXmlPath)
                 .build();
 
         log.info("Starting SBOM generation using Domino");

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/feature/sbom/generate/MavenDominoGeneratorTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/feature/sbom/generate/MavenDominoGeneratorTest.java
@@ -27,10 +27,7 @@ import java.util.Arrays;
 import org.jboss.sbomer.cli.feature.sbom.generate.MavenDominoGenerator;
 import org.jboss.sbomer.cli.feature.sbom.generate.ProcessRunner;
 import org.jboss.sbomer.core.errors.ValidationException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
@@ -38,28 +35,13 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-import nl.altindag.log.LogCaptor;
 
 public class MavenDominoGeneratorTest {
-    private static LogCaptor logCaptor;
+
 
     final Path dominoDir = Path.of("/path/to/domino/dir");
     final Path workDir = Path.of("work/dir");
 
-    @BeforeAll
-    public static void setup() {
-        logCaptor = LogCaptor.forClass(MavenDominoGenerator.class);
-    }
-
-    @AfterEach
-    public void afterEach() {
-        logCaptor.clearLogs();
-    }
-
-    @AfterAll
-    public static void tearDown() {
-        logCaptor.close();
-    }
 
     @Test
     void testFailedWhenNoDirProvided() {

--- a/pom.xml
+++ b/pom.xml
@@ -106,14 +106,14 @@
                 <artifactId>core</artifactId>
                 <version>${version.org.jboss.pnc.build.finder}</version>
                 <exclusions>
-                  <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>org.fusesource.jansi</groupId>
-                    <artifactId>jansi</artifactId>
-                  </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.fusesource.jansi</groupId>
+                        <artifactId>jansi</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Additionally remove the logcaptor dependency for now, because it is impossible to run the tests in Maven and vscode due to the multiple SLF4J providers issue.