### PR TITLE
feat: add support for retrieving product version from group config

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/pnc/GroupConfigurationClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/pnc/GroupConfigurationClient.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.service.pnc;
+
+import org.jboss.pnc.client.Configuration;
+import org.jboss.pnc.dto.GroupConfiguration;
+
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+
+public class GroupConfigurationClient extends ClientBase<GroupConfigurationEndpoint> {
+    public GroupConfigurationClient(Configuration configuration) {
+        super(configuration, GroupConfigurationEndpoint.class);
+    }
+
+    public GroupConfiguration getSpecific(String id) throws RemoteResourceException {
+        try {
+            return getEndpoint().getSpecific(id);
+        } catch (NotFoundException e) {
+            throw new RemoteResourceNotFoundException(e);
+        } catch (NotAuthorizedException e) {
+            if (configuration.getBearerTokenSupplier() != null) {
+                try {
+                    bearerAuthentication.setToken(configuration.getBearerTokenSupplier().get());
+                    return getEndpoint().getSpecific(id);
+                } catch (WebApplicationException wae) {
+                    throw new RemoteResourceException(readErrorResponse(wae), wae);
+                }
+            } else {
+                throw new RemoteResourceException(readErrorResponse(e), e);
+            }
+        } catch (WebApplicationException e) {
+            throw new RemoteResourceException(readErrorResponse(e), e);
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/pnc/GroupConfigurationEndpoint.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/pnc/GroupConfigurationEndpoint.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.service.pnc;
+
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.pnc.dto.GroupConfiguration;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Tag(name = "Group Configs")
+@Path("/group-configs")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+// @Client
+public interface GroupConfigurationEndpoint {
+    static final String GC_ID = "ID of the group config";
+
+    static final String GET_ALL_DESC = "Gets all group configs.";
+
+    static final String CREATE_NEW_DESC = "Creates a new group config.";
+
+    static final String GET_SPECIFIC_DESC = "Gets a specific group config.";
+
+    /**
+     * {@value GET_SPECIFIC_DESC}
+     *
+     * @param id {@value GC_ID}
+     * @return
+     */
+    @GET
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
+    GroupConfiguration getSpecific(@Parameter(description = GC_ID) @PathParam("id") String id);
+
+}

--- a/cli/src/main/resources/mapping/prod/product-mapping.yaml
+++ b/cli/src/main/resources/mapping/prod/product-mapping.yaml
@@ -47,7 +47,7 @@
     # - generator:
     #     type: maven-domino
     #     args: "--config-file .domino/manifest/quarkus-qpid-jms-bom-bom.json --warn-on-missing-scm"
-"483":
+"484":
   products:
     - processors:
         - type: redhat-product

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
@@ -22,10 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import jakarta.inject.Inject;
 
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.ProductVersionRef;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -63,7 +63,7 @@ public class PncServiceIT {
 
     @Test
     void testGetProductVersionMissingBuild() {
-        assertNull(service.getProductVersions("NOTEXISTING"));
+        assertEquals(Collections.emptyList(), service.getProductVersions("NOTEXISTING"));
     }
 
     @Test

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
@@ -18,9 +18,11 @@
 package org.jboss.sbomer.cli.test.integ.feature.sbom.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
@@ -61,16 +63,33 @@ public class PncServiceIT {
 
     @Test
     void testGetProductVersionMissingBuild() {
-        assertNull(service.getProductVersion("NOTEXISTING"));
+        assertNull(service.getProductVersions("NOTEXISTING"));
     }
 
     @Test
     void testGetProductVersion() {
-        ProductVersionRef productVersionRef = service.getProductVersion("ARYT3LBXDVYAC");
+        List<ProductVersionRef> productVersions = service.getProductVersions("ARYT3LBXDVYAC");
 
-        assertNotNull(productVersionRef);
-        assertEquals("179", productVersionRef.getId());
-        assertEquals("1.0", productVersionRef.getVersion());
+        assertNotNull(productVersions);
+        assertFalse(productVersions.isEmpty());
+        assertEquals(1, productVersions.size());
+        assertEquals("179", productVersions.get(0).getId());
+        assertEquals("1.0", productVersions.get(0).getVersion());
+    }
+
+    /**
+     * This tests a case where the productVersion in the build config is null. If this is the case we try to retrieve
+     * the productVersion from a groupConfig the build config is assigned to (if any).
+     */
+    @Test
+    void testGetProductVersionFromGroupConfig() {
+        List<ProductVersionRef> productVersions = service.getProductVersions("BUILDWITHGROUPSCONFIGPRODUCT");
+
+        assertNotNull(productVersions);
+        assertFalse(productVersions.isEmpty());
+        assertEquals(1, productVersions.size());
+        assertEquals("483", productVersions.get(0).getId());
+        assertEquals("3.2", productVersions.get(0).getVersion());
     }
 
     @Test

--- a/cli/src/test/resources/mappings/build-BUILDWITHGROUPSCONFIGPRODUCT.json
+++ b/cli/src/test/resources/mappings/build-BUILDWITHGROUPSCONFIGPRODUCT.json
@@ -1,0 +1,80 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/builds/BUILDWITHGROUPSCONFIGPRODUCT"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "BUILDWITHGROUPSCONFIGPRODUCT",
+      "submitTime": "2022-06-02T07:42:23.244Z",
+      "startTime": "2022-06-02T07:42:25.767Z",
+      "endTime": "2022-06-02T07:45:46.390Z",
+      "progress": "FINISHED",
+      "status": "SUCCESS",
+      "buildContentId": "build-ARYT3LBXDVYAC",
+      "temporaryBuild": false,
+      "alignmentPreference": null,
+      "scmUrl": "https://code.engineering.redhat.co",
+      "scmRevision": "08ad125da45653137814201b4d8527a1abba1e98",
+      "scmTag": "1.1.0.redhat-00008",
+      "buildOutputChecksum": "29f641f9dd0bccf99bb8321b23a986c4",
+      "lastUpdateTime": "2022-06-02T07:45:46.834Z",
+      "project": {
+        "id": "89",
+        "name": "microprofile",
+        "description": null,
+        "issueTrackerUrl": null,
+        "projectUrl": null,
+        "engineeringTeam": null,
+        "technicalLeader": null
+      },
+      "scmRepository": {
+        "id": "1069",
+        "internalUrl": "git+ssh://code.engineering",
+        "externalUrl": "https://github.com/eclipse/microprofile-graphql.git",
+        "preBuildSyncEnabled": true
+      },
+      "environment": {
+        "id": "264",
+        "name": "OpenJDK 1.8; Mvn 3.6.3",
+        "description": "OpenJDK 1.8; Mvn 3.6.3 [builder-rhel-7-j8-mvn3.6.3:1.0.4]",
+        "systemImageRepositoryUrl": "quay.io/rh-newcastle",
+        "systemImageId": "builder-rhel-7-j8-mvn3.6.3:1.0.4",
+        "attributes": {
+          "JDK": "1.8.0",
+          "MAVEN": "3.6.3",
+          "OS": "Linux",
+          "DEPRECATION_REPLACEMENT": "475"
+        },
+        "systemImageType": "DOCKER_IMAGE",
+        "deprecated": true,
+        "hidden": false
+      },
+      "attributes": {
+        "BREW_BUILD_VERSION": "1.1.0.redhat-00008",
+        "BUILD_OUTPUT_OK": "false",
+        "BREW_BUILD_NAME": "org.eclipse.microprofile.graphql:microprofile-graphql-parent"
+      },
+      "user": { "id": "1005", "username": "varjain" },
+      "buildConfigRevision": {
+        "id": "666",
+        "rev": 2560859,
+        "name": "microprofile-graphql-1.1.0",
+        "buildScript": "mvn clean deploy -B dependency:tree -DskipTests -Drat.skip -Dasciidoctor.skip -Dformatter.skip -Dimpsort.skip -Dcheckstyle.skip -Prelease -Dmaven.javadoc.skip -Dgpg.skip",
+        "scmRevision": "1.1.0",
+        "creationTime": "2021-09-15T11:26:52.852Z",
+        "modificationTime": "2021-09-15T12:06:04.819Z",
+        "buildType": "MVN",
+        "defaultAlignmentParams": "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true",
+        "brewPullActive": false
+      },
+      "productMilestone": null,
+      "groupBuild": null,
+      "noRebuildCause": null
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/cli/src/test/resources/mappings/build-config-666.json
+++ b/cli/src/test/resources/mappings/build-config-666.json
@@ -1,0 +1,65 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/build-configs/666"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "666",
+      "name": "microprofile-graphql-1.1.0",
+      "description": null,
+      "buildScript": "mvn clean deploy -B dependency:tree -DskipTests -Drat.skip -Dasciidoctor.skip -Dformatter.skip -Dimpsort.skip -Dcheckstyle.skip -Prelease -Dmaven.javadoc.skip -Dgpg.skip",
+      "scmRevision": "1.1.0",
+      "creationTime": "2021-09-15T11:26:52.852Z",
+      "modificationTime": "2021-09-15T12:06:04.819Z",
+      "buildType": "MVN",
+      "defaultAlignmentParams": "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true",
+      "brewPullActive": false,
+      "scmRepository": {
+        "id": "1069",
+        "internalUrl": "git+ssh://code.engineering.redhat.com/eclipse/microprofile-graphql.git",
+        "externalUrl": "https://github.com/eclipse/microprofile-graphql.git",
+        "preBuildSyncEnabled": true
+      },
+      "project": {
+        "id": "89",
+        "name": "microprofile",
+        "description": null,
+        "issueTrackerUrl": null,
+        "projectUrl": null,
+        "engineeringTeam": null,
+        "technicalLeader": null
+      },
+      "environment": {
+        "id": "264",
+        "name": "OpenJDK 1.8; Mvn 3.6.3",
+        "description": "OpenJDK 1.8; Mvn 3.6.3 [builder-rhel-7-j8-mvn3.6.3:1.0.4]",
+        "systemImageRepositoryUrl": "quay.io/rh-newcastle",
+        "systemImageId": "builder-rhel-7-j8-mvn3.6.3:1.0.4",
+        "attributes": {
+          "JDK": "1.8.0",
+          "MAVEN": "3.6.3",
+          "OS": "Linux",
+          "DEPRECATION_REPLACEMENT": "475"
+        },
+        "systemImageType": "DOCKER_IMAGE",
+        "deprecated": true,
+        "hidden": false
+      },
+      "dependencies": {},
+      "productVersion": null,
+      "groupConfigs": {
+        "666": { "id": "666", "name": "MicroProfile and SmallRye.Quarkus" }
+      },
+      "parameters": {
+        "ALIGNMENT_PARAMETERS": "-DgroovyScripts=https://gitlab.cee.redhat.com/middleware/build-configurations/raw/master/microprofile/common/manifests.groovy,https://gitlab.cee.redhat.com/middleware/build-configurations/raw/master/microprofile/common/no-spec-pdf-html.groovy -Prelease"
+      },
+      "creationUser": { "id": "38", "username": "pgallagh" },
+      "modificationUser": { "id": "38", "username": "pgallagh" }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/cli/src/test/resources/mappings/group-config-666.json
+++ b/cli/src/test/resources/mappings/group-config-666.json
@@ -1,0 +1,37 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/group-configs/666"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "666",
+      "name": "Quarkus Platform 3.2.5 all",
+      "productVersion": {
+        "id": "483",
+        "version": "3.2",
+        "attributes": {
+          "BREW_TAG_PREFIX": "qrksp-3.2-pnc"
+        }
+      },
+      "buildConfigs": {
+        "12921": {
+          "id": "12921",
+          "name": "io.quarkus-quarkus-platform-3.2.5",
+          "description": null,
+          "buildScript": "mvn -DskipTests clean deploy -B dependency:tree -Denforcer.skip=true -am",
+          "scmRevision": "3.2-temp-redhat",
+          "creationTime": "2023-08-30T17:53:49.481Z",
+          "modificationTime": "2023-09-08T13:33:42.354Z",
+          "buildType": "MVN",
+          "defaultAlignmentParams": "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true -DstrictPropertyValidation=true",
+          "brewPullActive": false
+        }
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/runtime/Config.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/runtime/Config.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
 /**
@@ -38,6 +39,7 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class Config {
 
     /**


### PR DESCRIPTION
In case the build config used to build the project doesn't have the `productVersion` set, we will try to get this information from a group configuration this build config is assigned to (if any).

In case the build config is assigned to multiple group configs -- we will take into account all of them. This will result in multiple "products" in SBOMer terms which will rpoduce multiple SBOMs for all of the productVersions found.