### PR TITLE
feat(SBOMER-54): HAProxy load balancer

### DIFF
--- a/helm/env/prod.yaml
+++ b/helm/env/prod.yaml
@@ -7,6 +7,7 @@ cache:
     repository: quay.io/rh-newcastle/sbomer-cache
 
 service:
+  enabled: true
   route: 
     enabled: true
   storage:
@@ -17,3 +18,6 @@ service:
 generator:
   image:
     repository: quay.io/rh-newcastle/sbomer-generator
+
+lb:
+  enabled: true

--- a/helm/env/stage.yaml
+++ b/helm/env/stage.yaml
@@ -8,6 +8,7 @@ cache:
     tag: latest
 
 service:
+  enabled: true
   route:
     enabled: true
   storage:
@@ -20,3 +21,6 @@ generator:
   image:
     repository: quay.io/rh-newcastle-stage/sbomer-generator
     tag: latest
+
+lb:
+  enabled: true

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -6,6 +6,18 @@ Define the name of the cache component
 {{- end -}}
 
 {{/*
+Target route service. In case the loabalancer is enabled, then the route will point
+to the loadbalancer service and if not -- to the main deployment service.
+*/}}
+{{- define "sbomer.routeTarget" -}}
+{{- if .Values.lb.enabled -}}
+{{ .Release.Name }}-lb
+{{- else -}}
+{{ .Release.Name }}-service
+{{- end -}}
+{{- end -}}
+
+{{/*
 SBOMer internal product mapping
 */}}
 {{- define "sbomer.productMapping" -}}

