### PR TITLE
test: make e2e tests run concurrently

### DIFF
--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
@@ -26,17 +26,17 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.hamcrest.CoreMatchers;
 import org.jboss.sbomer.test.e2e.E2EStageBase;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Tag("stage")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class StageGenerationRequestIT extends E2EStageBase {
 
     static Path sbomPath(String fileName) {

--- a/e2e/src/test/resources/junit-platform.properties
+++ b/e2e/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = same_thread

--- a/e2e/src/test/resources/logging.properties
+++ b/e2e/src/test/resources/logging.properties
@@ -1,0 +1,13 @@
+logger.level=DEBUG
+
+logger.handlers=CONSOLE
+
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=INFO
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c{1}] %m%n


### PR DESCRIPTION
Small caveat is that the logs are now mixed, like this:

```
14:48:49,534 INFO  [StageGenerationRequestIT] Gradle 5 build - Current generation request status: ENV_DETECTING
14:48:49,535 INFO  [StageGenerationRequestIT] Maven build - Current generation request status: INITIALIZING
14:48:49,537 INFO  [StageGenerationRequestIT] Gradle 4 build - Current generation request status: ENV_DETECTING
14:48:55,052 INFO  [StageGenerationRequestIT] Gradle 5 build - Current generation request status: ENV_DETECTING
14:48:55,060 INFO  [StageGenerationRequestIT] Maven build - Current generation request status: INITIALIZING
14:48:55,063 INFO  [StageGenerationRequestIT] Gradle 4 build - Current generation request status: ENV_DETECTING
14:49:00,568 INFO  [StageGenerationRequestIT] Maven build - Current generation request status: INITIALIZING
14:49:00,572 INFO  [StageGenerationRequestIT] Gradle 4 build - Current generation request status: ENV_DETECTING
14:49:00,573 INFO  [StageGenerationRequestIT] Gradle 5 build - Current generation request status: ENV_DETECTING
```