### PR TITLE
feat(umb): add generation request information to messages

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EStageBase.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EStageBase.java
@@ -24,4 +24,9 @@ public class E2EStageBase extends E2EBase {
         return "sbomerStageUri";
     }
 
+    @Override
+    public String datagrepperUriPropertyName() {
+        return "datagrepperStageUri";
+    }
+
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Property;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
 import org.jboss.sbomer.service.feature.sbom.config.features.ProductConfig;
 import org.jboss.sbomer.service.feature.sbom.config.features.UmbConfig;
@@ -44,6 +43,7 @@ import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Build.B
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.GenerationFinishedMessageBody;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Sbom.BomFormat;
+import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Sbom.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.service.SbomRepository;
 
 import lombok.extern.slf4j.Slf4j;
@@ -148,6 +148,7 @@ public class NotificationService {
         Sbom sbomPayload = Sbom.builder()
                 .id(String.valueOf(sbom.getId()))
                 .link(sbomerConfig.apiUrl() + "sboms/" + sbom.getId())
+                .generationRequest(GenerationRequest.builder().id(sbom.getGenerationRequest().getId()).build())
                 .bom(bomPayload)
                 .build();
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/UmbMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/UmbMessageProducer.java
@@ -47,6 +47,7 @@ public class UmbMessageProducer implements MessageProducer {
     public static final String MESSAGE_HEADER_PURL_KEY = "purl";
     public static final String MESSAGE_HEADER_BUILD_ID_KEY = "pnc_build_id";
     public static final String MESSAGE_HEADER_SBOM_ID_KEY = "sbom_id";
+    public static final String MESSAGE_HEADER_GENERATION_REQUEST_ID_KEY = "generation_request_id";
     public static final String MESSAGE_HEADER_PRODUCER_KEY = "producer";
     public static final String MESSAGE_HEADER_TYPE_KEY = "type";
 
@@ -96,6 +97,7 @@ public class UmbMessageProducer implements MessageProducer {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(MESSAGE_HEADER_PURL_KEY, message.getPurl());
         headers.put(MESSAGE_HEADER_BUILD_ID_KEY, message.getBuild().getId());
+        headers.put(MESSAGE_HEADER_GENERATION_REQUEST_ID_KEY, message.getSbom().getGenerationRequest().getId());
         headers.put(MESSAGE_HEADER_SBOM_ID_KEY, message.getSbom().getId());
         headers.put(MESSAGE_HEADER_PRODUCER_KEY, "PNC SBOMer");
         headers.put(MESSAGE_HEADER_TYPE_KEY, "GenerationFinishedMessage");

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/model/Sbom.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/model/Sbom.java
@@ -40,7 +40,14 @@ public class Sbom {
         String link;
     }
 
+    @Data
+    @Builder
+    public static class GenerationRequest {
+        String id;
+    }
+
     String id;
     String link;
     Bom bom;
+    GenerationRequest generationRequest;
 }

--- a/service/src/main/resources/schemas/message-success-schema.json
+++ b/service/src/main/resources/schemas/message-success-schema.json
@@ -67,6 +67,16 @@
           "description": "SBOM link to the SBOMer REST API",
           "type": "string"
         },
+        "generationRequest": {
+          "type": "object",
+          "description": "SBOM generation request",
+          "properties": {
+            "id": {
+              "description": "SBOM generation request identifier",
+              "type": "string"
+            }
+          }
+        },
         "bom": {
           "type": "object",
           "description": "BOM information",


### PR DESCRIPTION
This adds `generation_request_id` header to the UMB complete message notification, as well as to the body:

```json
"sbom": {
  "generationRequest": {
    "id": "AABBCC"
  }
}
```