--- a/helm/templates/lb/cm.yaml
+++ b/helm/templates/lb/cm.yaml
@@ -1,0 +1,55 @@
+{{ if .Values.lb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-lb
+{{ include "sbomer.labels" (list . "lb") | indent 2 }}
+data:
+  haproxy.cfg: |
+    global
+      daemon
+      maxconn 256
+
+        # modern configuration https://ssl-config.mozilla.org/#server=haproxy&version=2.9&config=modern&openssl=1.1.1k&guideline=5.7
+        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets
+
+        ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-server-options no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12 no-tls-tickets
+
+    defaults
+      mode http
+      option httpslog
+      log global
+      timeout connect 5000ms
+      timeout client 50000ms
+      timeout server 50000ms
+
+    frontend sbomer
+      log stdout format raw daemon debug
+      bind *:8080
+      bind *:8443 ssl crt /etc/ssl/certs/sbomer/cert.pem alpn h2,http/1.1
+      # Redirect http to https
+      http-request redirect scheme https unless { ssl_fc }
+      http-response set-header Strict-Transport-Security max-age=63072000
+
+      default_backend servers
+
+    backend servers
+      # Check whether the service is running properly
+      option httpchk
+      http-check connect ssl alpn h2 sni "${SBOMER_DOMAIN}"
+      http-check send meth GET uri /q/health ver HTTP/2 hdr host "${SBOMER_DOMAIN}"
+      http-check expect status 200
+      http-check expect string '"status": "UP"'
+
+      server local "${SBOMER_SERVICE_SERVICE_HOST}:443" maxconn 32 check inter 5s fall 5 rise 10 ssl verify required ca-file /etc/ssl/certs/sbomer/ca.pem verifyhost "${SBOMER_DOMAIN}"
+      server external "${SBOMER_ROUTE_EXTERNAL_HOST}:443" backup maxconn 32 check inter 5s fall 5 rise 10 ssl verify required ca-file /etc/ssl/certs/sbomer/ca.pem verifyhost "${SBOMER_DOMAIN}"
+
+    frontend stats
+      bind *:9901
+      stats enable
+      stats uri /
+        stats refresh 10s
+        stats admin if LOCALHOST
+{{ end }}

--- a/helm/templates/lb/secret.yaml
+++ b/helm/templates/lb/secret.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.lb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-lb
+{{ include "sbomer.labels" (list . "lb") | indent 2 }}
+type: Opaque
+data:
+  cert.pem: |
+{{ printf "%s\n%s\n" .Values.service.route.tls.key .Values.service.route.tls.caCertificate | b64enc | indent 4 }}
+  ca.pem: |
+{{ .Values.service.route.tls.caCertificate | b64enc | indent 4 }}
+{{ end }}

--- a/helm/templates/lb/service.yaml
+++ b/helm/templates/lb/service.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.lb.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lb
+{{ include "sbomer.labels" (list . "lb") | indent 2 }}
+spec:
+  selector:
+{{ include "sbomer.selector" (list . "lb") | indent 4 }}
+  type: ClusterIP
+  ports:
+    - name: https
+      port: 8443
+{{ end }}

--- a/helm/templates/lb/statefulset.yaml
+++ b/helm/templates/lb/statefulset.yaml
@@ -1,0 +1,51 @@
+{{ if .Values.lb.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-lb
+{{ include "sbomer.labels" (list . "lb") | indent 2 }}
+spec:
+  serviceName: {{ .Release.Name }}-lb
+  replicas: 2
+  selector:
+    matchLabels:
+{{ include "sbomer.selector" (list . "lb") | indent 6 }}
+  template:
+    metadata:
+{{ include "sbomer.labels" (list . "lb") | indent 6 }}
+    spec:
+      serviceAccountName: {{ include "sbomer.serviceAccountName" . }}
+      containers:
+        - image: haproxy:2.9.6-alpine
+          imagePullPolicy: IfNotPresent
+          name: {{ .Release.Name }}-lb
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 300m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: lb-certs
+              readOnly: true
+              mountPath: "/etc/ssl/certs/sbomer"
+            - name: lb-config
+              readOnly: true
+              mountPath: "/usr/local/etc/haproxy"
+          env:
+            - name: SBOMER_ROUTE_EXTERNAL_HOST
+              value: {{ .Values.service.route.external.host }}
+            - name: SBOMER_DOMAIN
+              value: {{ .Values.service.route.infinibloxHost }}
+      volumes:
+        - name: lb-certs
+          secret:
+            secretName: {{ .Release.Name }}-lb
+        - name: lb-config
+          configMap:
+            name: {{ .Release.Name }}-lb
+{{ end }}

--- a/helm/templates/service/deployment.yaml
+++ b/helm/templates/service/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Values.env "dev" }}
+{{ if .Values.service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/service/infiniblox-route.yaml
+++ b/helm/templates/service/infiniblox-route.yaml
@@ -12,7 +12,7 @@ spec:
   host: {{ .Values.service.route.infinibloxHost }}
   to:
     kind: Service
-    name: {{ .Release.Name }}-service
+    name: {{ include "sbomer.routeTarget" . }}
     weight: 100
   wildcardPolicy: None
   port:

--- a/helm/templates/service/route.yaml
+++ b/helm/templates/service/route.yaml
@@ -12,7 +12,7 @@ spec:
   host: {{ .Values.service.route.host }}
   to:
     kind: Service
-    name: {{ .Release.Name }}-service
+    name: {{ include "sbomer.routeTarget" . }}
     weight: 100
   wildcardPolicy: None
   port:

--- a/helm/templates/service/service.yaml
+++ b/helm/templates/service/service.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Values.env "dev" }}
+{{ if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -63,6 +63,7 @@ cache:
     pullPolicy: IfNotPresent
 
 service:
+  enabled: false
   # service.route Controls the Route creation on OpenShift
   route:
     # Disabled by default, enabled only in OpenShift environments


### PR DESCRIPTION
Introduction of HAProxy load balancer. It is only enabled in stage and prod environments.

Introduction of `service.enabled` Helm value. It is not currently actively used, but it's a preparation for better modularization of components.

To deploy a load balancer enabled following Helm values needs to be set:

- `service.route.external.host` -- this should be a name of a host that is external to the current cluster. Considering cluster A and B. If we are deploying this in Cluster A, it should be the host name of OpenShift router of cluster B.
- `service.route.infinibloxHost` -- the DNS name of the SBOMer service for a given environment (stage, prod).

https://issues.redhat.com/browse/SBOMER-54