### PR TITLE
docs: rename the main module from sbomer to antora

### DIFF
--- a/antora-playbook-dev.yml
+++ b/antora-playbook-dev.yml
@@ -18,7 +18,7 @@
 
 site:
   title: SBOMer Documentation
-  start_page: sbomer::index.adoc
+  start_page: docs::index.adoc
 content:
   sources:
     - url: ./

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -18,7 +18,7 @@
 
 site:
   title: SBOMer Documentation
-  start_page: sbomer::index.adoc
+  start_page: docs::index.adoc
 content:
   sources:
     # - url: https://github.com/project-ncl/sbomer.git

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-name: sbomer
+name: docs
 title: SBOMer Documentation
 version: latest
 


### PR DESCRIPTION
This ensures a better URL after publishing to GitLab pages.