### PR TITLE
Update the Build Finder version to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.rsql-jpa>v2023.35.5</version.rsql-jpa>
         <version.commons-cli>1.6.0</version.commons-cli>
         <version.quarkus-test-artemis>3.1.2</version.quarkus-test-artemis>
-        <version.build-finder>2.2.0</version.build-finder>
+        <version.build-finder>2.3.0</version.build-finder>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This update will solve the issue of Build Finder not finding the signed artifacts in Brew, updating to the latest released version. Build Finder PR is https://github.com/project-ncl/build-finder/pull/886