### PR TITLE
[NCL-8263] Enhance purl for all Red Hat components with repository_url

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -60,7 +60,7 @@ public class PncService {
     @Getter
     String apiUrl;
 
-    @ConfigProperty(name = "quarkus.oidc-client.enabled")
+    @ConfigProperty(name = "quarkus.oidc-client.client-enabled")
     boolean oidcClientEnabled;
 
     BuildClient buildClient;

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/utils/auth/TokensAlternative.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/utils/auth/TokensAlternative.java
@@ -27,7 +27,7 @@ import jakarta.enterprise.inject.Produces;
 import java.time.Duration;
 
 @ApplicationScoped
-@LookupIfProperty(name = "quarkus.oidc-client.enabled", stringValue = "false")
+@LookupIfProperty(name = "quarkus.oidc-client.client-enabled", stringValue = "false")
 @IfBuildProfile(anyOf = { "test", "dev" })
 /**
  * To be able to start in test mode without authorization

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -42,7 +42,7 @@ quarkus:
       format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
       stderr: true
   oidc-client:
-    enabled: true
+    client-enabled: true
     auth-server-url: http://localhost:8180/auth/realms/quarkus
     client-id: quarkus-app
     credentials:
@@ -75,7 +75,7 @@ sbomer:
         json:
           ~: false
     oidc-client:
-      enabled: false
+      client-enabled: false
 
   sbomer:
     pnc:
@@ -88,7 +88,7 @@ sbomer:
         json:
           ~: false
     oidc-client:
-      enabled: false
+      client-enabled: false
 
 
   sbomer:

--- a/cli/src/test/resources/boms/plain.json
+++ b/cli/src/test/resources/boms/plain.json
@@ -47,5 +47,50 @@
       "type": "library",
       "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?type=pom"
     }
-  }
+  },
+  "components": [
+    {
+      "publisher": "The Apache Software Foundation",
+      "group": "org.apache.logging.log4j",
+      "name": "log4j",
+      "version": "2.19.0.redhat-00001",
+      "description": "Apache Log4j 2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?type=pom",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://logging.apache.org/log4j/2.x/"
+        },
+        {
+          "type": "build-system",
+          "url": "https://github.com/apache/logging-log4j2/actions"
+        },
+        {
+          "type": "distribution",
+          "url": "https://logging.apache.org/log4j/2.x/download.html"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://issues.apache.org/jira/browse/LOG4J2"
+        },
+        {
+          "type": "mailing-list",
+          "url": "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type": "vcs",
+          "url": "https://gitbox.apache.org/repos/asf?p=logging-log4j2.git"
+        }
+      ],
+      "type": "library",
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?type=pom"
+    }
+  ]
 }

--- a/cli/src/test/resources/boms/valid.json
+++ b/cli/src/test/resources/boms/valid.json
@@ -41,8 +41,8 @@
   },
   "components": [
     {
-      "name": "jcommander",
-      "purl": "pkg:maven/com.beust/jcommander@1.72?type=jar",
+      "name": "log4j",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?type=pom",
       "type": "library",
       "group": "com.beust",
       "version": "1.72",
@@ -1077,6 +1077,20 @@
       "purl": "pkg:maven/org.jboss.arquillian.container/arquillian-container-spi@1.6.0.Final?type=jar",
       "type": "library",
       "group": "org.jboss.arquillian.container",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "08270058ba7f3f3e1754f5e739fddf12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5450e525a880b7967d5b086fdefcf88971218b4c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "122dd093db60b5fafcb428b28569aa72993e2a2c63d3d87b7dcc076bdebd8a72"
+        }
+      ],
       "version": "1.6.0.Final",
       "licenses": [
         {


### PR DESCRIPTION
This change updates the processing so that in case of a Red Hat component the purl will be enhanced with the `repository_url` pointing to https://maven.repository.redhat.com/ga.

Community components wont have this adjustment applied.

Additionally, the other commit updates the properties so that OIDC really works in dev mode :)