### PR TITLE
chore: version unification

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>org.jboss.pnc.build.finder</groupId>
       <artifactId>core</artifactId>
+      <version>${version.build-finder}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.lombok>1.18.28</version.lombok>
         <version.pnc-rest>2.5.1</version.pnc-rest>
         <version.pnc-common>2.4.0-alpha</version.pnc-common>
-        <version.quarkus-jgit>3.0.2</version.quarkus-jgit>
+        <version.quarkus-jgit>3.0.3</version.quarkus-jgit>
         <version.tekton-client>1.0.1</version.tekton-client>
         <version.rsql-parser>2.1.0</version.rsql-parser>
         <version.rsql-jpa>v2023.35.5</version.rsql-jpa>

--- a/pom.xml
+++ b/pom.xml
@@ -46,13 +46,19 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.3.1</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <failsafe-plugin.version>3.1.2</failsafe-plugin.version>
+
+        <version.surefire-plugin>3.1.2</version.surefire-plugin>
+        <version.failsafe-plugin>3.1.2</version.failsafe-plugin>
+
+        <!--
+        Keep "version.quarkus-platform" in sync with the Quarkus Operator SDK extension Quarkus version:
+        https://github.com/quarkiverse/quarkus-operator-sdk/blob/main/pom.xml#L15 for the Quarkus
+        Operator SDK extension version defined below ("version.quarkus-operator-sdk").
+        -->
+        <version.quarkus-platform>3.2.4.Final</version.quarkus-platform>
+        <version.quarkus-operator-sdk>6.3.0</version.quarkus-operator-sdk>
+
         <version.cyclonedx>7.3.2</version.cyclonedx>
-        <version.hibernatetypes>2.0.0</version.hibernatetypes>
         <version.lombok>1.18.28</version.lombok>
         <version.pnc-rest>2.5.1</version.pnc-rest>
         <version.pnc-common>2.4.0-alpha</version.pnc-common>
@@ -61,11 +67,8 @@
         <version.rsql-parser>2.1.0</version.rsql-parser>
         <version.rsql-jpa>v2023.35.5</version.rsql-jpa>
         <version.commons-cli>1.5.0</version.commons-cli>
-        <quarkus.qpid.jms.group-id>${quarkus.platform.group-id}</quarkus.qpid.jms.group-id>
-        <quarkus.qpid.jms.version>${quarkus.platform.version}</quarkus.qpid.jms.version>
-        <quarkus-test-artemis-version>3.1.0</quarkus-test-artemis-version>
-        <quarkus-operator-sdk-version>6.3.0</quarkus-operator-sdk-version>
-        <version.org.jboss.pnc.build.finder>2.2.0</version.org.jboss.pnc.build.finder>
+        <version.quarkus-test-artemis>3.1.0</version.quarkus-test-artemis>
+        <version.build-finder>2.2.0</version.build-finder>
     </properties>
 
     <dependencyManagement>
@@ -73,40 +76,16 @@
             <dependency>
                 <groupId>io.quarkiverse.operatorsdk</groupId>
                 <artifactId>quarkus-operator-sdk-bom</artifactId>
-                <version>${quarkus-operator-sdk-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-kubernetes</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
+                <version>${version.quarkus-operator-sdk}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>${quarkus.qpid.jms.group-id}</groupId>
+                <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-qpid-jms-bom</artifactId>
-                <version>${quarkus.qpid.jms.version}</version>
+                <version>${version.quarkus-platform}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.pnc.build.finder</groupId>
-                <artifactId>core</artifactId>
-                <version>${version.org.jboss.pnc.build.finder}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -116,7 +95,7 @@
                 <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus.platform.version}</version>
+                    <version>${version.quarkus-platform}</version>
                     <extensions>true</extensions>
                     <executions>
                         <execution>
@@ -130,7 +109,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${surefire-plugin.version}</version>
+                    <version>${version.surefire-plugin}</version>
                     <configuration>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -140,7 +119,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${failsafe-plugin.version}</version>
+                    <version>${version.failsafe-plugin}</version>
                     <executions>
                         <execution>
                             <goals>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -87,11 +87,6 @@
       <artifactId>quarkus-smallrye-context-propagation</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkiverse.hibernatetypes</groupId>
-      <artifactId>quarkus-hibernate-types</artifactId>
-      <version>${version.hibernatetypes}</version>
-    </dependency>
-    <dependency>
       <groupId>org.cyclonedx</groupId>
       <artifactId>cyclonedx-core-java</artifactId>
       <version>${version.cyclonedx}</version>
@@ -219,7 +214,7 @@
     <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-test-artemis</artifactId>
-      <version>${quarkus-test-artemis-version}</version>
+      <version>${version.quarkus-test-artemis}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/Sbom.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/Sbom.java
@@ -28,7 +28,6 @@ import org.cyclonedx.model.Bom;
 import org.cyclonedx.parsers.JsonParser;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
 import org.jboss.sbomer.core.features.sbom.validation.CycloneDxBom;
@@ -36,8 +35,6 @@ import org.jboss.sbomer.core.features.sbom.validation.CycloneDxBom;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.quarkiverse.hibernate.types.json.JsonBinaryType;
-import io.quarkiverse.hibernate.types.json.JsonTypes;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.persistence.CascadeType;
@@ -92,8 +89,8 @@ public class Sbom extends PanacheEntityBase {
     @Column(name = "creation_time", nullable = false, updatable = false)
     private Instant creationTime;
 
-    @Type(JsonBinaryType.class)
-    @Column(name = "sbom", columnDefinition = JsonTypes.JSON_BIN)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "sbom")
     @CycloneDxBom
     @ToString.Exclude
     private JsonNode sbom;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
@@ -37,8 +36,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.quarkiverse.hibernate.types.json.JsonBinaryType;
-import io.quarkiverse.hibernate.types.json.JsonTypes;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.persistence.Column;
@@ -93,8 +90,8 @@ public class SbomGenerationRequest extends PanacheEntityBase {
     @Column(name = "build_id", nullable = false, updatable = false)
     String buildId;
 
-    @Type(JsonBinaryType.class)
-    @Column(name = "config", columnDefinition = JsonTypes.JSON_BIN)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "config")
     @ToString.Exclude
     private JsonNode config;
 


### PR DESCRIPTION
We refrain from defining the Quarkus version explicitly now. Instead we use the transient version as defined by the Operator SDK Quarkus extension. This means that we are now at Quarkus 3.2.4.Final.

Unification of naming of properties related to versions was done as well.

Removal of custom Hibernate types. It's not needed anymore in Quarkus 3 which uses Hibernate 6.2.