### PR TITLE
Support for SmallRye Reactive messaging

### DIFF
--- a/helm/templates/service/deployment.yaml
+++ b/helm/templates/service/deployment.yaml
@@ -35,6 +35,8 @@ spec:
               echo "#!/bin/bash" >> /mnt/secrets/env.sh;
               echo "export CONSUMER_TOPIC=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/consumer.topic)\"" >> /mnt/secrets/env.sh;
               echo "export PRODUCER_TOPIC=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/producer.topic)\"" >> /mnt/secrets/env.sh;
+              echo "export UMB_BROKER_HOST=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/umb-broker.host)\"" >> /mnt/secrets/env.sh;
+              echo "export UMB_BROKER_PORT=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/umb-broker.port)\"" >> /mnt/secrets/env.sh;
               echo "export UMB_BROKER_URL=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/qpid-jms.url)\"" >> /mnt/secrets/env.sh;
               echo "export QUARKUS_OIDC_AUTH_SERVER_URL=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/auth-server-url.txt)\"" >> /mnt/secrets/env.sh;
               echo "export QUARKUS_DATASOURCE_USERNAME=\"$(cat /mnt/secrets/${SBOMER_SECRET_NAME}-${APP_ENV}/datasource.user)\"" >> /mnt/secrets/env.sh;

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -60,6 +60,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-bootstrap-app-model</artifactId>
     </dependency>
     <dependency>
@@ -77,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
-   </dependency>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-panache</artifactId>

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/features/UmbConfig.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/features/UmbConfig.java
@@ -19,11 +19,10 @@ package org.jboss.sbomer.service.feature.sbom.config.features;
 
 import java.util.Optional;
 
