### PR TITLE
Upgrade to domino 0.0.100

### DIFF
--- a/core/src/main/resources/META-INF/sbomer-config.yaml
+++ b/core/src/main/resources/META-INF/sbomer-config.yaml
@@ -22,8 +22,8 @@ sbomer:
     default-generator: maven-cyclonedx
     generators:
       maven-domino:
-        default-version: "0.0.97"
-        default-args: "--include-non-managed --warn-on-missing-scm"
+        default-version: "0.0.100"
+        default-args: "--warn-on-missing-scm"
       maven-cyclonedx:
         default-version: "2.7.9"
         default-args: "--batch-mode"

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
@@ -39,7 +39,7 @@ public class SbomerConfigProviderTest {
                 "--batch-mode",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_CYCLONEDX).defaultArgs());
         assertEquals(
-                "--include-non-managed --warn-on-missing-scm",
+                "--warn-on-missing-scm",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_DOMINO).defaultArgs());
         assertEquals("-info", defaultGenerationConfig.generators().get(GeneratorType.GRADLE_CYCLONEDX).defaultArgs());
     }

--- a/images/sbomer-generator/install.sh
+++ b/images/sbomer-generator/install.sh
@@ -59,7 +59,7 @@ function install_gradle() {
 }
 
 function install_domino() {
-  for domino_version in 0.0.90 0.0.97; do
+  for domino_version in 0.0.90 0.0.97 0.0.100; do
     curl -L https://github.com/quarkusio/quarkus-platform-bom-generator/releases/download/${domino_version}/domino.jar -o domino-${domino_version}.jar
   done
 }


### PR DESCRIPTION
* record dependency graphs instead of trees (in line with the CycloneDX Maven plugin)
* use CycloneDX spec 1.5

`--include-non-managed` is enabled by default when `--manifest` is present.