### PR TITLE
[NCL-8018] - Add SBOM generation for Gradle builds 

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGradleGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGradleGenerateCommand.java
@@ -17,21 +17,21 @@
  */
 package org.jboss.sbomer.cli.feature.sbom.command;
 
-import lombok.Getter;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
+import java.nio.file.Path;
 
-@Command(
-        mixinStandardHelpOptions = true,
-        name = "process",
-        aliases = { "p" },
-        description = "Process SBOM using selected processor",
-        subcommands = { DefaultProcessCommand.class, RedHatProductProcessCommand.class },
-        subcommandsRepeatable = true)
-public class ProcessCommand {
+import lombok.Getter;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ScopeType;
+
+public abstract class AbstractGradleGenerateCommand extends AbstractGenerateCommand {
 
     @Getter
-    @ParentCommand
-    AbstractGenerateCommand parent;
+    @Option(
+            names = { "--init-script" },
+            description = "Path to Gradle init script file that should be used for this run instead of the default one",
+            converter = PathConverter.class,
+            defaultValue = "${env:SBOMER_GRADLE_SETTINGS_XML_PATH}",
+            scope = ScopeType.INHERIT)
+    Path initScriptPath;
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AutoCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AutoCommand.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.cli.feature.sbom.command;
 
 import org.jboss.sbomer.cli.feature.sbom.command.auto.GenerateCommand;
 import org.jboss.sbomer.cli.feature.sbom.command.auto.GenerateConfigCommand;
+import org.jboss.sbomer.cli.feature.sbom.command.auto.GenerateEnvConfigCommand;
 
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine.Command;
@@ -31,7 +32,7 @@ import picocli.CommandLine.Spec;
         name = "auto",
         aliases = { "a" },
         description = "SBOM generation automation using configuration files",
-        subcommands = { GenerateConfigCommand.class, GenerateCommand.class })
+        subcommands = { GenerateConfigCommand.class, GenerateEnvConfigCommand.class, GenerateCommand.class })
 public class AutoCommand {
 
     @Spec

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GenerateCommand.java
@@ -31,7 +31,8 @@ import picocli.CommandLine.ScopeType;
         name = "generate",
         aliases = { "g" },
         description = "SBOM generation",
-        subcommands = { MavenCycloneDxGenerateCommand.class, MavenDominoGenerateCommand.class })
+        subcommands = { MavenCycloneDxGenerateCommand.class, MavenDominoGenerateCommand.class,
+                GradleCycloneDxGenerateCommand.class })
 public class GenerateCommand {
 
     @Getter

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateCommand.java
@@ -46,7 +46,7 @@ import picocli.CommandLine.Spec;
 @Command(
         mixinStandardHelpOptions = true,
         name = "generate",
-        description = "Scripted SBOM generation using runtime configuration file being the output of the 'generate-config' command")
+        description = "Scripted SBOM generation using runtime configuration file being the output of the 'generate-env-config' command")
 public class GenerateCommand implements Callable<Integer> {
     @Option(
             names = { "-c", "--config", },

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateEnvConfigCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateEnvConfigCommand.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.command.auto;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import org.jboss.pnc.dto.Build;
+import org.jboss.sbomer.cli.feature.sbom.ConfigReader;
+import org.jboss.sbomer.cli.feature.sbom.command.PathConverter;
+import org.jboss.sbomer.cli.feature.sbom.service.PncService;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
+import org.jboss.sbomer.core.features.sbom.utils.EnvironmentAttributesUtils;
+
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * <p>
+ * Command to generate a runtime environment configuration file (compliant with SDKMan) for SBOMer generation
+ * </p>
+ */
+@Slf4j
+@Command(
+        mixinStandardHelpOptions = true,
+        name = "generate-env-config",
+        description = "Generates the runtime environment configuration used for automation for a given PNC build")
+public class GenerateEnvConfigCommand implements Callable<Integer> {
+
+    public static enum ConfigFormat {
+        yaml, json;
+    }
+
+    @Option(names = { "--build-id" }, required = true, description = "The PNC build identifier, example: AYHJRDPEUMYAC")
+    String buildId;
+
+    @Option(
+            names = { "--format" },
+            defaultValue = "yaml",
+            description = "Format of the generated environment configuration.")
+    ConfigFormat format;
+
+    @Option(
+            names = { "--target" },
+            paramLabel = "FILE",
+            description = "Location where the configuration environment file should be stored. If not provided, environment configuration will be printed to standard output.",
+            converter = PathConverter.class)
+    Path target;
+
+    @Inject
+    PncService pncService;
+
+    @Inject
+    ConfigReader configReader;
+
+    /**
+     * Retrieves environment configuration from a PNC Build, compliant with SDKMan.
+     *
+     * @return a Map object if the configuration could be retrieved or {@code null} otherwise.
+     */
+    private Map<String, String> environmentConfig() {
+        // Make sure there is no context
+        MDCUtils.removeContext();
+        MDCUtils.addBuildContext(buildId);
+        log.debug("Attempting to fetch environment configuration from a PNC build");
+
+        Build build = pncService.getBuild(buildId);
+
+        if (build == null) {
+            log.warn("Could not retrieve PNC build '{}'", buildId);
+            return Collections.emptyMap();
+        }
+        Map<String, String> buildEnvAttributes = build.getEnvironment().getAttributes();
+        if (buildEnvAttributes == null || buildEnvAttributes.isEmpty()) {
+            log.debug("Build environment attributes not found for the specified PNC build");
+            return Collections.emptyMap();
+        }
+        Map<String, String> envConfig = EnvironmentAttributesUtils.getSDKManCompliantAttributes(buildEnvAttributes);
+        if (envConfig == null || envConfig.isEmpty()) {
+            log.debug("No compliant SDKMan environment attributes could be generated");
+            return Collections.emptyMap();
+        }
+
+        return envConfig;
+    }
+
+    /**
+     *
+     * @return {@code 0} in case the environment config file was generated successfully. An empty Map is valid as
+     *         default versions will be used
+     */
+    @Override
+    public Integer call() throws Exception {
+        Map<String, String> envConfig = environmentConfig();
+
+        if (envConfig.isEmpty()) {
+            log.debug(
+                    "Could not obtain environment attributes for the '{}' build. The generation will use default versions!",
+                    buildId);
+        }
+
+        log.debug("RAW envConfig: '{}'", envConfig);
+        log.debug("Using {} format", format);
+
+        String configuration;
+
+        if (format.equals(ConfigFormat.json)) {
+
+            configuration = configReader.getJsonObjectMapper()
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(envConfig);
+        } else {
+            configuration = configReader.getYamlObjectMapper()
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(envConfig);
+        }
+
+        if (target != null) {
+            Files.writeString(target, configuration);
+            log.info("Environment configuration saved as '{}' file", target.toAbsolutePath());
+        } else {
+            System.out.println(configuration);
+        }
+
+        return GenerationResult.SUCCESS.getCode();
+    }
+}

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/utils/GradleCycloneDxGenerateCommandMockAlternative.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/utils/GradleCycloneDxGenerateCommandMockAlternative.java
@@ -1,0 +1,42 @@
+package org.jboss.sbomer.cli.test.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.enterprise.inject.Alternative;
+
+import org.jboss.sbomer.cli.feature.sbom.command.GradleCycloneDxGenerateCommand;
+import org.jboss.sbomer.cli.feature.sbom.command.ProcessCommand;
+
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+
+@Alternative
+@Slf4j
+@Command(
+        mixinStandardHelpOptions = true,
+        name = "gradle-cyclonedx-plugin",
+        aliases = { "gradle-cyclonedx" },
+        description = "SBOM generation for Gradle projects using the CycloneDX Gradle plugin",
+        subcommands = { ProcessCommand.class })
+public class GradleCycloneDxGenerateCommandMockAlternative extends GradleCycloneDxGenerateCommand {
+
+    @Override
+    protected void doClone(String url, String tag, Path path, boolean force) {
+        log.info("Would clone url: {}, with tag: {}, into: {}, force: {}", url, tag, path, force);
+    }
+
+    @Override
+    protected Path doGenerate(String buildCmdOptions) {
+
+        try {
+            Files.copy(getClass().getClassLoader().getResourceAsStream("boms/plain.json"), getParent().getOutput());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return getParent().getOutput();
+    }
+
+}

--- a/core/src/main/java/org/jboss/sbomer/core/SchemaValidator.java
+++ b/core/src/main/java/org/jboss/sbomer/core/SchemaValidator.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
-
 import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.Draft;
 import io.vertx.json.schema.JsonSchema;

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/Constants.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/Constants.java
@@ -43,6 +43,8 @@ public class Constants {
     public final static String PROPERTY_ERRATA_PRODUCT_VERSION = "errata-tool-product-version";
     public final static String PROPERTY_ERRATA_PRODUCT_VARIANT = "errata-tool-product-variant";
 
+    public final static String BUILD_ATTRIBUTES_BREW_BUILD_VERSION = "BREW_BUILD_VERSION";
+
     /**
      * The label name that identifies the particular Sbom resource.
      */

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/enums/GeneratorType.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/enums/GeneratorType.java
@@ -27,5 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public enum GeneratorType {
     @JsonProperty("maven-cyclonedx")
     MAVEN_CYCLONEDX, @JsonProperty("maven-domino")
-    MAVEN_DOMINO;
+    MAVEN_DOMINO, @JsonProperty("gradle-cyclonedx")
+    GRADLE_CYCLONEDX
 }

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -317,6 +318,25 @@ public class SbomUtils {
             String configuration = ObjectMapperProvider.json()
                     .writerWithDefaultPrettyPrinter()
                     .writeValueAsString(config);
+            return ObjectMapperProvider.json().readTree(configuration);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Converts the given environment config {@link Map} into a {@link JsonNode} object.
+     *
+     * @param envConfig The environment config {@link Map} to convert
+     * @return {@link JsonNode} representation of the {@link Map}.
+     */
+    public static JsonNode toJsonNode(Map<String, String> envConfig) {
+
+        try {
+            String configuration = ObjectMapperProvider.json()
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(envConfig);
             return ObjectMapperProvider.json().readTree(configuration);
         } catch (JsonProcessingException e) {
             log.error(e.getMessage(), e);

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/CommandLineParserUtil.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/CommandLineParserUtil.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.core.features.sbom.utils.commandline;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.jboss.pnc.dto.Build;
+import org.jboss.sbomer.core.features.sbom.Constants;
+import org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandLineParser;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CommandLineParserUtil {
+
+    public static String getLaunderedCommandScript(Build build) {
+        String buildCmdOptions = "";
+        if (org.jboss.pnc.enums.BuildType.MVN.equals(build.getBuildConfigRevision().getBuildType())) {
+            buildCmdOptions = "mvn";
+            try {
+                MavenCommandLineParser lineParser = MavenCommandLineParser.build()
+                        .launder(build.getBuildConfigRevision().getBuildScript());
+                buildCmdOptions = lineParser.getRebuiltMvnCommandScript();
+            } catch (IllegalArgumentException exc) {
+                log.error("Could not launder the provided build command script! Using the default build command", exc);
+            }
+        } else if (org.jboss.pnc.enums.BuildType.GRADLE.equals(build.getBuildConfigRevision().getBuildType())) {
+            buildCmdOptions = "gradle";
+            // Looks like we need to override the final version as it might not be picked up in the CycloneDX
+            // generation, which would be overridden by the gradle.properties. The BREW_BUILD_VERSION attribute contains
+            // the version we need.
+            Optional<String> versionOverride = getVersionFromBuildAttributes(build);
+            if (versionOverride.isPresent()) {
+                buildCmdOptions += " -Pversion=" + versionOverride.get();
+            }
+        }
+        return buildCmdOptions;
+    }
+
+    private final static Optional<String> getVersionFromBuildAttributes(Build build) {
+        Map<String, String> attributes = build.getAttributes();
+        return attributes != null && !attributes.isEmpty()
+                && attributes.containsKey(Constants.BUILD_ATTRIBUTES_BREW_BUILD_VERSION)
+                        ? Optional.of(attributes.get(Constants.BUILD_ATTRIBUTES_BREW_BUILD_VERSION))
+                        : Optional.empty();
+    }
+}

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/maven/MavenCommandLineParser.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/maven/MavenCommandLineParser.java
@@ -15,12 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.features.sbom.utils.maven;
+package org.jboss.sbomer.core.features.sbom.utils.commandline.maven;
 
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.PROFILES_OPTION;
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.PROJECTS_OPTION;
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.SYSTEM_PROPERTIES_OPTION;
-import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.NO_ARGS_OPTIONS;
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.addIgnorableOptions;
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.addIneffectiveOptions;
 import static org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandOptions.addNoArgsOptions;
@@ -125,7 +124,7 @@ public class MavenCommandLineParser {
                 projects = parseKeyValuePairs(cmd.getOptionValues(PROJECTS_OPTION));
             }
 
-            for (String option : NO_ARGS_OPTIONS) {
+            for (String option : MavenCommandOptions.NO_ARGS_OPTIONS) {
                 if (cmd.hasOption(option)) {
                     noArgsOptions.add(option);
                 }

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/maven/MavenCommandOptions.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/maven/MavenCommandOptions.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.features.sbom.utils.maven;
+package org.jboss.sbomer.core.features.sbom.utils.commandline.maven;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;

--- a/core/src/main/resources/META-INF/sbomer-config.yaml
+++ b/core/src/main/resources/META-INF/sbomer-config.yaml
@@ -27,6 +27,9 @@ sbomer:
       maven-cyclonedx:
         default-version: "2.7.9"
         default-args: "--batch-mode"
+      gradle-cyclonedx:
+        default-version: "1.7.4"
+        default-args: "-info"
 
   processing:
     enabled: true

--- a/core/src/main/resources/schemas/config.json
+++ b/core/src/main/resources/schemas/config.json
@@ -81,7 +81,8 @@
                 "description": "Type of generator",
                 "enum": [
                   "maven-cyclonedx",
-                  "maven-domino"
+                  "maven-domino",
+                  "gradle-cyclonedx"
                 ]
               },
               "args": {

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/MavenCommandLineParserTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/MavenCommandLineParserTest.java
@@ -17,14 +17,14 @@
  */
 package org.jboss.sbomer.core.test.unit;
 
+import org.jboss.sbomer.core.features.sbom.utils.commandline.maven.MavenCommandLineParser;
+import org.jboss.sbomer.core.test.TestResources;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-
-import org.jboss.sbomer.core.features.sbom.utils.maven.MavenCommandLineParser;
-import org.jboss.sbomer.core.test.TestResources;
-import org.junit.jupiter.api.Test;
 
 public class MavenCommandLineParserTest {
 

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
@@ -34,13 +34,14 @@ public class SbomerConfigProviderTest {
 
         assertTrue(defaultGenerationConfig.isEnabled());
         assertEquals(GeneratorType.MAVEN_CYCLONEDX, defaultGenerationConfig.defaultGenerator());
-        assertEquals(2, defaultGenerationConfig.generators().size());
+        assertEquals(3, defaultGenerationConfig.generators().size());
         assertEquals(
                 "--batch-mode",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_CYCLONEDX).defaultArgs());
         assertEquals(
                 "--include-non-managed --warn-on-missing-scm",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_DOMINO).defaultArgs());
+        assertEquals("-info", defaultGenerationConfig.generators().get(GeneratorType.GRADLE_CYCLONEDX).defaultArgs());
     }
 
     @Nested

--- a/helm/templates/tekton/task-env-config.yaml
+++ b/helm/templates/tekton/task-env-config.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sbomer-env-config
+{{ include "sbomer.labels" (list .) | indent 2 }}
+spec:
+  params:
+    - name: build-id
+      type: string
+      description: "PNC build identifier"
+  steps:
+    - name: generate
+      image: {{ .Values.generator.image.repository }}:{{ .Values.generator.image.tag }}
+      imagePullPolicy: {{ .Values.generator.image.pullPolicy }}
+      resources:
+        limits:
+          cpu: 500m
+          memory: 500Mi
+        requests:
+          cpu: 200m
+          memory: 300Mi
+      env:
+        - name: SBOMER_HOST
+          value: {{ include "sbomer.serviceUrl" . }}
+        - name: SBOMER_PNC_HOST
+          value: {{ .Values.pnc.host }}
+        - name: SBOMER_GERRIT_HOST
+          value: {{ .Values.gerrit.host }}
+        - name: SBOMER_PNC_PRODUCT_MAPPING
+          value: {{ include "sbomer.productMapping" . }}
+        # SBOMER_CACHE_SERVICE_HOST is set by Kubernetes for us
+      script: |
+        #!/usr/bin/env bash
+
+        set -e
+        set -x
+
+        exec /workdir/.sdkman/candidates/java/17/bin/java -jar ./generator/quarkus-run.jar -v sbom auto generate-env-config --build-id "$(params.build-id)" --format yaml --target "$(results.env-config.path)"
+  results:
+    - name: "env-config"
+      description: "Environment Runtime configuration"

--- a/helm/templates/tekton/task-generate.yaml
+++ b/helm/templates/tekton/task-generate.yaml
@@ -5,6 +5,9 @@ metadata:
 {{ include "sbomer.labels" (list .) | indent 2 }}
 spec:
   params:
+    - name: env-config
+      type: string
+      description: "Environment configuration"
     - name: config
       type: string
       description: "Runtime generation configuration"
@@ -45,9 +48,12 @@ spec:
         set -o pipefail
 
         CONFIG_PATH="/workdir/config.yaml"
+        ENV_CONFIG_PATH="/workdir/env-config.yaml"
 
-        # Set the path to Maven settings.xml file so that ict can be used by the generator
+        # Set the path to Maven settings.xml file so that it can be used by the generator
         export SBOMER_MAVEN_SETTINGS_XML_PATH="/workdir/settings.xml"
+        # Set the path to Gradle init script file so that it can be used by the generator
+        export SBOMER_GRADLE_SETTINGS_XML_PATH="/workdir/cyclonedx-init.gradle"
 
         source /workdir/.sdkman/bin/sdkman-init.sh
 
@@ -55,6 +61,27 @@ spec:
 
         echo "Storing configuration in the $CONFIG_PATH file"
         echo "$(params.config)" | tee $CONFIG_PATH
+
+        echo "Storing environment configuration in the $ENV_CONFIG_PATH file"
+        echo "$(params.env-config)" | tee $ENV_CONFIG_PATH
+
+        echo "Parsing the environment config file...."
+        # Read the YAML file and iterate through its entries
+        while IFS=':' read -r key value; do
+           # Remove leading and trailing spaces from key and value
+           key=$(echo "$key" | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+           value=$(echo "$value" | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+
+           # Check if the output is not empty
+           if [ -n "$key" ]; then
+              # Call the script with softwaretype and required_version as arguments
+              best_available_version=$(/workdir/sdk_find_closest_installed_software.sh "$key" "$value" )
+              # Now set the closest softwaretype to the required_version
+              if [ -n "$best_available_version" ]; then
+                 sdk use $key ${best_available_version}
+              fi
+           fi      
+        done < /workdir/env-config.yaml
 
         mkdir -p $(workspaces.data.path)/$(context.taskRun.name)
         cd $(workspaces.data.path)/$(context.taskRun.name)

--- a/images/sbomer-generator/Containerfile
+++ b/images/sbomer-generator/Containerfile
@@ -18,11 +18,17 @@ RUN sh -c ./install_cert.sh
 
 USER 65532
 
-COPY --chown=65532:0 images/sbomer-generator/settings.xml images/sbomer-generator/install.sh /workdir/
+COPY --chown=65532:0 \
+    images/sbomer-generator/settings.xml \
+    images/sbomer-generator/cyclonedx-init.gradle \
+    images/sbomer-generator/install.sh \
+    images/sbomer-generator/sdk_find_closest_installed_software.sh \
+    /workdir/
 RUN sh -c ./install.sh
 
 ENV SBOMER_DOMINO_DIR="/workdir"
 ENV SBOMER_MAVEN_SETTINGS_XML_PATH="/workdir/settings.xml"
+ENV SBOMER_GRADLE_SETTINGS_XML_PATH="/workdir/cyclonedx-init.gradle"
 
 COPY --chown=65532:0 cli/target/quarkus-app/lib/ /workdir/generator/lib/
 COPY --chown=65532:0 cli/target/quarkus-app/*.jar /workdir/generator/

--- a/images/sbomer-generator/cyclonedx-init.gradle
+++ b/images/sbomer-generator/cyclonedx-init.gradle
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+allprojects {
+  repositories {
+    maven {
+        url "http://${System.env.SBOMER_CACHE_SERVICE_HOST}:7070/maven/central/"
+        name "proxy-central"
+    }
+    mavenCentral()
+
+    maven {
+        url "http://${System.env.SBOMER_CACHE_SERVICE_HOST}:7070/maven/redhat-ga/"
+        name "proxy-redhat-ga"
+    }
+    maven {
+        url "https://maven.repository.redhat.com/ga/"
+        name "redhat-ga"
+    }
+
+    maven {
+        url "http://${System.env.SBOMER_CACHE_SERVICE_HOST}:7070/maven/indy-static/"
+        name "proxy-indy"
+    }
+    maven {
+        url "https://${System.env.SBOMER_INDY_HOST}/api/content/maven/group/static/"
+        name "indy"
+    }
+  }
+}
+
+initscript {
+  repositories {
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
+  }
+
+  dependencies {
+    classpath "org.cyclonedx:cyclonedx-gradle-plugin:1.7.4"
+  }
+}
+
+allprojects {
+  apply plugin:org.cyclonedx.gradle.CycloneDxPlugin
+  cyclonedxBom {
+    // includeConfigs is the list of configuration names to include when generating the BOM (leave empty to include every configuration)
+    includeConfigs = ["runtimeClasspath", "compileClasspath"]
+    // skipConfigs is a list of configuration names to exclude when generating the BOM
+    skipConfigs = ["testRuntimeClasspath", "testCompileClasspath"]
+    // Specified the type of project being built. Defaults to 'library'
+    projectType = "library"
+    // Specified the version of the CycloneDX specification to use. Defaults to '1.4'
+    schemaVersion = "1.4"
+    // Boms destination directory. Defaults to 'build/reports'
+    destination = file("build/sbom")
+    // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
+    outputName = "bom"
+    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
+    outputFormat = "json"
+    // Exclude BOM Serial Number. Defaults to 'true'
+    includeBomSerialNumber = false
+    // Exclude License Text. Defaults to 'true'
+    includeLicenseText = false
+  }
+}

--- a/images/sbomer-generator/install.sh
+++ b/images/sbomer-generator/install.sh
@@ -27,8 +27,7 @@ function install_sdk() {
 }
 
 function install_java() {
-  # 8.0.362 11.0.18
-  for java_version in 17.0.7; do
+  for java_version in 8.0.362 11.0.18 17.0.7; do
     sdk install java ${java_version}-tem
     sdk install java ${java_version%%.*} "$(sdk home java ${java_version}-tem)"
     sdk use java ${java_version}-tem
@@ -52,6 +51,13 @@ function install_maven() {
   done
 }
 
+function install_gradle() {
+  for gradle_version in 4.10 5.4.1 5.6.2 6.3 6.8.3 7.1.1 7.6; do
+    sdk install gradle ${gradle_version}
+    sdk install gradle ${gradle_version%.*} "$(sdk home gradle ${gradle_version})"
+  done
+}
+
 function install_domino() {
   for domino_version in 0.0.90 0.0.97; do
     curl -L https://github.com/quarkusio/quarkus-platform-bom-generator/releases/download/${domino_version}/domino.jar -o domino-${domino_version}.jar
@@ -61,4 +67,5 @@ function install_domino() {
 install_sdk
 install_java
 install_maven
+install_gradle
 install_domino

--- a/images/sbomer-generator/sdk_find_closest_installed_software.sh
+++ b/images/sbomer-generator/sdk_find_closest_installed_software.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2023 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Check if SDKMAN! is installed
+if [ ! -d "$HOME/.sdkman" ]; then
+    echo "SDKMAN! is not installed. Please install it first."
+    exit 1
+fi
+
+source $HOME/.sdkman/bin/sdkman-init.sh
+
+# Check if two arguments are provided (version and software type)
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <software_type> <desired_version>"
+    exit 1
+fi
+
+software_type=$1
+desired_version=$2
+
+# Check if software_type is valid
+if [ "$software_type" != "java" ] && [ "$software_type" != "gradle" ] && [ "$software_type" != "maven" ]; then
+    echo "Invalid software type. Must be either 'java', 'gradle', or 'maven'."
+    exit 1
+fi
+
+compare_versions() {
+    local desired=$1
+    local installed_versions=("${@:2}")
+
+    local closest_version=""
+
+    for installed in "${installed_versions[@]}"; do
+        IFS='.' read -r -a desired_parts <<< "$desired"
+        IFS='.' read -r -a installed_parts <<< "$installed"
+
+        # Check for exact match
+        if [[ "$desired" == "$installed" ]]; then
+            echo "$installed"
+            return
+        fi
+
+        local is_match=true
+
+        for i in "${!desired_parts[@]}"; do
+            if (( ${desired_parts[i]} > ${installed_parts[i]} )); then
+                is_match=false
+                break
+            fi
+        done
+
+        if $is_match; then
+            closest_version=$installed
+            break  # Exit loop once a match is found
+        fi
+    done
+
+    echo "$closest_version"
+}
+
+result=""
+
+if [ "$software_type" == "java" ]; then
+    # List available Temurin Java versions from SDKMAN!
+    output=$(ls -l "$HOME/.sdkman/candidates/$software_type" | grep "tem")
+    # Extract versions using awk with extended regex
+    installed_versions=($(echo "$output" | awk -F'-tem' '{print $1}' | grep -oP "\d+\.\d+(\.\d+)?" | sort -V))
+
+    result=$(compare_versions "$desired_version" "${installed_versions[@]}" 2>/dev/null)
+    if [ -n "$result" ]; then
+        result="${result}-tem"
+    fi
+else 
+    # List available versions from SDKMAN of the provided software_type!
+    output=$(ls -l "$HOME/.sdkman/candidates/$software_type")
+    # Extract versions using awk with extended regex
+    installed_versions=($(echo "$output" | awk -F'-tem' '{print $1}' | grep -oP "\d+\.\d+(\.\d+)?" | sort -V))
+
+    result=$(compare_versions "$desired_version" "${installed_versions[@]}" 2>/dev/null)
+fi
+
+# Finally check if the result is not null and the directory exists
+if [ -n "$result" ] && [ ! -d "$HOME/.sdkman/candidates/$software_type/$result" ]; then
+    # No directory was found, returning empty result
+    result=""
+fi
+
+echo $result
+
+

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncMessageParser.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncMessageParser.java
@@ -200,7 +200,8 @@ public class PncMessageParser implements Runnable {
         if (!msgBody.getBuild().isTemporaryBuild() && ProgressStatus.FINISHED.equals(msgBody.getBuild().getProgress())
                 && (BuildStatus.SUCCESS.equals(msgBody.getBuild().getStatus())
                         || BuildStatus.NO_REBUILD_REQUIRED.equals(msgBody.getBuild().getStatus()))
-                && BuildType.MVN.equals(msgBody.getBuild().getBuildConfigRevision().getBuildType())) {
+                && (BuildType.MVN.equals(msgBody.getBuild().getBuildConfigRevision().getBuildType())
+                        || BuildType.GRADLE.equals(msgBody.getBuild().getBuildConfigRevision().getBuildType()))) {
             return true;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -72,6 +72,7 @@ public class GenerationRequest extends ConfigMap {
     public static final String KEY_REASON = "reason";
     public static final String KEY_RESULT = "result";
     public static final String KEY_CONFIG = "config";
+    public static final String KEY_ENV_CONFIG = "env-config";
 
     public GenerationRequest() {
         super();
@@ -112,6 +113,15 @@ public class GenerationRequest extends ConfigMap {
 
     public void setConfig(String config) {
         getData().put(KEY_CONFIG, config);
+    }
+
+    @JsonIgnore
+    public String getEnvConfig() {
+        return getData().get(KEY_ENV_CONFIG);
+    }
+
+    public void setEnvConfig(String envConfig) {
+        getData().put(KEY_ENV_CONFIG, envConfig);
     }
 
     @JsonIgnore
@@ -180,6 +190,20 @@ public class GenerationRequest extends ConfigMap {
 
         try {
             return ObjectMapperProvider.yaml().readValue(getConfig().toString().getBytes(), Config.class);
+        } catch (IOException e) {
+            log.warn(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @JsonIgnore
+    public Map<String, String> toEnvConfig() {
+        if (getEnvConfig() == null) {
+            return null;
+        }
+
+        try {
+            return ObjectMapperProvider.yaml().readValue(getEnvConfig().toString().getBytes(), Map.class);
         } catch (IOException e) {
             log.warn(e.getMessage(), e);
             return null;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
@@ -31,8 +31,8 @@ public class GenerationRequestBuilder extends GenerationRequestFluentImpl<Genera
         addToData(GenerationRequest.KEY_ID, RandomStringIdGenerator.generate());
         addToData(GenerationRequest.KEY_BUILD_ID, getBuildId());
         addToData(GenerationRequest.KEY_REASON, getReason());
-        addToData(GenerationRequest.KEY_ENV_CONFIG, getConfig());
-        addToData(GenerationRequest.KEY_CONFIG, getEnvConfig());
+        addToData(GenerationRequest.KEY_ENV_CONFIG, getEnvConfig());
+        addToData(GenerationRequest.KEY_CONFIG, getConfig());
         addToData(GenerationRequest.KEY_REASON, getReason());
         addToData(
                 GenerationRequest.KEY_STATUS,

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
@@ -31,7 +31,8 @@ public class GenerationRequestBuilder extends GenerationRequestFluentImpl<Genera
         addToData(GenerationRequest.KEY_ID, RandomStringIdGenerator.generate());
         addToData(GenerationRequest.KEY_BUILD_ID, getBuildId());
         addToData(GenerationRequest.KEY_REASON, getReason());
-        addToData(GenerationRequest.KEY_CONFIG, getConfig());
+        addToData(GenerationRequest.KEY_ENV_CONFIG, getConfig());
+        addToData(GenerationRequest.KEY_CONFIG, getEnvConfig());
         addToData(GenerationRequest.KEY_REASON, getReason());
         addToData(
                 GenerationRequest.KEY_STATUS,

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
@@ -31,6 +31,8 @@ public interface GenerationRequestFluent<A extends GenerationRequestFluent<A>> e
 
     public A withReason(String reason);
 
+    public A withEnvConfig(String envConfig);
+
     public A withConfig(String config);
 
     public A withResult(GenerationResult result);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluentImpl.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluentImpl.java
@@ -33,6 +33,7 @@ public class GenerationRequestFluentImpl<A extends GenerationRequestFluent<A>> e
     private SbomGenerationStatus status;
     private String reason;
     private String config;
+    private String envConfig;
     private GenerationResult result;
 
     @Override
@@ -81,6 +82,16 @@ public class GenerationRequestFluentImpl<A extends GenerationRequestFluent<A>> e
 
     public String getReason() {
         return reason;
+    }
+
+    @Override
+    public A withEnvConfig(String envConfig) {
+        this.envConfig = envConfig;
+        return (A) this;
+    }
+
+    public String getEnvConfig() {
+        return envConfig;
     }
 
     @Override

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationPhase.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationPhase.java
@@ -18,5 +18,5 @@
 package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 public enum SbomGenerationPhase {
-    INIT, GENERATE;
+    INIT, DETECTENVINFO, GENERATE;
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationStatus.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationStatus.java
@@ -18,7 +18,7 @@
 package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 public enum SbomGenerationStatus {
-    NEW, INITIALIZING, INITIALIZED, GENERATING, FINISHED, FAILED;
+    NEW, INITIALIZING, INITIALIZED, ENV_DETECTING, ENV_DETECTED, GENERATING, FINISHED, FAILED;
 
     public static SbomGenerationStatus fromName(String phase) {
         return SbomGenerationStatus.valueOf(phase.toUpperCase());

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
@@ -47,7 +47,9 @@ import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.ConfigAvailableCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.ConfigMissingCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.EnvConfigMissingCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunEnvDetectDependentResource;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunGenerateDependentResource;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunInitDependentResource;
 import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
@@ -103,6 +105,10 @@ import lombok.extern.slf4j.Slf4j;
                         type = TaskRunInitDependentResource.class,
                         useEventSourceWithName = EVENT_SOURCE_NAME,
                         reconcilePrecondition = ConfigMissingCondition.class),
+                @Dependent(
+                        type = TaskRunEnvDetectDependentResource.class,
+                        useEventSourceWithName = EVENT_SOURCE_NAME,
+                        reconcilePrecondition = EnvConfigMissingCondition.class),
                 @Dependent(
                         type = TaskRunGenerateDependentResource.class,
                         reconcilePrecondition = ConfigAvailableCondition.class,
@@ -168,6 +174,7 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         if (generationRequest.getStatus() != null) {
             String label = switch (generationRequest.getStatus()) {
                 case INITIALIZING -> SbomGenerationPhase.INIT.name().toLowerCase();
+                case ENV_DETECTING -> SbomGenerationPhase.DETECTENVINFO.name().toLowerCase();
                 case GENERATING -> SbomGenerationPhase.GENERATE.name().toLowerCase();
                 default -> null;
             };
@@ -272,7 +279,7 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
     }
 
     /**
-     * Possible next statuses: {@link SbomGenerationStatus#GENERATING}
+     * Possible next statuses: {@link SbomGenerationStatus#ENV_DETECTING}
      *
      * @param secondaryResources
      * @param generationRequest
@@ -283,9 +290,74 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
             GenerationRequest generationRequest,
             Set<TaskRun> secondaryResources) {
 
-        Set<TaskRun> generateTaskRuns = generateTaskRuns(secondaryResources);
+        TaskRun envDetectTaskRun = envDetectTaskRuns(secondaryResources);
 
-        if (generateTaskRuns.isEmpty()) {
+        if (envDetectTaskRun == null) {
+            return UpdateControl.noUpdate();
+        }
+
+        return updateRequest(generationRequest, SbomGenerationStatus.ENV_DETECTING, null, null);
+    }
+
+    /**
+     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#ENV_DETECTED}
+     *
+     * @param secondaryResources
+     * @param generationRequest
+     *
+     * @return
+     */
+    private UpdateControl<GenerationRequest> reconcileEnvDetecting(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        TaskRun envDetectTaskRun = envDetectTaskRuns(secondaryResources);
+
+        if (envDetectTaskRun == null) {
+            log.error(
+                    "There is no environment detecting TaskRun related to GenerationRequest '{}'",
+                    generationRequest.getName());
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Environment detection failed. Unable to find related TaskRun. See logs for more information.");
+        }
+
+        if (!isFinished(envDetectTaskRun)) {
+            return UpdateControl.noUpdate();
+        }
+
+        if (isSuccessful(envDetectTaskRun)) {
+            setEnvConfig(generationRequest, envDetectTaskRun);
+            return updateRequest(generationRequest, SbomGenerationStatus.ENV_DETECTED, null, null);
+        }
+
+        StringBuilder sb = new StringBuilder("Environment detection failed. System failure. ");
+        GenerationResult result = GenerationResult.ERR_SYSTEM;
+        String reason = sb.append("See logs for more information.").toString();
+
+        log.warn("GenerationRequest '{}' failed. {}", generationRequest.getName(), reason);
+
+        return updateRequest(generationRequest, SbomGenerationStatus.FAILED, result, reason);
+    }
+
+    /**
+     * Possible next statuses: {@link SbomGenerationStatus#GENERATING}
+     *
+     * @param secondaryResources
+     * @param generationRequest
+     *
+     * @return
+     */
+    private UpdateControl<GenerationRequest> reconcileEnvDetected(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        TaskRun envDetectTaskRun = envDetectTaskRuns(secondaryResources);
+
+        if (envDetectTaskRun == null) {
             return UpdateControl.noUpdate();
         }
 
@@ -505,6 +577,26 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
     }
 
     /**
+     * Returns the env-detection {@link TaskRun} from the given {@link TaskRun} {@link Set}.
+     *
+     * @param taskRuns
+     * @return The {@link TaskRun} or {@code null} if not found.
+     */
+    private TaskRun envDetectTaskRuns(Set<TaskRun> taskRuns) {
+        Optional<TaskRun> taskRun = taskRuns.stream().filter(tr -> {
+            if (Objects.equals(
+                    tr.getMetadata().getLabels().get(Labels.LABEL_PHASE),
+                    SbomGenerationPhase.DETECTENVINFO.name().toLowerCase())) {
+                return true;
+            }
+
+            return false;
+        }).findFirst();
+
+        return taskRun.orElse(null);
+    }
+
+    /**
      * Removes related to finished {@link GenerationRequest} and its instance as well.
      *
      * @param generationRequest
@@ -627,7 +719,7 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         // Fetch any secondary resources (Tekton TaskRuns) that are related to the primary resource (GenerationRequest)
         // There may be between 0 or more TaskRuns related to the GenerationRequest:
         // 0 In case these were not created yet,
-        // 1 in case the initiation tasks is only running
+        // 1 in case the initialization or environment config tasks are running
         // 2 or more in case the generation is running
         Set<TaskRun> secondaryResources = context.getSecondaryResources(TaskRun.class);
 
@@ -647,6 +739,12 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
                 break;
             case INITIALIZED:
                 action = reconcileInitialized(generationRequest, secondaryResources);
+                break;
+            case ENV_DETECTING:
+                action = reconcileEnvDetecting(generationRequest, secondaryResources);
+                break;
+            case ENV_DETECTED:
+                action = reconcileEnvDetected(generationRequest, secondaryResources);
                 break;
             case GENERATING:
                 action = reconcileGenerating(generationRequest, secondaryResources);
@@ -772,6 +870,59 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         }
 
         return config;
+    }
+
+    private Map<String, String> setEnvConfig(GenerationRequest generationRequest, TaskRun taskRun) {
+        log.debug("Handling result of the environment detection task");
+
+        if (taskRun.getStatus() == null) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have status sub-resource despite it is expected",
+                    taskRun.getMetadata().getName());
+
+        }
+
+        if (taskRun.getStatus().getTaskResults() == null || taskRun.getStatus().getTaskResults().isEmpty()) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have any results despite it is expected to have one",
+                    taskRun.getMetadata().getName());
+        }
+
+        Optional<TaskRunResult> envConfigResult = taskRun.getStatus()
+                .getTaskResults()
+                .stream()
+                .filter(result -> Objects.equals(result.getName(), TaskRunEnvDetectDependentResource.RESULT_NAME))
+                .findFirst();
+
+        if (envConfigResult.isEmpty()) {
+            throw new ApplicationException(
+                    "Could not find the '{}' result within the TaskRun '{}'",
+                    TaskRunEnvDetectDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName());
+        }
+
+        String envConfigVal = envConfigResult.get().getValue().getStringVal();
+        Map<String, String> envConfig;
+
+        try {
+            envConfig = objectMapper.readValue(envConfigVal.getBytes(), Map.class);
+        } catch (IOException e) {
+            throw new ApplicationException(
+                    "Could not parse the '{}' result within the TaskRun '{}': {}",
+                    TaskRunEnvDetectDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName(),
+                    envConfigVal);
+        }
+
+        log.debug("Environment config from TaskRun '{}' parsed: {}", taskRun.getMetadata().getName(), envConfig);
+
+        try {
+            generationRequest.setEnvConfig(objectMapper.writeValueAsString(envConfig));
+        } catch (JsonProcessingException e) {
+            log.error("Unable to serialize environment configuration", e);
+        }
+
+        return envConfig;
     }
 
     @Override

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/condition/ConfigAvailableCondition.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/condition/ConfigAvailableCondition.java
@@ -32,8 +32,8 @@ public class ConfigAvailableCondition implements Condition<TaskRun, GenerationRe
             GenerationRequest primary,
             Context<GenerationRequest> context) {
 
-        // If the configuration is available, reconcile
-        if (primary.getConfig() != null) {
+        // If the configurations are available, reconcile
+        if (primary.getConfig() != null && primary.getEnvConfig() != null) {
             return true;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/condition/EnvConfigMissingCondition.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/condition/EnvConfigMissingCondition.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+public class EnvConfigMissingCondition implements Condition<TaskRun, GenerationRequest> {
+
+    Boolean cleanup = ConfigProvider.getConfig()
+            .getValue("sbomer.controller.generation-request.cleanup", Boolean.class);
+
+    @Override
+    public boolean isMet(
+            DependentResource<TaskRun, GenerationRequest> dependentResource,
+            GenerationRequest primary,
+            Context<GenerationRequest> context) {
+
+        // Here we are checking whether the environment configuration exists already or not, only of the configuration
+        // exists already.
+        // In case it's not there, we need to generate one, thus returning true to let the reconciliation happen on the
+        // TaskRunEnvDetectDependentResource.
+        if (primary.getConfig() != null && primary.getEnvConfig() == null) {
+            return true;
+        }
+
+        // If the configuration is available (meaning that the initialization phase is finished) and the {@code cleanup}
+        // setting is set to false, reconcile. We won't reconcile multiple times at this point, the only thing we want
+        // to achieve is that the dependent resource (TaskRun) is retained.
+        // We should do this only in the case when there are already some secondary resources.
+        if (!cleanup && initTaskRunExist(context) && envDetectTaskRunExist(context)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean initTaskRunExist(Context<GenerationRequest> context) {
+        Set<TaskRun> secondaryResources = context.getSecondaryResources(TaskRun.class);
+
+        // No TaskRuns at all, so no init TaskRun for sure...
+        if (secondaryResources.isEmpty()) {
+            return false;
+        }
+
+        return secondaryResources.stream().anyMatch(taskRun -> {
+            Map<String, String> labels = taskRun.getMetadata().getLabels();
+
+            if (labels != null
+                    && Objects.equals(labels.get(Labels.LABEL_PHASE), SbomGenerationPhase.INIT.name().toLowerCase())) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    private boolean envDetectTaskRunExist(Context<GenerationRequest> context) {
+        Set<TaskRun> secondaryResources = context.getSecondaryResources(TaskRun.class);
+
+        // No TaskRuns at all, so no env detect TaskRun for sure...
+        if (secondaryResources.isEmpty()) {
+            return false;
+        }
+
+        return secondaryResources.stream().anyMatch(taskRun -> {
+            Map<String, String> labels = taskRun.getMetadata().getLabels();
+
+            if (labels != null && Objects
+                    .equals(labels.get(Labels.LABEL_PHASE), SbomGenerationPhase.DETECTENVINFO.name().toLowerCase())) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/AbstractResourceDiscriminator.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/AbstractResourceDiscriminator.java
@@ -32,7 +32,7 @@ import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEven
 
 public abstract class AbstractResourceDiscriminator implements ResourceDiscriminator<TaskRun, GenerationRequest> {
     /**
-     * The phase of the SBOM generation, could be: init or generate.
+     * The phase of the SBOM generation, could be: init, envconfig or generate.
      *
      * @return Name of the phase
      */

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/EnvDetectResourceDiscriminator.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/EnvDetectResourceDiscriminator.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.k8s.resources;
+
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+
+public class EnvDetectResourceDiscriminator extends AbstractResourceDiscriminator {
+
+    @Override
+    protected SbomGenerationPhase getPhase() {
+        return SbomGenerationPhase.DETECTENVINFO;
+    }
+
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunEnvDetectDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunEnvDetectDependentResource.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.k8s.resources;
+
+import java.util.Map;
+
+import org.jboss.sbomer.service.feature.sbom.config.TektonConfig;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.ParamBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRefBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDNoGCKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@KubernetesDependent(resourceDiscriminator = EnvDetectResourceDiscriminator.class)
+@Slf4j
+public class TaskRunEnvDetectDependentResource extends CRUDNoGCKubernetesDependentResource<TaskRun, GenerationRequest> {
+
+    public static final String RESULT_NAME = "env-config";
+    public static final String PARAM_BUILD_ID_NAME = "build-id";
+
+    @Inject
+    TektonConfig tektonConfig;
+
+    TaskRunEnvDetectDependentResource() {
+        super(TaskRun.class);
+    }
+
+    public TaskRunEnvDetectDependentResource(Class<TaskRun> resourceType) {
+        super(TaskRun.class);
+    }
+
+    /**
+     * <p>
+     * Method that creates a {@link TaskRun} related to the {@link GenerationRequest} in order to perform the
+     * environment configuration.
+     * </p>
+     *
+     * <p>
+     * This is done after the init phase is completed.
+     * </p>
+     */
+    @Override
+    protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
+
+        log.debug(
+                "Preparing dependent resource for the '{}' phase related to '{}'",
+                SbomGenerationPhase.DETECTENVINFO,
+                generationRequest.getMetadata().getName());
+
+        Map<String, String> labels = Labels.defaultLabelsToMap();
+
+        labels.put(Labels.LABEL_BUILD_ID, generationRequest.getBuildId());
+        labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.DETECTENVINFO.name().toLowerCase());
+        labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+
+        return new TaskRunBuilder().withNewMetadata()
+                .withNamespace(generationRequest.getMetadata().getNamespace())
+                .withLabels(labels)
+                .withName(generationRequest.dependentResourceName(SbomGenerationPhase.DETECTENVINFO))
+                .withOwnerReferences(
+                        new OwnerReferenceBuilder().withKind(generationRequest.getKind())
+                                .withName(generationRequest.getMetadata().getName())
+                                .withApiVersion(generationRequest.getApiVersion())
+                                .withUid(generationRequest.getMetadata().getUid())
+                                .build())
+                .endMetadata()
+
+                .withNewSpec()
+                .withServiceAccountName(tektonConfig.sa())
+                .withParams(
+                        new ParamBuilder().withName(PARAM_BUILD_ID_NAME)
+                                .withNewValue(generationRequest.getBuildId())
+                                .build())
+                .withTaskRef(new TaskRefBuilder().withName("sbomer-env-config").build())
+                .endSpec()
+                .build();
+
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.model;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -95,6 +96,11 @@ public class SbomGenerationRequest extends PanacheEntityBase {
     @ToString.Exclude
     private JsonNode config;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "env_config")
+    @ToString.Exclude
+    private JsonNode envConfig;
+
     @Column(name = "reason", nullable = true, updatable = true)
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     String reason;
@@ -150,6 +156,20 @@ public class SbomGenerationRequest extends PanacheEntityBase {
                                         .readValue(generationRequest.getConfig().getBytes(), Config.class)));
             } catch (IOException e) {
                 throw new ApplicationException("Could not convert configuration to store in the database", e);
+            }
+        }
+
+        // Update environment config, if available
+        if (generationRequest.getEnvConfig() != null) {
+            try {
+                sbomGenerationRequest.setEnvConfig(
+                        SbomUtils.toJsonNode(
+                                ObjectMapperProvider.yaml()
+                                        .readValue(generationRequest.getEnvConfig().getBytes(), Map.class)));
+            } catch (IOException e) {
+                throw new ApplicationException(
+                        "Could not convert environment configuration to store in the database",
+                        e);
             }
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -160,7 +161,7 @@ public class SbomGenerationRequest extends PanacheEntityBase {
         }
 
         // Update environment config, if available
-        if (generationRequest.getEnvConfig() != null) {
+        if (generationRequest.getEnvConfig() != null && !generationRequest.getEnvConfig().isEmpty()) {
             try {
                 sbomGenerationRequest.setEnvConfig(
                         SbomUtils.toJsonNode(
@@ -171,6 +172,8 @@ public class SbomGenerationRequest extends PanacheEntityBase {
                         "Could not convert environment configuration to store in the database",
                         e);
             }
+        } else {
+            sbomGenerationRequest.setEnvConfig(MissingNode.getInstance());
         }
 
         // Store it in the database

--- a/service/src/main/resources/db-update/00008-1.0.1.sql
+++ b/service/src/main/resources/db-update/00008-1.0.1.sql
@@ -1,0 +1,26 @@
+--
+-- JBoss, Home of Professional Open Source.
+-- Copyright 2023 Red Hat, Inc., and individual contributors
+-- as indicated by the @author tags.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+
+BEGIN transaction;
+
+    ALTER TABLE sbom_generation_request ADD COLUMN env_config jsonb NULL;
+
+    INSERT INTO db_version(version, creation_time) VALUES ('00008', now());
+
+COMMIT;

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/EnvInitializationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/EnvInitializationPhaseGenerationRequestReconcilerIT.java
@@ -1,0 +1,194 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.test.integ.feature.sbom.k8s.reconciler;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.test.TestResources;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunEnvDetectDependentResource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.fabric8.knative.internal.pkg.apis.ConditionBuilder;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminatedBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.ParamBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.ParamValue;
+import io.fabric8.tekton.pipeline.v1beta1.StepStateBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunResultBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunStatusBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Class responsible for testing reconciliation workflow for the environment initialization phase.
+ */
+@QuarkusTest
+public class EnvInitializationPhaseGenerationRequestReconcilerIT {
+
+    @Inject
+    GenerationRequestReconciler controller;
+
+    private GenerationRequest dummyGenerationRequest(SbomGenerationStatus status) throws IOException {
+        return new GenerationRequestBuilder().withNewMetadata()
+                .withName("test")
+                .endMetadata()
+                .withBuildId("AABBCC")
+                .withStatus(status)
+                .build();
+    }
+
+    private TaskRun dummyTaskRun() {
+        return new TaskRunBuilder().withNewMetadata()
+                .withName("env-init-task-run")
+                .withLabels(Map.of(Labels.LABEL_PHASE, SbomGenerationPhase.DETECTENVINFO.name().toLowerCase()))
+                .endMetadata()
+                .withNewSpec()
+                .withParams(new ParamBuilder().withName("build-id").withValue(new ParamValue("AABBCC")).build())
+                .endSpec()
+                .build();
+    }
+
+    private void setTaskRunStatus(TaskRun taskRun, String status) {
+        taskRun.setStatus(
+                new TaskRunStatusBuilder().withConditions(List.of(new ConditionBuilder().withStatus(status).build()))
+                        .build());
+    }
+
+    private void setTaskRunResult(TaskRun taskRun) throws IOException {
+        taskRun.getStatus()
+                .getTaskResults()
+                .add(
+                        new TaskRunResultBuilder().withName(TaskRunEnvDetectDependentResource.RESULT_NAME)
+                                .withValue(new ParamValue(TestResources.asString("configs/env-config.yaml")))
+                                .build());
+    }
+
+    private void setTaskRunExitCode(TaskRun taskRun, int exitCode) throws IOException {
+        taskRun.getStatus()
+                .getSteps()
+                .add(
+                        new StepStateBuilder()
+                                .withTerminated(new ContainerStateTerminatedBuilder().withExitCode(exitCode).build())
+                                .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Context<GenerationRequest> mockContext(Set<TaskRun> secondaryResources) {
+        Context<GenerationRequest> mockedContext = Mockito.mock(Context.class);
+
+        when(mockedContext.getSecondaryResources(TaskRun.class)).thenReturn(secondaryResources);
+
+        return mockedContext;
+    }
+
+    @Test
+    void testEnvDetectingWithoutDependentResources() throws Exception {
+        GenerationRequest request = dummyGenerationRequest(SbomGenerationStatus.ENV_DETECTING);
+
+        UpdateControl<GenerationRequest> updateControl = controller
+                .reconcile(request, mockContext(Collections.emptySet()));
+
+        assertTrue(updateControl.isUpdateResource());
+        assertEquals(SbomGenerationStatus.FAILED, updateControl.getResource().getStatus());
+        assertEquals(
+                "Environment detection failed. Unable to find related TaskRun. See logs for more information.",
+                updateControl.getResource().getReason());
+        assertEquals(GenerationResult.ERR_SYSTEM, updateControl.getResource().getResult());
+        assertEquals("FAILED", updateControl.getResource().getMetadata().getLabels().get(Labels.LABEL_STATUS));
+        assertEquals("detectenvinfo", updateControl.getResource().getMetadata().getLabels().get(Labels.LABEL_PHASE));
+    }
+
+    @Test
+    void testSuccessful() throws Exception {
+        GenerationRequest request = dummyGenerationRequest(SbomGenerationStatus.ENV_DETECTING);
+
+        TaskRun taskRun = dummyTaskRun();
+
+        // Set the Task run status to reflect it being in "finished" state
+        setTaskRunStatus(taskRun, "True");
+        setTaskRunResult(taskRun);
+
+        UpdateControl<GenerationRequest> updateControl = controller.reconcile(request, mockContext(Set.of(taskRun)));
+
+        assertTrue(updateControl.isUpdateResource());
+        assertEquals(SbomGenerationStatus.ENV_DETECTED, updateControl.getResource().getStatus());
+
+        // For in-progress generation we don't set reason nor result
+        assertNull(updateControl.getResource().getReason());
+        assertNull(updateControl.getResource().getResult());
+        assertEquals("ENV_DETECTED", updateControl.getResource().getMetadata().getLabels().get(Labels.LABEL_STATUS));
+    }
+
+    @Test
+    void testInProgress() throws Exception {
+        GenerationRequest request = dummyGenerationRequest(SbomGenerationStatus.ENV_DETECTING);
+
+        TaskRun taskRun = dummyTaskRun();
+
+        // Set the Task run status to reflect it being in "running" state
+        setTaskRunStatus(taskRun, "Unknown");
+
+        UpdateControl<GenerationRequest> updateControl = controller.reconcile(request, mockContext(Set.of(taskRun)));
+
+        assertTrue(updateControl.isNoUpdate());
+    }
+
+    @Test
+    public void testFailedNoPNCBuild() throws Exception {
+        GenerationRequest request = dummyGenerationRequest(SbomGenerationStatus.ENV_DETECTING);
+
+        Set<TaskRun> secondaryTaskRuns = new HashSet<>();
+
+        TaskRun taskRun = dummyTaskRun();
+        setTaskRunStatus(taskRun, "False");
+        setTaskRunExitCode(taskRun, GenerationResult.ERR_GENERAL.getCode());
+        secondaryTaskRuns.add(taskRun);
+
+        UpdateControl<GenerationRequest> updateControl = controller.reconcile(request, mockContext(secondaryTaskRuns));
+
+        assertTrue(updateControl.isUpdateResource());
+        assertEquals(SbomGenerationStatus.FAILED, updateControl.getResource().getStatus());
+        assertEquals(GenerationResult.ERR_GENERAL, updateControl.getResource().getResult());
+        assertEquals(
+                "Environment detection failed. System failure. General error occurred (could not retrieve the provided PNC buildId).See logs for more information.",
+                updateControl.getResource().getReason());
+    }
+
+}

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
@@ -104,6 +104,7 @@ public class GenerationPhaseGenerationRequestReconcilerIT {
                 .endMetadata()
                 .withBuildId("AABBCC")
                 .withStatus(SbomGenerationStatus.GENERATING)
+                .withEnvConfig("")
                 .withConfig(TestResources.asString("configs/multi-product.yaml"))
                 .build();
     }

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
@@ -104,8 +104,8 @@ public class GenerationPhaseGenerationRequestReconcilerIT {
                 .endMetadata()
                 .withBuildId("AABBCC")
                 .withStatus(SbomGenerationStatus.GENERATING)
-                .withEnvConfig("")
                 .withConfig(TestResources.asString("configs/multi-product.yaml"))
+                .withEnvConfig(TestResources.asString("configs/env-config.yaml"))
                 .build();
     }
 

--- a/service/src/test/resources/configs/env-config.yaml
+++ b/service/src/test/resources/configs/env-config.yaml
@@ -1,0 +1,3 @@
+# Environment config file example
+java: 11
+maven: 3.6.3


### PR DESCRIPTION
@goldmann 
With the following changes, I am adding the capability to generate CycloneDX SBOMs for Gradle builds. 

The new generation uses an init-script, to be used from the CycloneDX Gradle plugin when doing the generation, to configure properly the repositories to be used when fetching dependencies (similar to Maven settings.xml) and to configure the CycloneDX parameters used for the SBOM generation.

As Gradle depends heavily on the Gradle and JDK installed in the `sbomer-generator` container  (where we default to Java17, which is not compatible with earlier versions of Gradle thus making the SBOM generation impossible), I also had to make some changes to the TaskRuns.
I have added an intermediate `sbomer-env-config` TaskRun, to be run after the `sbomer-init` TaskRun, which fetches the build environment information used to generate a PNC build. The environment properties are stored inside the DB, and passed over to the `sbomer-generate` TaskRun which is responsible to trigger the SBOM generation. These environment information are then used to call a script which detects (and returns) the best matching software version installed in the container (the managed software types are `java`, `gradle`, `maven` for now). The best matching software version is then configured to be used prior the call to the SBOM Generation. For example, when having to generate an SBOM for a build which was built using `Gradle 5.6.2 and JDK 11`, these steps allow to search for any best matching Gradle / JDK installed locally, set them as default, and then call the generation, which otherwise would have failed.

Why did I create a new intermediate `sbomer-env-config` TaskRun and not used the `sbomer-init`? Because I did not feel like the users would need to care about the environment information. This way, if they provide a Product Config (thus letting us skip the `sbomer-init` TaskRun), they can still benefit transparently from the environment setup.