### PR TITLE
fix(api): page generation requests properly

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -86,8 +86,9 @@ public class SbomService {
                 .build();
 
         List<SbomRecord> content = sbomRepository.searchSbomRecords(parameters);
+        Long count = sbomRepository.countByRsqlQuery(parameters.getRsqlQuery());
 
-        return toPage(content, parameters);
+        return toPage(content, parameters, count);
     }
 
     @WithSpan
@@ -105,8 +106,9 @@ public class SbomService {
                 .build();
 
         List<Sbom> content = sbomRepository.search(parameters);
+        Long count = sbomRepository.countByRsqlQuery(parameters.getRsqlQuery());
 
-        return toPage(content, parameters);
+        return toPage(content, parameters, count);
     }
 
     @WithSpan
@@ -124,8 +126,9 @@ public class SbomService {
                 .build();
 
         List<SbomGenerationRequest> content = sbomRequestRepository.search(parameters);
+        Long count = sbomRequestRepository.countByRsqlQuery(parameters.getRsqlQuery());
 
-        return toPage(content, parameters);
+        return toPage(content, parameters, count);
     }
 
     /**
@@ -135,10 +138,7 @@ public class SbomService {
      * @param parameters Query parameters passed to the search.
      * @return A {@link Page} element with content.
      */
-    protected <X> Page<X> toPage(List<X> content, QueryParameters parameters) {
-        // Count the total number of entries so that we can set up pagination.
-        Long count = sbomRepository.countByRsqlQuery(parameters.getRsqlQuery());
-
+    protected <X> Page<X> toPage(List<X> content, QueryParameters parameters, Long count) {
         int totalPages = 0;
 
         if (count == 0) {


### PR DESCRIPTION
When returning generation requests pages, do the paging correctly. Currently it fails because we try to  count Sbom entities instead of SbomGenerationRequests.