### PR TITLE
feat(SBOMER-45): record should match what is in the entity

### DIFF
--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/SBOMerClientTestIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/SBOMerClientTestIT.java
@@ -55,6 +55,7 @@ public class SBOMerClientTestIT {
         assertEquals(Status.OK.getStatusCode(), response.getStatus());
         Sbom sbom = response.readEntity(Sbom.class);
         assertNotNull(sbom);
+        assertNotNull(sbom.getSbom());
         assertEquals("123", sbom.getId());
         assertEquals("QUARKUS", sbom.getBuildId());
         assertNotNull(sbom.getGenerationRequest());

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomRecord.java
@@ -28,7 +28,7 @@ public record SbomRecord(
         Instant creationTime,
         Integer configIndex,
         String statusMessage,
-        SbomGenerationRequestRecord sbomGenerationRequest) {
+        SbomGenerationRequestRecord generationRequest) {
 
     public SbomRecord(
             String id,

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SBOMResourceIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SBOMResourceIT.java
@@ -46,7 +46,13 @@ public class SBOMResourceIT {
     @Test
     public void testExistenceOfSbomsEndpoint() {
         Mockito.when(sbomService.searchSbomsByQueryPaginated(0, 50, null, null)).thenReturn(new Page<>());
-        given().when().get("/api/v1alpha2/sboms").then().statusCode(200);
+        given().when()
+                .get("/api/v1alpha2/sboms")
+                .then()
+                .statusCode(200)
+                .body("totalHits", CoreMatchers.is(1))
+                .and()
+                .body("content[0].generationRequest.id", CoreMatchers.is("AASSBB"));
     }
 
     @Test


### PR DESCRIPTION
This fixes the case where there is a difference in the respose between v1alpha1 and v1alpha2 API. The /sboms endpoint returned elements with `sbomGenerationRequest` field, but it should be `generationRequest` instead.