-import jakarta.enterprise.context.ApplicationScoped;
-
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * @author Marek Goldmann
@@ -88,6 +87,24 @@ public interface UmbConfig {
     @WithDefault("false")
     @WithName("enabled")
     boolean isEnabled();
+
+    /**
+     * <p>
+     * Enables the new AMQP client using reactive pattern and the SmallRye Reactive framework. Please note that setting
+     * this to {@code true} will automatically disable the Qpid JMS client. If set to {@code false} the old Qpid JMS
+     * client will be used instead.
+     * </p>
+     *
+     * <p>
+     * {@see https://smallrye.io/smallrye-reactive-messaging/4.12.0/amqp/amqp/}
+     * </p>
+     *
+     * @return {@code true} if SmallRye Reactive Messaging should be used for message processing, {@code false} to use
+     *         Qpid JMS
+     */
+    @WithDefault("true")
+    @WithName("reactive")
+    boolean usesReactive();
 
     UmbConsumerConfig consumer();
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/AmqpUmbClientOptionProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/AmqpUmbClientOptionProducer.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.umb;
+
+import io.smallrye.common.annotation.Identifier;
+import io.vertx.amqp.AmqpClientOptions;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Marek Goldmann
+ */
+@Singleton
+@Slf4j
+public class AmqpUmbClientOptionProducer {
+
+    @Produces
+    @Identifier("umb")
+    public AmqpClientOptions getClientOptions() {
+        log.info("Setting up AMQP client options");
+
+        return new AmqpClientOptions().setSsl(true).setConnectTimeout(30 * 1000).setReconnectInterval(5 * 1000);
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.umb.consumer;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.sbomer.service.feature.sbom.config.features.UmbConfig;
+import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.model.PncBuildNotificationMessageBody;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An UMB message consumer that uitlizies the SmallRye Reactive messaging support with the AMQ connector.
+ *
+ * @author Marek Goldmann
+ */
+@ApplicationScoped
+@Unremovable
+@Slf4j
+public class AmqpMessageConsumer {
+
+    @Inject
+    UmbConfig umbConfig;
+
+    @Inject
+    PncBuildNotificationHandler buildNotificationHandler;
+
+    private AtomicInteger receivedMessages = new AtomicInteger(0);
+
+    public void init(@Observes StartupEvent ev) {
+        if (!umbConfig.usesReactive()) {
+            log.info("Reactive AMQP message handling is disabled in the configuration: reactive: false");
+            return;
+        }
+
+        log.info("Will use the reactive AMQP message consumer");
+
+        if (!umbConfig.isEnabled()) {
+            log.warn(
+                    "UMB feature is disabled, but this setting will be ignored because the 'sbomer.features.umb.reactive' is set to true");
+            return;
+        }
+
+        if (!umbConfig.consumer().isEnabled()) {
+            log.info(
+                    "UMB feature to consume messages is disabled, but this setting will be ignored because the 'sbomer.features.umb.reactive' is set to true");
+            return;
+        }
+    }
+
+    @Incoming("builds")
+    @Blocking(ordered = false, value = "build-processor-pool")
+    public CompletionStage<Void> process(Message<PncBuildNotificationMessageBody> message) {
+        log.debug("Received new message via the AMQP consumer");
+
+        receivedMessages.incrementAndGet();
+
+        buildNotificationHandler.handle(message.getPayload());
+
+        return message.ack();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncBuildNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncBuildNotificationHandler.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.umb.consumer;
+
+import java.util.Objects;
+
+import org.jboss.pnc.api.enums.BuildStatus;
+import org.jboss.pnc.api.enums.BuildType;
+import org.jboss.pnc.api.enums.ProgressStatus;
+import org.jboss.pnc.common.Strings;
+import org.jboss.sbomer.service.feature.sbom.config.features.UmbConfig;
+import org.jboss.sbomer.service.feature.sbom.config.features.UmbConfig.UmbConsumerTrigger;
+import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.model.PncBuildNotificationMessageBody;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Handler for PNC build notifications.
+ *
+ * @author Marek Goldmann
+ */
+@ApplicationScoped
+@Slf4j
+public class PncBuildNotificationHandler {
+
+    @Inject
+    UmbConfig config;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    /**
+     * Handles a particular message received from PNC after the build is finished.
+     *
+     * @param messageBody the body of the PNC build notification.
+     */
+    public void handle(PncBuildNotificationMessageBody messageBody) {
+        if (messageBody == null) {
+            log.warn("Received message does not contain body, ignoring");
+            return;
+        }
+
+        if (Strings.isEmpty(messageBody.getBuild().getId())) {
+            log.warn("Received message without PNC Build ID specified");
+            return;
+        }
+
+        if (Objects.equals(config.consumer().trigger().orElse(null), UmbConsumerTrigger.NONE)) {
+            log.warn(
+                    "The UMB consumer configuration is set to NONE, skipping SBOM generation for PNC Build '{}'",
+                    messageBody.getBuild().getId());
+            return;
+        }
+
+        if (isSuccessfulPersistentBuild(messageBody)) {
+            // TODO: Check whether it is a product-related build?
+
+            log.info("Triggering the automated SBOM generation for build {} ...", messageBody.getBuild().getId());
+
+            GenerationRequest req = new GenerationRequestBuilder()
+                    .withNewDefaultMetadata(messageBody.getBuild().getId())
+                    .endMetadata()
+                    .withBuildId(messageBody.getBuild().getId())
+                    .withStatus(SbomGenerationStatus.NEW)
+                    .build();
+
+            ConfigMap cm = kubernetesClient.configMaps().resource(req).create();
+
+            log.info("Request created: {}", cm.getMetadata().getName());
+        }
+    }
+
+    public boolean isSuccessfulPersistentBuild(PncBuildNotificationMessageBody msgBody) {
+        log.info(
+                "Received UMB message notification for {} build {}, with status {}, progress {} and build type {}",
+                msgBody.getBuild().isTemporaryBuild() ? "temporary" : "persistent",
+                msgBody.getBuild().getId(),
+                msgBody.getBuild().getStatus(),
+                msgBody.getBuild().getProgress(),
+                msgBody.getBuild().getBuildConfigRevision().getBuildType());
+
+        if (!msgBody.getBuild().isTemporaryBuild() && ProgressStatus.FINISHED.equals(msgBody.getBuild().getProgress())
+                && (BuildStatus.SUCCESS.equals(msgBody.getBuild().getStatus())
+                        || BuildStatus.NO_REBUILD_REQUIRED.equals(msgBody.getBuild().getStatus()))
+                && (BuildType.MVN.equals(msgBody.getBuild().getBuildConfigRevision().getBuildType())
+                        || BuildType.GRADLE.equals(msgBody.getBuild().getBuildConfigRevision().getBuildType()))) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/UmbMessageConsumer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/UmbMessageConsumer.java
@@ -89,8 +89,8 @@ public class UmbMessageConsumer implements MessageConsumer {
 
     @Override
     public void init(@Observes StartupEvent ev) {
-        if (!umbConfig.isEnabled()) {
-            log.info("UMB feature disabled");
+        if (!umbConfig.isEnabled() || umbConfig.usesReactive()) {
+            log.info("UMB feature disabled, Qpid UMB message consumer will be disabled");
             return;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/AmqpMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/AmqpMessageProducer.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.umb.producer;
+
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.GenerationFinishedMessageBody;
+
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@ApplicationScoped
+@Unremovable
+@Slf4j
+public class AmqpMessageProducer {
+
+	@Inject
+	@Channel("generation-finished")
+	Emitter<GenerationFinishedMessageBody> emitter;
+
+	public void notify(GenerationFinishedMessageBody msg) {
+		log.info("About to send notification for finished SBOM generation using the AMQP producer");
+		CompletionStage<Void> acked = emitter.send(msg);
+		acked.toCompletableFuture().join();
+	}
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -73,8 +73,8 @@ public class NotificationService {
 
     public void notifyCompleted(List<org.jboss.sbomer.service.feature.sbom.model.Sbom> sboms) {
 
-        if (!umbConfig.isEnabled()) {
-            log.info("UMB feature disabled");
+        if (!umbConfig.isEnabled() || umbConfig.usesReactive()) {
+            log.info("UMB feature disabled, Qpid UMB notification service will be disabled");
             return;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -66,6 +66,9 @@ public class NotificationService {
     UmbConfig umbConfig;
 
     @Inject
+    AmqpMessageProducer amqpMessageProducer;
+
+    @Inject
     UmbMessageProducer messageProducer;
 
     @Inject
@@ -73,8 +76,8 @@ public class NotificationService {
 
     public void notifyCompleted(List<org.jboss.sbomer.service.feature.sbom.model.Sbom> sboms) {
 
-        if (!umbConfig.isEnabled() || umbConfig.usesReactive()) {
-            log.info("UMB feature disabled, Qpid UMB notification service will be disabled");
+        if (!umbConfig.isEnabled()) {
+            log.info("UMB feature disabled, notification service won't send a notification");
             return;
         }
 
@@ -112,7 +115,13 @@ public class NotificationService {
             ValidationResult result = validator.validate(msg);
             if (result.isValid()) {
                 log.info("GenerationFinishedMessage is valid, sending it to the topic!");
-                messageProducer.sendToTopic(msg);
+
+                if (umbConfig.usesReactive()) {
+                    amqpMessageProducer.notify(msg);
+                } else {
+                    messageProducer.sendToTopic(msg);
+                }
+
             } else {
                 log.warn(
                         "GenerationFinishedMessage is NOT valid, NOT sending it to the topic! Validation errors: {}",

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/UmbMessageProducer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/UmbMessageProducer.java
@@ -64,8 +64,8 @@ public class UmbMessageProducer implements MessageProducer {
 
     @Override
     public void init(@Observes StartupEvent ev) {
-        if (!umbConfig.isEnabled()) {
-            log.info("UMB feature disabled");
+        if (!umbConfig.isEnabled() || umbConfig.usesReactive()) {
+            log.info("UMB feature disabled, Qpid UMB message producer will be disabled");
             return;
         }
 

--- a/service/src/main/resources/application-prod.yaml
+++ b/service/src/main/resources/application-prod.yaml
@@ -23,6 +23,11 @@ mp:
         port: ${UMB_BROKER_PORT}
         address: "${CONSUMER_TOPIC}"
         host: "${UMB_BROKER_HOST}"
+    outgoing:
+      generation-finished:
+        port: ${UMB_BROKER_PORT}
+        address: "${PRODUCER_TOPIC}"
+        host: "${UMB_BROKER_HOST}"
 
 sbomer:
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha2/"

--- a/service/src/main/resources/application-prod.yaml
+++ b/service/src/main/resources/application-prod.yaml
@@ -16,6 +16,14 @@
 # limitations under the License.
 #
 
+mp:
+  messaging:
+    incoming:
+      builds:
+        port: ${UMB_BROKER_PORT}
+        address: "${CONSUMER_TOPIC}"
+        host: "${UMB_BROKER_HOST}"
+
 sbomer:
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha2/"
 

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -33,6 +33,15 @@ mp:
         # that would allow to programmatically control the SmallRye Messaging subsystem.
         enabled: ${sbomer.features.umb.reactive}
         client-options-name: umb
+    outgoing:
+      generation-finished:
+        connector: smallrye-amqp
+        # This ignores the "sbomer.features.umb.enabled" property.
+        # This means that if it is disabled, we need to remember to NOT set
+        # "sbomer.features.umb.reactive" to true. I couldn't find better solution
+        # that would allow to programmatically control the SmallRye Messaging subsystem.
+        enabled: ${sbomer.features.umb.reactive}
+        client-options-name: umb
 
 quarkus:
   application:

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -16,6 +16,24 @@
 # limitations under the License.
 #
 
+smallrye:
+  messaging:
+    worker:
+      "build-processor-pool":
+        max-concurrency: 10
+
+mp:
+  messaging:
+    incoming:
+      builds:
+        connector: smallrye-amqp
+        # This ignores the "sbomer.features.umb.enabled" property.
+        # This means that if it is disabled, we need to remember to NOT set
+        # "sbomer.features.umb.reactive" to true. I couldn't find better solution
+        # that would allow to programmatically control the SmallRye Messaging subsystem.
+        enabled: ${sbomer.features.umb.reactive}
+        client-options-name: umb
+
 quarkus:
   application:
     version: ${buildNumber}
@@ -24,7 +42,7 @@ quarkus:
   banner:
     path: banner.txt
 
-  # We don't use https://quarkus.io/guides/dev-services currently 
+  # We don't use https://quarkus.io/guides/dev-services currently
   devservices:
     enabled: false
 
@@ -84,7 +102,7 @@ quarkus:
       # Just validate, do not do anything else
       generation:
         ~: validate
-  
+
   # https://docs.quarkiverse.io/quarkus-operator-sdk/dev/index.html
   operator-sdk:
     crd:
@@ -108,13 +126,15 @@ sbomer:
     umb:
       # Disable UMB feature entirely by default
       enabled: false
+      # Enables the new AMQP client based on SmallRye Reactive.
+      # If it is disabled, the old client based on Qpid will be used.
+      reactive: false
 
   # Tekton-related configuration
   tekton:
-
     # Name of the ServiceAccount used to run Tekton TaskRuns
     sa: sbomer
-  
+
   controller:
     generation-request:
       # # The directory where the content between TaskRuns (dependent resources) will be

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
@@ -35,6 +35,7 @@ import org.jboss.pnc.api.enums.BuildStatus;
 import org.jboss.pnc.api.enums.ProgressStatus;
 import org.jboss.sbomer.core.test.TestResources;
 import org.jboss.sbomer.service.feature.sbom.features.umb.JmsUtils;
+import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.PncBuildNotificationHandler;
 import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.PncMessageParser;
 import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.UmbMessageConsumer;
 import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.model.PncBuildNotificationMessageBody;
@@ -63,7 +64,7 @@ public class PncBuildIT {
     ConnectionFactory connectionFactory;
 
     @Inject
-    PncMessageParser pncMessageParser;
+    PncBuildNotificationHandler handler;
 
     @Test
     @Order(1)
@@ -98,7 +99,7 @@ public class PncBuildIT {
         assertEquals(ProgressStatus.FINISHED, msgBody.getBuild().getProgress());
         assertEquals("AX5TJMYHQAIAE", msgBody.getBuild().getId());
 
-        assertTrue(pncMessageParser.isSuccessfulPersistentBuild(msgBody));
+        assertTrue(handler.isSuccessfulPersistentBuild(msgBody));
     }
 
     private TextMessage preparePNCBuildMsg(JMSContext context) throws IOException {


### PR DESCRIPTION
https://issues.redhat.com/browse/NCL-8323

This is an attempt to implement support for sending UMB messages using the SmallRye Reactive Messaging framework. It looks like its much more elegant to use and I hope it will be more stable as well. Switching from Qpid makes handling of receiving and sending messages much easier.

This is added in addition to the already existing Qpid support. I hope to test this on stage and eventually remove qpid support entirely.