### PR TITLE
feat(service): NCL-8201: exposure of /sboms/purl/[PURL] endpoint

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/QueryParameters.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/QueryParameters.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.rest;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class QueryParameters {
 
     String rsqlQuery;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -216,4 +216,32 @@ public class SbomService {
 
         log.debug("SBOM '{}' is valid!", sbom.getId());
     }
+
+    /**
+     * Searches for the latest generated SBOM matching the provided {@code purl}.
+     *
+     * @param purl
+     * @return The latest generated SBOM or {@code null}.
+     */
+    public Sbom findByPurl(String purl) {
+        log.debug("Trying to find latest generated SBOM for purl: '{}'", purl);
+
+        QueryParameters parameters = QueryParameters.builder()
+                .rsqlQuery("rootPurl=eq='" + purl + "'")
+                .sort("creationTime=desc=")
+                .pageSize(10)
+                .pageIndex(0)
+                .build();
+
+        List<Sbom> sboms = sbomRepository.search(parameters);
+
+        log.debug("Found {} results for the '{}' purl", sboms.size(), purl);
+
+        if (sboms.isEmpty()) {
+            return null;
+        }
+
+        return sboms.get(0);
+
+    }
 }

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
@@ -36,6 +36,7 @@ import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.rest.QueryParameters;
 import org.jboss.sbomer.service.feature.sbom.service.SbomRepository;
 import org.jboss.sbomer.service.test.utils.QuarkusTransactionalTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
This new endpoint makes it possible to retrieve the SBOM by giving just the purl. In case of multiple SBOMs will be found for a given purl, latest SBOM will be returned.

In case no SBOM can be found, 404 will be returned.

Additionally `/sboms/purl/[PURL]/bom` is exposed as well to retrieve the BOM content.