### PR TITLE
feat(NCL-8317): add periodic reconnects

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncMessageParser.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncMessageParser.java
@@ -178,6 +178,10 @@ public class PncMessageParser implements Runnable, ExceptionListener {
         return connected.get();
     }
 
+    public void scheduleReconnect() {
+        connected.set(false);
+    }
+
     public Message getLastMessage() {
         return lastMessage;
     }
@@ -233,8 +237,7 @@ public class PncMessageParser implements Runnable, ExceptionListener {
     @Override
     public void onException(JMSException e) {
         logFailure(e);
-
-        connected.set(false);
+        scheduleReconnect();
     }
 
 }


### PR DESCRIPTION
Add periodic reconnects in case no new messages were received over particular period of time. Currently it is configured for allowing up to 3 hours of quiet period. If more than this is discovered, a client reconnection is scheduled.