### PR TITLE
Make the gradle cyclonedx plugin version configurable with config options

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
@@ -43,10 +43,7 @@ public class GradleCycloneDxGenerateCommand extends AbstractGradleGenerateComman
     @Override
     protected Path doGenerate(String buildCmdOptions) {
         ProcessBuilder processBuilder = new ProcessBuilder().inheritIO();
-
-        // Making the plugin version configurable
-        processBuilder.command()
-                .add(String.format("PLUGIN_VERSION=%s", toolVersion()));
+        processBuilder.environment().put("PLUGIN_VERSION", toolVersion());
 
         List.of(buildCmdOptions.split(SPLIT_BY_SPACE_HONORING_SINGLE_AND_DOUBLE_QUOTES))
                 .stream()

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
@@ -44,6 +44,10 @@ public class GradleCycloneDxGenerateCommand extends AbstractGradleGenerateComman
     protected Path doGenerate(String buildCmdOptions) {
         ProcessBuilder processBuilder = new ProcessBuilder().inheritIO();
 
+        // Making the plugin version configurable
+        processBuilder.command()
+                .add(String.format("PLUGIN_VERSION=%s", toolVersion()));
+
         List.of(buildCmdOptions.split(SPLIT_BY_SPACE_HONORING_SINGLE_AND_DOUBLE_QUOTES))
                 .stream()
                 .forEach(processBuilder.command()::add);

--- a/images/sbomer-generator/cyclonedx-init.gradle
+++ b/images/sbomer-generator/cyclonedx-init.gradle
@@ -51,7 +51,7 @@ initscript {
   }
 
   dependencies {
-    classpath "org.cyclonedx:cyclonedx-gradle-plugin:1.7.4"
+    classpath "org.cyclonedx:cyclonedx-gradle-plugin:${System.env.PLUGIN_VERSION}"
   }
 }
 
@@ -70,11 +70,12 @@ allprojects {
     destination = file("build/sbom")
     // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
     outputName = "bom"
-    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
-    outputFormat = "json"
     // Exclude BOM Serial Number. Defaults to 'true'
     includeBomSerialNumber = false
+    // Below properties are suppressed to be backward compatible with older versions of plugin (1.6.1)
+    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
+    // outputFormat = "json"
     // Exclude License Text. Defaults to 'true'
-    includeLicenseText = false
+    // includeLicenseText = false
   }
 }


### PR DESCRIPTION
@goldmann Ok, here I make the plugin version configurable via config options. I might in future add some logic to override the version based on the Gradle version required, as it looks like older Gradle versions (4.10) does not work with versions 1.7.x of the plugin. But with this PR, it will be possible to specify the version via configuration.