### PR TITLE
fix(service): handle more UMB errors and force the reconnection

### DIFF
--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
@@ -148,7 +148,7 @@ public class StageGenerationRequestIT extends E2EStageBase {
         });
     }
 
-    //@Test
+    // @Test
     @Order(6)
     public void ensureUmbMessageWasSentForGradle4Build() {
         Awaitility.await().atMost(2, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS).until(() -> {


### PR DESCRIPTION
This adds handling for errors that are thrown by the system. In case of a failure, it is logged (as error, with the exception as well) and the flag of being connected is set to false. I was thinking whether this is the best approach or not.

I don't think the proposed logic is perfect. It forces reconnection on any JMS exception, but I haven't figured out (yet) more accurate representation of fatal errors.