### PR TITLE
feat: add support for feature-flags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,6 @@ promote:
     KUBERNETES_MEMORY_REQUEST: "256Mi"
     KUBERNETES_MEMORY_LIMIT: "256Mi"
   stage: deploy
-  when: manual
   resource_group: deploy
   script:
     - dnf install -y --setopt=tsflags=nodocs skopeo
@@ -207,6 +206,7 @@ promote:
 deploy-prod:
   extends:
     - .deploy
+  when: manual
   variables:
     APP_ENV: prod
   environment: gitlab-cd-prod-spoke-aws-us-east-1

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <version.pnc-rest>2.6.10</version.pnc-rest>
         <version.pnc-common>2.4.0-alpha</version.pnc-common>
         <version.quarkus-jgit>3.0.7</version.quarkus-jgit>
+        <version.quarkus-unleash>1.5.0</version.quarkus-unleash>
         <version.tekton-client>1.0.1</version.tekton-client>
         <version.rsql-parser>2.1.0</version.rsql-parser>
         <version.rsql-jpa>v2023.35.5</version.rsql-jpa>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>quarkus-oidc</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkiverse.unleash</groupId>
+      <artifactId>quarkus-unleash</artifactId>
+      <version>${version.quarkus-unleash}</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-keycloak-authorization</artifactId>
     </dependency>

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/FeatureFlags.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/FeatureFlags.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.getunleash.FeatureToggle;
+import io.getunleash.Unleash;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.repository.FeatureToggleResponse;
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An entrypoint for all feature flags supported in SBOMer.
+ */
+@ApplicationScoped
+@Unremovable
+@Getter
+@Slf4j
+public class FeatureFlags implements UnleashSubscriber {
+    private static final String TOGGLE_DRY_RUN = "dry-run";
+
+    /**
+     * A map holding all toggle values we are interested in. This is used for logging purposes. We are retrieving the
+     * state of the toggle via {@link Unleash} object instead.
+     */
+    private final Map<String, Boolean> toggleValues = new HashMap<>();
+
+    @Inject
+    Unleash unleash;
+
+    /**
+     * Returns {@code true} in case the dry-run mode is enabled.
+     *
+     * @return {@code true} if dry-run is enabled, {@code false} otherwise
+     */
+    public boolean isDryRun() {
+        return unleash.isEnabled(TOGGLE_DRY_RUN, false);
+    }
+
+    private void updateToggles(final FeatureToggleResponse toggleResponse) {
+        for (String toggleName : Set.of(TOGGLE_DRY_RUN)) {
+            FeatureToggle toggle = toggleResponse.getToggleCollection().getToggle(toggleName);
+
+            if (toggle != null) {
+                Boolean previousValue = toggleValues.put(toggleName, toggle.isEnabled());
+
+                if (previousValue == null || previousValue != toggle.isEnabled()) {
+                    log.info("Feature toggle {} was just {}", toggleName, toggle.isEnabled() ? "enabled" : "disabled");
+                }
+            } else {
+                log.debug("Feature toggle {} was disabled", toggleName);
+                toggleValues.remove(toggleName);
+            }
+        }
+
+        try {
+            log.debug("Current feature toggles: {}", ObjectMapperProvider.json().writeValueAsString(toggleValues));
+        } catch (JsonProcessingException e) {
+            // Ignored
+        }
+    }
+
+    /**
+     * A callback which will be called when feature flags will be retreieved.
+     */
+    @Override
+    public void togglesFetched(FeatureToggleResponse toggleResponse) {
+        switch (toggleResponse.getStatus()) {
+            case CHANGED:
+                log.debug("Feature flags change detected, procesing...");
+                updateToggles(toggleResponse);
+                break;
+            case NOT_CHANGED:
+                log.debug("No changes detected to feature flags");
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -37,6 +37,7 @@ import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
 import org.jboss.sbomer.service.feature.sbom.config.features.ProductConfig;
 import org.jboss.sbomer.service.feature.sbom.config.features.UmbConfig;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Operation;
+import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Build;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.Build.BuildSystem;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.model.GenerationFinishedMessageBody;
@@ -66,6 +67,9 @@ public class NotificationService {
     SbomRepository sbomRepository;
 
     @Inject
+    FeatureFlags featureFlags;
+
+    @Inject
     UmbConfig umbConfig;
 
     @Inject
@@ -78,9 +82,13 @@ public class NotificationService {
     OperationGenerationFinishedMessageBodyValidator operationValidator;
 
     public void notifyCompleted(List<org.jboss.sbomer.service.feature.sbom.model.Sbom> sboms) {
+        if (!featureFlags.isDryRun()) {
+            log.info("SBOMer running in dry-run mode, notification service won't send the notification");
+            return;
+        }
 
         if (!umbConfig.isEnabled()) {
-            log.info("UMB feature disabled, notification service won't send a notification");
+            log.info("UMB feature disabled, notification service won't send the notification");
             return;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -82,7 +82,7 @@ public class NotificationService {
     OperationGenerationFinishedMessageBodyValidator operationValidator;
 
     public void notifyCompleted(List<org.jboss.sbomer.service.feature.sbom.model.Sbom> sboms) {
-        if (!featureFlags.isDryRun()) {
+        if (featureFlags.isDryRun()) {
             log.info("SBOMer running in dry-run mode, notification service won't send the notification");
             return;
         }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/runtime/ApplicationLifecycle.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/runtime/ApplicationLifecycle.java
@@ -19,6 +19,9 @@ package org.jboss.sbomer.service.feature.sbom.runtime;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
 
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
@@ -33,7 +36,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ApplicationLifecycle {
 
+    @Inject
+    FeatureFlags featureFlags;
+
     void onStart(@Observes StartupEvent event) {
+        log.info("SBOMer will run in dry-run mode");
 
         // we need to log startup and shutdown events
         log.info("Application has started");

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/runtime/ApplicationLifecycle.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/runtime/ApplicationLifecycle.java
@@ -40,8 +40,6 @@ public class ApplicationLifecycle {
     FeatureFlags featureFlags;
 
     void onStart(@Observes StartupEvent event) {
-        log.info("SBOMer will run in dry-run mode");
-
         // we need to log startup and shutdown events
         log.info("Application has started");
     }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -25,7 +25,6 @@ import org.jboss.sbomer.core.errors.ValidationException;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.core.features.sbom.utils.UrlUtils;
 import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
-import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
@@ -58,9 +57,6 @@ public class SbomService {
 
     @Inject
     Validator validator;
-
-    @Inject
-    FeatureFlags featureFlags;
 
     @Inject
     NotificationService notificationService;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -25,6 +25,7 @@ import org.jboss.sbomer.core.errors.ValidationException;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.core.features.sbom.utils.UrlUtils;
 import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
+import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
@@ -57,6 +58,9 @@ public class SbomService {
 
     @Inject
     Validator validator;
+
+    @Inject
+    FeatureFlags featureFlags;
 
     @Inject
     NotificationService notificationService;

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -53,6 +53,19 @@ quarkus:
       group-id: com.fasterxml.jackson.jakarta.rs
       artifact-id: jackson-jakarta-rs-yaml-provider
 
+  # Support for feature-flags
+  unleash:
+    # Disable extension by default
+    active: false
+    # By default we use the 'dev' application name
+    application: dev
+    # Fetch flags every 30s
+    fetch-toggles-interval: 30
+    # Fetch initial update in synchronous way
+    synchronous-fetch-on-initialisation: true
+    # The Unleash server URL
+    url: "https://localhost"
+
   # Default logging settings
   log:
     level: INFO

--- a/service/src/main/resources/db-update/00010-1.0.2.sql
+++ b/service/src/main/resources/db-update/00010-1.0.2.sql
@@ -41,5 +41,10 @@ BEGIN transaction;
     CREATE INDEX idx_request_identifier ON sbom_generation_request (identifier);
     CREATE INDEX idx_request_type ON sbom_generation_request (type);
 
+    INSERT INTO
+        db_version (version, creation_time)
+    VALUES
+        ('00010', now ());
+
 COMMIT;
 


### PR DESCRIPTION
Initial implementation adds support for a single `dry-run` toggle. When enabled, no changes will be allowed to be made via the REST API returning 405 HTTP code.

Support for disabling UMB processing will be added later, because it is non-trivial to disable/enable it on demand.

In dev mode, feature flags are disabled entirely and default values from `FeatureFlags` class will be used.