### PR TITLE
fix(oidc): use proper configuration properties for the OIDC client

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -60,7 +60,7 @@ public class PncService {
     @Getter
     String apiUrl;
 
-    @ConfigProperty(name = "quarkus.oidc-client.enabled")
+    @ConfigProperty(name = "quarkus.oidc-client.client-enabled")
     boolean oidcClientEnabled;
 
     BuildClient buildClient;

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/utils/auth/TokensAlternative.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/utils/auth/TokensAlternative.java
@@ -27,7 +27,7 @@ import jakarta.enterprise.inject.Produces;
 import java.time.Duration;
 
 @ApplicationScoped
-@LookupIfProperty(name = "quarkus.oidc-client.enabled", stringValue = "false")
+@LookupIfProperty(name = "quarkus.oidc-client.client-enabled", stringValue = "false")
 @IfBuildProfile(anyOf = { "test", "dev" })
 /**
  * To be able to start in test mode without authorization

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -42,7 +42,7 @@ quarkus:
       format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
       stderr: true
   oidc-client:
-    enabled: true
+    client-enabled: true
     auth-server-url: http://localhost:8180/auth/realms/quarkus
     client-id: quarkus-app
     credentials:
@@ -75,7 +75,7 @@ sbomer:
         json:
           ~: false
     oidc-client:
-      enabled: false
+      client-enabled: false
 
   sbomer:
     pnc:
@@ -88,7 +88,7 @@ sbomer:
         json:
           ~: false
     oidc-client:
-      enabled: false
+      client-enabled: false
 
 
   sbomer:


### PR DESCRIPTION
Fixes according to: https://quarkus.io/guides/all-config#quarkus-oidc-client_quarkus.oidc-client.client-enabled