### PR TITLE
feat(SBOMER-49): improvements in error handling

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/CLI.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/CLI.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.jboss.sbomer.cli.errors.SbomerExitCodeExceptionMapper;
+
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 
@@ -67,6 +69,8 @@ public class CLI implements QuarkusApplication {
             log.debug("Registering '{}' subcommand", cmd.getClass().getName());
             commandLine.addSubcommand(cmd);
         });
+
+        commandLine.setExitCodeExceptionMapper(new SbomerExitCodeExceptionMapper());
 
         return commandLine.execute(args);
     }

--- a/cli/src/main/java/org/jboss/sbomer/cli/ExceptionHandler.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/ExceptionHandler.java
@@ -17,7 +17,13 @@
  */
 package org.jboss.sbomer.cli;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
 import org.jboss.sbomer.core.errors.ClientException;
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 
 import picocli.CommandLine;
 import picocli.CommandLine.IExecutionExceptionHandler;
@@ -55,8 +61,20 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
             ex.printStackTrace(cmd.getErr());
         }
 
-        return cmd.getExitCodeExceptionMapper() != null ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
+        int exitCode = cmd.getExitCodeExceptionMapper() != null ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
                 : cmd.getCommandSpec().exitCodeOnExecutionException();
+
+        String failureReasonPath = System.getenv("SBOMER_CLI_FAILURE_REASON_PATH");
+
+        if (failureReasonPath != null) {
+            Files.write(
+                    Path.of(failureReasonPath),
+                    ObjectMapperProvider.json()
+                            .writeValueAsString(Map.of("message", ex.getMessage(), "exitCode", exitCode))
+                            .getBytes(StandardCharsets.UTF_8));
+        }
+
+        return exitCode;
     }
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/CommandLineException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/CommandLineException.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.errors;
+
+import org.jboss.sbomer.core.errors.ApplicationException;
+
+/**
+ * <p>
+ * This exception can be used to indicate a failure in the CLI. Provided {@code exitCode} will be used when the CLI
+ * finishes.
+ * </p>
+ */
+public abstract class CommandLineException extends ApplicationException {
+    private int exitCode = 1;
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public CommandLineException(ApplicationException ex) {
+        super(ex.getMessage());
+    }
+
+    public CommandLineException(int exitCode, ApplicationException ex) {
+        super(ex.getMessage());
+
+        this.exitCode = exitCode;
+    }
+
+    public CommandLineException(int exitCode, String msg, Object... params) {
+        super(msg, params);
+
+        this.exitCode = exitCode;
+    }
+
+    public CommandLineException(String msg, Object... params) {
+        super(msg, params);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/GitCloneException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/GitCloneException.java
@@ -15,21 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.errors;
+package org.jboss.sbomer.cli.errors;
 
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.ext.Provider;
-import lombok.extern.slf4j.Slf4j;
+import org.jboss.sbomer.core.errors.ApplicationException;
 
-@Slf4j
-@Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
-    @Override
-    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
+public class GitCloneException extends CommandLineException {
 
-        return responseBuilder.build();
+    private static final int EXIT_CODE = 200;
+
+    public GitCloneException(String msg, Object... params) {
+        super(GitCloneException.EXIT_CODE, msg, params);
+    }
+
+    public GitCloneException(ApplicationException e) {
+        super(GitCloneException.EXIT_CODE, e);
     }
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/SbomerExitCodeExceptionMapper.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/SbomerExitCodeExceptionMapper.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.errors;
+
+import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.IExitCodeExceptionMapper;
+import picocli.CommandLine.UnmatchedArgumentException;
+
+/**
+ * Takes care of providing appropriate {@code exitCode} so that the execution can be terminated with the correct one.
+ */
+public class SbomerExitCodeExceptionMapper implements IExitCodeExceptionMapper {
+
+    /**
+     * Returns {@code exitCode} for known exceptions or {@code 1} otherwise.
+     */
+    @Override
+    public int getExitCode(Throwable exception) {
+        if (exception instanceof CommandLineException) {
+            return ((CommandLineException) exception).getExitCode();
+        }
+
+        if (exception instanceof UnmatchedArgumentException) {
+            return ExitCode.USAGE;
+        }
+
+        return ExitCode.SOFTWARE;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/GeneralPncException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/GeneralPncException.java
@@ -15,23 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.rest.v1alpha3;
+package org.jboss.sbomer.cli.errors.pnc;
 
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.sbomer.cli.errors.CommandLineException;
+import org.jboss.sbomer.core.errors.ApplicationException;
 
-import jakarta.annotation.security.PermitAll;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
+/**
+ * General error related to PNC.
+ */
+public class GeneralPncException extends CommandLineException {
+    private static final int EXIT_CODE = 30;
 
-@Path("/api/v1alpha3/stats")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
-@ApplicationScoped
-@Tag(name = "v1alpha3")
-@PermitAll
-public class StatsResources extends org.jboss.sbomer.service.feature.sbom.rest.v1alpha2.StatsResources {
+    public GeneralPncException(String msg, Object... params) {
+        super(GeneralPncException.EXIT_CODE, msg, params);
+    }
+
+    public GeneralPncException(ApplicationException e) {
+        super(GeneralPncException.EXIT_CODE, e);
+    }
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/InvalidPncBuildStateException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/InvalidPncBuildStateException.java
@@ -15,11 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.dto.v1alpha3;
+package org.jboss.sbomer.cli.errors.pnc;
 
-import java.time.Instant;
+import org.jboss.sbomer.cli.errors.CommandLineException;
+import org.jboss.sbomer.core.errors.ApplicationException;
 
-import com.fasterxml.jackson.databind.JsonNode;
+/**
+ * Error indicating a failure related to the build progress or status received from PNC.
+ */
+public class InvalidPncBuildStateException extends CommandLineException {
+    private static final int EXIT_CODE = 31;
 
-public record BaseSbomGenerationRequestRecord(String id, String identifier, JsonNode config, String type, Instant creationTime) {
-};
+    public InvalidPncBuildStateException(String msg, Object... params) {
+        super(InvalidPncBuildStateException.EXIT_CODE, msg, params);
+    }
+
+    public InvalidPncBuildStateException(ApplicationException e) {
+        super(InvalidPncBuildStateException.EXIT_CODE, e);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/MissingPncBuildException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/MissingPncBuildException.java
@@ -15,21 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.errors;
+package org.jboss.sbomer.cli.errors.pnc;
 
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.ext.Provider;
-import lombok.extern.slf4j.Slf4j;
+import org.jboss.sbomer.cli.errors.CommandLineException;
+import org.jboss.sbomer.core.errors.ApplicationException;
 
-@Slf4j
-@Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
-    @Override
-    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
+/**
+ * Error indicating that the requested PNC build does not exist in PNC.
+ */
+public class MissingPncBuildException extends CommandLineException {
+    private static final int EXIT_CODE = 33;
 
-        return responseBuilder.build();
+    public MissingPncBuildException(String msg, Object... params) {
+        super(MissingPncBuildException.EXIT_CODE, msg, params);
+    }
+
+    public MissingPncBuildException(ApplicationException e) {
+        super(MissingPncBuildException.EXIT_CODE, e);
     }
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/UnsupportedPncBuildException.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/errors/pnc/UnsupportedPncBuildException.java
@@ -15,21 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.errors;
+package org.jboss.sbomer.cli.errors.pnc;
 
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.ext.Provider;
-import lombok.extern.slf4j.Slf4j;
+import org.jboss.sbomer.cli.errors.CommandLineException;
+import org.jboss.sbomer.core.errors.ApplicationException;
 
-@Slf4j
-@Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
-    @Override
-    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
+/**
+ * Error indicating that the PNC build type is not yet supported in SBOMer.
+ */
+public class UnsupportedPncBuildException extends CommandLineException {
+    private static final int EXIT_CODE = 32;
 
-        return responseBuilder.build();
+    public UnsupportedPncBuildException(String msg, Object... params) {
+        super(UnsupportedPncBuildException.EXIT_CODE, msg, params);
+    }
+
+    public UnsupportedPncBuildException(ApplicationException e) {
+        super(UnsupportedPncBuildException.EXIT_CODE, e);
     }
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/ClientExceptionMapper.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/ClientExceptionMapper.java
@@ -35,7 +35,7 @@ public class ClientExceptionMapper implements ExceptionMapper<ClientException> {
     public Response toResponse(ClientException ex) {
         ErrorResponse error = ErrorResponse.builder()
                 .errorId(ex.getErrorId())
-                .errorType(ex.getClass().getSimpleName())
+                .error(ex.getClass().getSimpleName())
                 .message(ex.getMessage())
                 .errors(ex.getErrors())
                 .build();

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateConfigCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateConfigCommand.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.ProductVersionRef;
+import org.jboss.sbomer.cli.errors.pnc.MissingPncBuildException;
 import org.jboss.sbomer.cli.feature.sbom.ConfigReader;
 import org.jboss.sbomer.cli.feature.sbom.ProductVersionMapper;
 import org.jboss.sbomer.cli.feature.sbom.command.PathConverter;
@@ -363,8 +364,7 @@ public class GenerateConfigCommand implements Callable<Integer> {
         Build build = pncService.getBuild(this.buildId);
 
         if (build == null) {
-            log.error("Could not retrieve PNC build '{}'", this.buildId);
-            return GenerationResult.ERR_GENERAL.getCode();
+            throw new MissingPncBuildException("Could not retrieve PNC build '{}'", this.buildId);
         }
 
         if (config == null) {

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -47,6 +47,7 @@ import org.jboss.pnc.dto.GroupConfigurationRef;
 import org.jboss.pnc.dto.ProductMilestone;
 import org.jboss.pnc.dto.ProductVersion;
 import org.jboss.pnc.dto.ProductVersionRef;
+import org.jboss.sbomer.cli.errors.pnc.GeneralPncException;
 import org.jboss.pnc.dto.response.AnalyzedArtifact;
 import org.jboss.sbomer.core.errors.ApplicationException;
 
@@ -146,7 +147,7 @@ public class PncService {
             log.warn("Build with id '{}' was not found in PNC", buildId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException("Build could not be retrieved because PNC responded with an error", ex);
+            throw new GeneralPncException("Build could not be retrieved because PNC responded with an error", ex);
         }
     }
 
@@ -171,9 +172,7 @@ public class PncService {
             log.warn("BuildConfig with id '{}' was not found in PNC", buildConfigId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
-                    "BuildConfig could not be retrieved because PNC responded with an error",
-                    ex);
+            throw new GeneralPncException("BuildConfig could not be retrieved because PNC responded with an error", ex);
         }
     }
 
@@ -198,7 +197,7 @@ public class PncService {
             log.warn("GroupConfiguration with id '{}' was not found in PNC", groupConfigId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "GroupConfiguration could not be retrieved because PNC responded with an error",
                     ex);
         }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/AlternativePncService.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/AlternativePncService.java
@@ -29,8 +29,14 @@ import org.jboss.pnc.dto.BuildConfigurationRevisionRef;
 import org.jboss.pnc.dto.Environment;
 import org.jboss.pnc.dto.ProductVersionRef;
 import org.jboss.pnc.dto.SCMRepository;
+import org.jboss.pnc.enums.BuildProgress;
+import org.jboss.pnc.enums.BuildStatus;
+import org.jboss.pnc.enums.BuildType;
 import org.jboss.sbomer.cli.feature.sbom.service.PncService;
 
+/**
+ * Currently unused, but may be in the future.
+ */
 @Alternative
 @Singleton
 public class AlternativePncService extends PncService {
@@ -48,7 +54,11 @@ public class AlternativePncService extends PncService {
                 .scmTag("scmtag")
                 .scmRevision("scmrevision")
                 .scmUrl("scmurl")
-                .buildConfigRevision(BuildConfigurationRevisionRef.refBuilder().id("BCID").build())
+                .buildConfigRevision(
+                        BuildConfigurationRevisionRef.refBuilder().buildType(BuildType.MVN).id("BCID").build())
+                .temporaryBuild(false)
+                .status(BuildStatus.BUILDING)
+                .progress(BuildProgress.IN_PROGRESS)
                 .build();
     }
 

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/BaseGenerateCommandIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/BaseGenerateCommandIT.java
@@ -1,0 +1,65 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.test.integ.feature.sbom.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+/**
+ * General tests that apply to all generation commands.
+ */
+@QuarkusMainTest
+public class BaseGenerateCommandIT {
+    @Test
+    @DisplayName("Should fail in case of build not found in PNC")
+    void shouldFailForMissingBuild(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher.launch("-v", "sbom", "generate", "--build-id", "NOTEXISTING", "maven-cyclonedx");
+        assertEquals(33, result.exitCode());
+        assertTrue(result.getErrorOutput().contains("Could not fetch the PNC build with id 'NOTEXISTING'"));
+    }
+
+    @Test
+    @DisplayName("Should fail in case the PNC build is still in progress")
+    void shouldFailForBuildInProgress(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher.launch("-v", "sbom", "generate", "--build-id", "IN_PROGRESS", "maven-cyclonedx");
+        assertEquals(31, result.exitCode());
+        assertTrue(
+                result.getErrorOutput()
+                        .contains(
+                                "Build 'IN_PROGRESS' is not valid! Progress needs to be 'FINISHED' with status 'SUCCESS' or 'NO_REBUILD_REQUIRED'. Currently: progress: 'IN_PROGRESS', status: 'BUILDING'"));
+    }
+
+    @Test
+    @DisplayName("Should fail in case the PNC build type is not supported")
+    void shouldFailForInvalidBuildType(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher
+                .launch("-v", "sbom", "generate", "--build-id", "UNSUPPORTED_BUILD_TYPE", "maven-cyclonedx");
+        assertEquals(32, result.exitCode());
+        assertTrue(
+                result.getErrorOutput()
+                        .contains("The generation of SBOMs for the build type 'SBT' is not yet implemented"));
+    }
+
+}

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/CycloneDXPluginMavenGenerateCommandIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/CycloneDXPluginMavenGenerateCommandIT.java
@@ -17,34 +17,15 @@
  */
 package org.jboss.sbomer.cli.test.integ.feature.sbom.command;
 
-import java.util.Set;
-
-import org.jboss.sbomer.cli.test.integ.feature.sbom.AlternativePncService;
-import org.jboss.sbomer.cli.test.integ.feature.sbom.command.CycloneDXPluginMavenGenerateCommandIT.CustomPncServiceProfile;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
-import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.QuarkusMainTest;
 
 @QuarkusMainTest
-@TestProfile(CustomPncServiceProfile.class)
 public class CycloneDXPluginMavenGenerateCommandIT {
-    public static class CustomPncServiceProfile implements QuarkusTestProfile {
 
-        @Override
-        public Set<Class<?>> getEnabledAlternatives() {
-            return Set.of(AlternativePncService.class);
-        }
-    }
-
-    @Test
-    @Disabled("Figure out how to run a generation integration test")
-    @DisplayName("Should run the cyclonedx generation")
-    @Launch(value = { "-v", "generate", "--sbom-id", "123", "maven", "cyclonedx" })
-    void shouldRunGeneration() throws Exception {
-    }
+    // @Test
+    // // @Disabled("Figure out how to run a generation integration test")
+    // @DisplayName("Should run the cyclonedx generation")
+    // @Launch(value = { "-v", "sbom", "generate", "--build-id", "BBVVCC", "maven-cyclonedx" })
+    // void shouldRunGeneration() throws Exception {
+    // }
 }

--- a/cli/src/test/resources/mappings/pnc/cli/build-IN_PROGRESS.json
+++ b/cli/src/test/resources/mappings/pnc/cli/build-IN_PROGRESS.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/builds/IN_PROGRESS"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "QUARKUS",
+      "buildConfigRevision": {
+        "id": "QUARKUS",
+        "buildType": "MVN",
+        "buildScript": "mvn -DskipTests clean deploy"
+      },
+      "temporaryBuild": false,
+      "progress": "IN_PROGRESS",
+      "status": "BUILDING",
+      "scmUrl": "https://c.r.com/gerrit/project/name.git",
+      "scmTag": "a-tag"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/cli/src/test/resources/mappings/pnc/cli/build-UNSUPPORTED_BUILD_TYPE.json
+++ b/cli/src/test/resources/mappings/pnc/cli/build-UNSUPPORTED_BUILD_TYPE.json
@@ -1,0 +1,25 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/builds/UNSUPPORTED_BUILD_TYPE"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "TMP",
+      "buildConfigRevision": {
+        "id": "TMP",
+        "buildType": "SBT",
+        "buildScript": "blah"
+      },
+      "temporaryBuild": false,
+      "progress": "FINISHED",
+      "status": "SUCCESS",
+      "scmUrl": "https://c.r.com/gerrit/project/name.git",
+      "scmTag": "a-tag"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/core/src/main/java/org/jboss/sbomer/core/dto/BaseSbomGenerationRequestRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/BaseSbomGenerationRequestRecord.java
@@ -15,21 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.errors;
+package org.jboss.sbomer.core.dto;
 
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.ext.Provider;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Instant;
+import java.util.Map;
 
-@Slf4j
-@Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
-    @Override
-    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-        return responseBuilder.build();
-    }
+import com.fasterxml.jackson.databind.JsonNode;
 
-}
+public record BaseSbomGenerationRequestRecord(
+        String id,
+        String identifier,
+        @Schema(implementation = Map.class) JsonNode config,
+        String type,
+        Instant creationTime) {
+};

--- a/core/src/main/java/org/jboss/sbomer/core/dto/BaseSbomRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/BaseSbomRecord.java
@@ -15,57 +15,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.dto.v1alpha1;
+package org.jboss.sbomer.core.dto;
 
 import java.time.Instant;
-import java.util.Map;
-
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-@Schema(name = "V1Alpha1SbomRecord")
-public record SbomRecord(
-        @Schema(example = "3D4E6A6836AE457") String id,
-        @Schema(example = "A6XHP5F42DYAA") String buildId,
-        @Schema(example = "pkg:maven/io.hawt/project@4.0.0?type=pom") String rootPurl,
+public record BaseSbomRecord(
+        String id,
+        String identifier,
+        String rootPurl,
         Instant creationTime,
-        @Schema(implementation = Map.class) JsonNode sbom,
-        @Schema(example = "0") Integer configIndex,
+        Integer configIndex,
         String statusMessage,
-        org.jboss.sbomer.core.dto.v1alpha1.SbomGenerationRequestRecord generationRequest) {
+        BaseSbomGenerationRequestRecord generationRequest) {
 
-    public SbomRecord(
+    public BaseSbomRecord(
             String id,
-            String buildId,
+            String identifier,
             String rootPurl,
             Instant creationTime,
-            JsonNode sbom,
             Integer configIndex,
             String statusMessage,
             String gId,
-            Instant gCreationTime,
-            String gStatus,
-            String gResult,
-            String gBuildId,
+            String gIdentifier,
             JsonNode gConfig,
-            String gReason) {
+            String gType,
+            Instant gCreationTime) {
         this(
                 id,
-                buildId,
+                identifier,
                 rootPurl,
                 creationTime,
-                sbom,
                 configIndex,
                 statusMessage,
-                new org.jboss.sbomer.core.dto.v1alpha1.SbomGenerationRequestRecord(
-                        gId,
-                        gCreationTime,
-                        gStatus,
-                        gResult,
-                        gBuildId,
-                        gConfig,
-                        gReason));
+                new BaseSbomGenerationRequestRecord(gId, gIdentifier, gConfig, gType, gCreationTime));
     }
 
 };

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha1/SbomGenerationRequestRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha1/SbomGenerationRequestRecord.java
@@ -18,10 +18,19 @@
 package org.jboss.sbomer.core.dto.v1alpha1;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+@Schema(name = "V1Alpha1SbomGenerationRequestRecord")
 public record SbomGenerationRequestRecord(
-    String id, Instant creationTime, String status, String result, String buildId, JsonNode config, String reason) {
-
+        @Schema(example = "AA4E6A6836AE457") String id,
+        Instant creationTime,
+        @Schema(example = "FINISHED") String status,
+        @Schema(example = "SUCCESS") String result,
+        @Schema(example = "A6XHP5F42DYAA") String buildId,
+        @Schema(implementation = Map.class) JsonNode config,
+        String reason) {
 };

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomGenerationRequestRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomGenerationRequestRecord.java
@@ -18,8 +18,16 @@
 package org.jboss.sbomer.core.dto.v1alpha2;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public record SbomGenerationRequestRecord(String id, String buildId, JsonNode config, Instant creationTime) {
+@Schema(name = "V1Alpha2SbomGenerationRequestRecord")
+public record SbomGenerationRequestRecord(
+        String id,
+        String buildId,
+        @Schema(implementation = Map.class) JsonNode config,
+        Instant creationTime) {
 };

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomRecord.java
@@ -18,13 +18,18 @@
 package org.jboss.sbomer.core.dto.v1alpha2;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+@Schema(name = "V1Alpha2SbomRecord")
 public record SbomRecord(
         String id,
         String buildId,
         String rootPurl,
+        @Schema(implementation = Map.class) JsonNode sbom,
         Instant creationTime,
         Integer configIndex,
         String statusMessage,
@@ -34,6 +39,7 @@ public record SbomRecord(
             String id,
             String buildId,
             String rootPurl,
+            JsonNode sbom,
             Instant creationTime,
             Integer configIndex,
             String statusMessage,
@@ -45,6 +51,7 @@ public record SbomRecord(
                 id,
                 buildId,
                 rootPurl,
+                sbom,
                 creationTime,
                 configIndex,
                 statusMessage,

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomSearchRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha2/SbomSearchRecord.java
@@ -15,41 +15,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.dto.v1alpha3;
+package org.jboss.sbomer.core.dto.v1alpha2;
 
 import java.time.Instant;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
-public record BaseSbomRecord(
+@Schema(name = "V1Alpha2SbomSearchRecord")
+public record SbomSearchRecord(
         String id,
-        String identifier,
+        String buildId,
         String rootPurl,
         Instant creationTime,
         Integer configIndex,
         String statusMessage,
-        org.jboss.sbomer.core.dto.v1alpha3.BaseSbomGenerationRequestRecord generationRequest) {
+        SbomGenerationRequestRecord generationRequest) {
 
-    public BaseSbomRecord(
+    public SbomSearchRecord(
             String id,
-            String identifier,
+            String buildId,
             String rootPurl,
             Instant creationTime,
             Integer configIndex,
             String statusMessage,
             String gId,
-            String gIdentifier,
+            String gBuildId,
             JsonNode gConfig,
-            String gType,
             Instant gCreationTime) {
         this(
                 id,
-                identifier,
+                buildId,
                 rootPurl,
                 creationTime,
                 configIndex,
                 statusMessage,
-                new org.jboss.sbomer.core.dto.v1alpha3.BaseSbomGenerationRequestRecord(gId, gIdentifier, gConfig, gType, gCreationTime));
+                new SbomGenerationRequestRecord(gId, gBuildId, gConfig, gCreationTime));
     }
 
 };

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha3/SbomGenerationRequestRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha3/SbomGenerationRequestRecord.java
@@ -18,8 +18,19 @@
 package org.jboss.sbomer.core.dto.v1alpha3;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public record SbomGenerationRequestRecord(String id, String identifier, JsonNode config, String type, Instant creationTime, String status, String result, String reason) {
+public record SbomGenerationRequestRecord(
+        String id,
+        String identifier,
+        @Schema(implementation = Map.class) JsonNode config,
+        String type,
+        Instant creationTime,
+        String status,
+        String result,
+        String reason) {
 };

--- a/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha3/SbomRecord.java
+++ b/core/src/main/java/org/jboss/sbomer/core/dto/v1alpha3/SbomRecord.java
@@ -18,18 +18,22 @@
 package org.jboss.sbomer.core.dto.v1alpha3;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+@Schema(name = "V1Alpha3SbomRecord")
 public record SbomRecord(
         String id,
         String identifier,
         String rootPurl,
         Instant creationTime,
-        JsonNode sbom,
+        @Schema(implementation = Map.class) JsonNode sbom,
         Integer configIndex,
         String statusMessage,
-        org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord generationRequest) {
+        SbomGenerationRequestRecord generationRequest) {
 
     public SbomRecord(
             String id,
@@ -55,7 +59,15 @@ public record SbomRecord(
                 sbom,
                 configIndex,
                 statusMessage,
-                new org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord(gId, gIdentifier, gConfig, gType, gCreationTime, gStatus, gResult, gReason));
+                new SbomGenerationRequestRecord(
+                        gId,
+                        gIdentifier,
+                        gConfig,
+                        gType,
+                        gCreationTime,
+                        gStatus,
+                        gResult,
+                        gReason));
 
-            }
-        }
+    }
+}

--- a/core/src/main/java/org/jboss/sbomer/core/errors/ErrorResponse.java
+++ b/core/src/main/java/org/jboss/sbomer/core/errors/ErrorResponse.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.sbomer.core.errors;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AccessLevel;
@@ -37,7 +38,10 @@ import lombok.ToString;
 @ToString
 public class ErrorResponse {
     String errorId;
-    String errorType;
+    String error;
+    String resource;
     String message;
-    List<String> errors;
+    @Builder.Default
+    List<String> errors = new ArrayList<>();
+
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/AbstractExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/AbstractExceptionMapper.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.errors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.resteasy.spi.Failure;
+import org.jboss.sbomer.core.errors.ErrorResponse;
+import org.slf4j.helpers.MessageFormatter;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
+    @Inject
+    UriInfo uriInfo;
+
+    @Inject
+    Request request;
+
+    @Inject
+    SecurityContext securityContext;
+
+    @Inject
+    HttpHeaders httpHeaders;
+
+    String generateErrorId() {
+        return UUID.randomUUID().toString();
+    }
+
+    Status getStatus() {
+        return Status.INTERNAL_SERVER_ERROR;
+    }
+
+    String errorMessage(T ex) {
+        return "An error occurred while processing your request, please contact administrator providing the 'errorId'";
+    }
+
+    /**
+     * <p>
+     * Override to privide any additional error messages that can be useful for the clinet to understand the problem.
+     * See {@link ErrorResponse#getErrors()}.
+     * </p>
+     *
+     * <p>
+     * By default empty list is returned.
+     * </p>
+     *
+     * @return
+     */
+    List<String> customErrors() {
+        return new ArrayList<>();
+    }
+
+    /**
+     * <p>
+     * A hook that is executed before the response is returned. It can be used for example to help audit things (log
+     * messages).
+     * </p>
+     *
+     * <p>
+     * Returned {@link Response} object is returned to the client.
+     * </p>
+     *
+     * @param responseBuilder The prepared default {@link Response} object.
+     * @param ex The {@link Throwable} containing the cause
+     */
+    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
+        return responseBuilder.build();
+    }
+
+    ErrorResponse errorResponse(T ex) {
+        return ErrorResponse.builder()
+                .resource(uriInfo.getPath())
+                .errorId(generateErrorId())
+                .error(getStatus().getReasonPhrase())
+                .errors(customErrors())
+                .message(errorMessage(ex))
+                .build();
+    }
+
+    void copyHeaders(T ex, ResponseBuilder builder) {
+        Response response = null;
+
+        if (ex instanceof Failure) {
+            Failure failure = (Failure) ex;
+            response = failure.getResponse();
+        }
+
+        if (ex instanceof WebApplicationException) {
+            WebApplicationException wax = (WebApplicationException) ex;
+            response = wax.getResponse();
+        }
+
+        if (response == null) {
+            return;
+        }
+
+        for (Map.Entry<String, List<Object>> en : response.getHeaders().entrySet()) {
+            String headerName = en.getKey();
+            List<Object> headerValues = en.getValue();
+            for (Object headerValue : headerValues) {
+                builder.header(headerName, headerValue);
+            }
+        }
+    }
+
+    @Override
+    public Response toResponse(T ex) {
+        // Prepare default error entity for a given exception
+        ErrorResponse errorResponse = errorResponse(ex);
+
+        // Prepare initial response builder with default 500 error and JSON content type
+        ResponseBuilder responseBuilder = Response.status(getStatus())
+                .entity(errorResponse)
+                .type(MediaType.APPLICATION_JSON);
+
+        // If headers are available, copy them
+        copyHeaders(ex, responseBuilder);
+
+        // Customize the response, if needed
+        Response response = hook(responseBuilder, ex);
+
+        // Log the entity in any case
+        log.debug(response.getEntity().toString());
+
+        return response;
+    }
+
+    String formattedString(String message, Object... params) {
+        return MessageFormatter.arrayFormat(message, params).getMessage();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ClientExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ClientExceptionMapper.java
@@ -17,25 +17,25 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
-import jakarta.ws.rs.ext.Provider;
-
 import org.jboss.sbomer.core.errors.ClientException;
 import org.jboss.sbomer.core.errors.ErrorResponse;
 
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 @Provider
 @Slf4j
-public class ClientExceptionMapper implements ExceptionMapper<ClientException> {
+public class ClientExceptionMapper extends AbstractExceptionMapper<ClientException> {
 
     @Override
     public Response toResponse(ClientException ex) {
         ErrorResponse error = ErrorResponse.builder()
+                .resource(uriInfo.getPath())
                 .errorId(ex.getErrorId())
-                .errorType(ex.getClass().getSimpleName())
+                .error(Status.fromStatusCode(ex.getCode()).getReasonPhrase())
                 .message(ex.getMessage())
                 .errors(ex.getErrors())
                 .build();

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ForbiddenExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ForbiddenExceptionMapper.java
@@ -1,3 +1,4 @@
+
 /*
  * JBoss, Home of Professional Open Source.
  * Copyright 2023 Red Hat, Inc., and individual contributors
@@ -17,19 +18,30 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
+@Slf4j
+public class ForbiddenExceptionMapper extends AbstractExceptionMapper<ForbiddenException> {
+
+    @Override
+    Status getStatus() {
+        return Status.FORBIDDEN;
+    }
+
     @Override
     Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
-
+        log.warn("Access to '{}' resource requested by a client has been forbidden.", uriInfo.getPath(), ex);
         return responseBuilder.build();
     }
 
+    @Override
+    String errorMessage(ForbiddenException ex) {
+        return formattedString("Access to '{}' resource is forbidden!", uriInfo.getPath());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/IllegalArgumentExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/IllegalArgumentExceptionMapper.java
@@ -15,23 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.rest.v1alpha2;
+package org.jboss.sbomer.service.feature.sbom.errors;
 
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
 
-import jakarta.annotation.security.PermitAll;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
+@Provider
+public class IllegalArgumentExceptionMapper extends AbstractExceptionMapper<IllegalArgumentException> {
 
-@Path("/api/v1alpha2/stats")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
-@ApplicationScoped
-@Tag(name = "v1alpha2", description = "v1alpha2 API endpoints")
-@PermitAll
-public class StatsResources extends org.jboss.sbomer.service.feature.sbom.rest.v1alpha1.StatsResources {
+    @Override
+    Status getStatus() {
+        return Status.BAD_REQUEST;
+    }
 
+    @Override
+    String errorMessage(IllegalArgumentException ex) {
+        return formattedString("Invalid arguments provided: {}", ex.getMessage());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/MismatchedInputExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/MismatchedInputExceptionMapper.java
@@ -17,15 +17,10 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
-import java.util.UUID;
-
-import org.jboss.sbomer.core.errors.ErrorResponse;
-
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,21 +29,16 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Provider
 @Slf4j
-public class MismatchedInputExceptionMapper implements ExceptionMapper<MismatchedInputException> {
+public class MismatchedInputExceptionMapper extends AbstractExceptionMapper<MismatchedInputException> {
+
     @Override
-    public Response toResponse(MismatchedInputException e) {
-        log.error("Received content that cannot be deserialized");
-
-        Response.ResponseBuilder builder = Response.status(400);
-
-        ErrorResponse error = ErrorResponse.builder()
-                .errorId(UUID.randomUUID().toString())
-                .errorType(e.getClass().getSimpleName())
-                .message("An error occurred while deserializing provided content: " + e.getOriginalMessage())
-                .build();
-
-        return builder.entity(error).type(MediaType.APPLICATION_JSON).build();
-
+    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
+        log.error("Received content that cannot be deserialized", ex);
+        return responseBuilder.build();
     }
 
+    @Override
+    String errorMessage(MismatchedInputException ex) {
+        return formattedString("An error occurred while deserializing provided content: {}", ex.getOriginalMessage());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotAllowedExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotAllowedExceptionMapper.java
@@ -17,19 +17,37 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
+import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
+@Slf4j
+public class NotAllowedExceptionMapper extends AbstractExceptionMapper<NotAllowedException> {
+
+    @Override
+    Status getStatus() {
+        return Status.METHOD_NOT_ALLOWED;
+    }
+
     @Override
     Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
-
+        log.warn(
+                "Client requested '{}' resource with not allowed method: '{}'",
+                uriInfo.getPath(),
+                request.getMethod(),
+                ex);
         return responseBuilder.build();
     }
 
+    @Override
+    String errorMessage(NotAllowedException ex) {
+        return formattedString(
+                "Requesting resource '{}' using '{}' method is not allowed. Please consult API documentation.",
+                uriInfo.getPath(),
+                request.getMethod());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotAuthorizedExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotAuthorizedExceptionMapper.java
@@ -17,19 +17,30 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
+import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
+@Slf4j
+public class NotAuthorizedExceptionMapper extends AbstractExceptionMapper<NotAuthorizedException> {
+
+    @Override
+    Status getStatus() {
+        return Status.UNAUTHORIZED;
+    }
+
     @Override
     Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
-
+        log.warn("Access to '{}' resource requested by an unauthorized client.", uriInfo.getPath(), ex);
         return responseBuilder.build();
     }
 
+    @Override
+    String errorMessage(NotAuthorizedException ex) {
+        return formattedString("Access to '{}' resource is not authorized!", uriInfo.getPath());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotFoundExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/NotFoundExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.errors;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class NotFoundExceptionMapper extends AbstractExceptionMapper<NotFoundException> {
+
+    @Override
+    Status getStatus() {
+        return Status.NOT_FOUND;
+    }
+
+    @Override
+    String errorMessage(NotFoundException ex) {
+        return formattedString("Requested resource '{}' was not found", uriInfo.getPath());
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/RSQLExceptionMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/RSQLExceptionMapper.java
@@ -17,33 +17,31 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
-import java.util.UUID;
-
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
-import jakarta.ws.rs.ext.Provider;
-
-import org.jboss.sbomer.core.errors.ErrorResponse;
-
 import cz.jirutka.rsql.parser.RSQLParserException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 @Provider
 @Slf4j
-public class RSQLExceptionMapper implements ExceptionMapper<RSQLParserException> {
+public class RSQLExceptionMapper extends AbstractExceptionMapper<RSQLParserException> {
 
     @Override
-    public Response toResponse(RSQLParserException e) {
-        Response.StatusType status = Response.Status.BAD_REQUEST;
-        ErrorResponse error = ErrorResponse.builder()
-                .errorId(UUID.randomUUID().toString())
-                .errorType(e.getClass().getSimpleName())
-                .message(e.getMessage())
-                .build();
+    Status getStatus() {
+        return Status.BAD_REQUEST;
+    }
 
-        log.error(error.toString(), e);
+    @Override
+    String errorMessage(RSQLParserException ex) {
+        return "An error occurred while parsing the RSQL query, please make sure you use correct syntax";
+    }
 
-        return Response.status(status).entity(error).type(MediaType.APPLICATION_JSON).build();
+    @Override
+    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
+        log.error("Could not parse RSQL", ex);
+
+        return responseBuilder.build();
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ResteasyFailureMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errors/ResteasyFailureMapper.java
@@ -17,17 +17,42 @@
  */
 package org.jboss.sbomer.service.feature.sbom.errors;
 
+import org.jboss.resteasy.spi.Failure;
+import org.jboss.sbomer.core.errors.ErrorResponse;
+
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.StatusType;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
+@Slf4j
+public class ResteasyFailureMapper extends AbstractExceptionMapper<Failure> {
+
+    @Override
+    ErrorResponse errorResponse(Failure ex) {
+        Failure failure = ((Failure) ex);
+        StatusType statusType = failure.getResponse().getStatusInfo();
+
+        return ErrorResponse.builder()
+                .resource(uriInfo.getPath())
+                .errorId(generateErrorId())
+                .error(statusType.getReasonPhrase())
+                .message(errorMessage(ex))
+                .build();
+    }
+
     @Override
     Response hook(ResponseBuilder responseBuilder, Throwable ex) {
         log.error("Failure occurred while processing request", ex);
+
+        Failure failure = ((Failure) ex);
+
+        if (failure.getErrorCode() > 0) {
+            // Update the status based on the one defined in the Failure object
+            responseBuilder.status(failure.getErrorCode());
+        }
 
         return responseBuilder.build();
     }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.pnc.common.Strings;
 import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
 import org.jboss.sbomer.core.features.sbom.config.runtime.OperationConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/EntityMapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/EntityMapper.java
@@ -15,21 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.service.feature.sbom.errors;
+package org.jboss.sbomer.service.feature.sbom.mapper;
 
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.ext.Provider;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
-@Slf4j
-@Provider
-public class DefaultExceptionMapper extends AbstractExceptionMapper<Throwable> {
-    @Override
-    Response hook(ResponseBuilder responseBuilder, Throwable ex) {
-        log.error("Failure occurred while processing request", ex);
+import org.jboss.sbomer.core.features.sbom.rest.Page;
 
-        return responseBuilder.build();
-    }
+public interface EntityMapper<E, R> {
+    R toSbomRecord(E entity);
+
+    Page<R> toRecordPage(Page<E> entities);
+
+    List<R> toRecordList(List<E> entities);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha1Mapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha1Mapper.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.mapper;
 
 import java.util.List;
 
+import org.jboss.sbomer.core.dto.v1alpha1.SbomRecord;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha2Mapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha2Mapper.java
@@ -19,6 +19,10 @@ package org.jboss.sbomer.service.feature.sbom.mapper;
 
 import java.util.List;
 
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomGenerationRequestRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomSearchRecord;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
@@ -29,32 +33,19 @@ import org.mapstruct.Mapping;
 public interface V1Alpha2Mapper {
 
     @Mapping(source = "identifier", target = "buildId")
-    org.jboss.sbomer.core.dto.v1alpha2.SbomRecord toSbomRecord(Sbom entity);
+    SbomRecord toSbomRecord(Sbom entity);
 
     @Mapping(source = "identifier", target = "buildId")
-    // @Mapping(target = "reason", expression = "java(reason == null ? '' : reason)")
-    org.jboss.sbomer.core.dto.v1alpha2.SbomGenerationRequestRecord toSbomRequestRecord(SbomGenerationRequest entity);
-
-    Page<org.jboss.sbomer.core.dto.v1alpha2.SbomRecord> toSbomRecordPage(Page<Sbom> sboms);
-
-    Page<org.jboss.sbomer.core.dto.v1alpha2.SbomGenerationRequestRecord> toSbomRequestRecordPage(
-            Page<SbomGenerationRequest> sbomRequests);
-
-    List<org.jboss.sbomer.core.dto.v1alpha2.SbomRecord> toSbomRecordList(List<Sbom> sboms);
+    @Mapping(source = "generationRequest.identifier", target = "generationRequest.buildId")
+    SbomSearchRecord toSbomSearchRecord(BaseSbomRecord entity);
 
     @Mapping(source = "identifier", target = "buildId")
-    org.jboss.sbomer.core.dto.v1alpha2.SbomRecord toSbomRecord(
-            org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord record);
+    SbomGenerationRequestRecord toSbomRequestRecord(SbomGenerationRequest entity);
 
-    @Mapping(source = "identifier", target = "buildId")
-    // @Mapping(target = "reason", expression = "java(reason == null ? '' : reason)")
-    org.jboss.sbomer.core.dto.v1alpha2.SbomGenerationRequestRecord toSbomRequestRecord(
-            org.jboss.sbomer.core.dto.v1alpha3.BaseSbomGenerationRequestRecord record);
+    Page<SbomSearchRecord> toSbomSearchRecordPage(Page<BaseSbomRecord> sboms);
 
-    List<org.jboss.sbomer.core.dto.v1alpha2.SbomRecord> toV2SbomRecordList(
-            List<org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord> sboms);
+    Page<SbomGenerationRequestRecord> toSbomRequestRecordPage(Page<SbomGenerationRequest> sbomRequests);
 
-    Page<org.jboss.sbomer.core.dto.v1alpha2.SbomRecord> toV2SbomRecordPage(
-            Page<org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord> sboms);
+    List<SbomRecord> toSbomRecordList(List<Sbom> sboms);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha3Mapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/mapper/V1Alpha3Mapper.java
@@ -17,8 +17,9 @@
  */
 package org.jboss.sbomer.service.feature.sbom.mapper;
 
-import java.util.List;
-
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord;
+import org.jboss.sbomer.core.dto.v1alpha3.SbomRecord;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
@@ -27,15 +28,16 @@ import org.mapstruct.Mapper;
 @Mapper(config = MapperConfig.class)
 public interface V1Alpha3Mapper {
 
-    org.jboss.sbomer.core.dto.v1alpha3.SbomRecord toSbomRecord(Sbom entity);
+    SbomRecord toSbomRecord(Sbom entity);
 
-    org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord toSbomRequestRecord(SbomGenerationRequest entity);
+    BaseSbomRecord toSearchRecord(Sbom entity);
 
-    Page<org.jboss.sbomer.core.dto.v1alpha3.SbomRecord> toSbomRecordPage(Page<Sbom> sboms);
+    SbomGenerationRequestRecord toSbomRequestRecord(SbomGenerationRequest entity);
 
-    Page<org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord> toSbomRequestRecordPage(
-            Page<SbomGenerationRequest> sbomRequests);
+    Page<BaseSbomRecord> toSbomSearchRecordPage(Page<BaseSbomRecord> sboms);
 
-    List<org.jboss.sbomer.core.dto.v1alpha3.SbomRecord> toSbomRecordList(List<Sbom> sboms);
+    Page<SbomRecord> toSbomRecordPage(Page<Sbom> sboms);
+
+    Page<SbomGenerationRequestRecord> toSbomRequestRecordPage(Page<SbomGenerationRequest> sbomRequests);
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/Sbom.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/Sbom.java
@@ -20,12 +20,14 @@ package org.jboss.sbomer.service.feature.sbom.model;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.schemaVersion;
 
 import java.time.Instant;
+import java.util.Map;
 
 import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.parsers.JsonParser;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -93,6 +95,8 @@ public class Sbom extends PanacheEntityBase {
     @Column(name = "sbom")
     @CycloneDxBom
     @ToString.Exclude
+    @Schema(implementation = Map.class) // Workaround for swagger limitation of not being able to digest through a very
+                                        // big schema which is the case if we would use the Bom.class
     private JsonNode sbom;
 
     @Column(name = "config_index")

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -19,7 +19,9 @@ package org.jboss.sbomer.service.feature.sbom.model;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -102,6 +104,7 @@ public class SbomGenerationRequest extends PanacheEntityBase {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "config")
     @ToString.Exclude
+    @Schema(implementation = Map.class)
     private JsonNode config;
 
     @Column(name = "reason", nullable = true, updatable = true)

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/SBOMerApplication.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/SBOMerApplication.java
@@ -17,18 +17,18 @@
  */
 package org.jboss.sbomer.service.feature.sbom.rest;
 
-import jakarta.ws.rs.core.Application;
-
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.info.Contact;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.info.License;
 
+import jakarta.ws.rs.core.Application;
+
 @OpenAPIDefinition(
         info = @Info(
                 title = "SBOMer service",
                 version = "0.0.1",
-                contact = @Contact(name = "SBOMer Team", url = "https://chat.google.com/room/AAAACy6IApc"),
+                contact = @Contact(name = "SBOMer Team"),
                 license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html")))
 public class SBOMerApplication extends Application {
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha2/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha2/SBOMResource.java
@@ -17,21 +17,33 @@
  */
 package org.jboss.sbomer.service.feature.sbom.rest.v1alpha2;
 
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomGenerationRequestRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha2.SbomSearchRecord;
+import org.jboss.sbomer.core.errors.ErrorResponse;
+import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.core.utils.PaginationParameters;
 import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
 import org.jboss.sbomer.service.feature.sbom.mapper.V1Alpha2Mapper;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
+import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.rest.api.AbstractApiProvider;
 
-import cz.jirutka.rsql.parser.RSQLParserException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
+
 import jakarta.annotation.security.PermitAll;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -50,14 +62,14 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import lombok.extern.slf4j.Slf4j;
 
-@Path("/api/v1alpha2/sboms")
+@Path("/api/v1alpha2")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @ApplicationScoped
-@Tag(name = "v1alpha2", description = "v1alpha2 API endpoints")
+@Tag(name = "v1alpha2", description = "v1alpha2 API endpoints (deprecated)")
 @PermitAll
 @Slf4j
-public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1alpha1.SBOMResource {
+public class SBOMResource extends AbstractApiProvider {
 
     @Inject
     protected V1Alpha2Mapper mapper;
@@ -65,12 +77,9 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
     @Inject
     FeatureFlags featureFlags;
 
-    protected Object mapSbomRecordPage(Page<BaseSbomRecord> sbomRecords) {
-        return mapper.toV2SbomRecordPage(sbomRecords);
-    }
-
     @GET
-    @Operation(summary = "List SBOMs", description = "List paginated SBOMs using RSQL advanced search.")
+    @Path("/sboms")
+    @Operation(summary = "Search SBOMs", description = "List paginated SBOMs using RSQL advanced search.")
     @Parameter(
             name = "query",
             description = "A RSQL query to search the SBOMs",
@@ -87,75 +96,124 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
                             name = "Order SBOMs by creation time in descending order",
                             value = "creationTime=desc=") })
     @APIResponses({
-            @APIResponse(
-                    responseCode = "200",
-                    description = "List of SBOMs in the system for a specified RSQL query.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(responseCode = "200", description = "List of SBOMs in the system for a specified RSQL query."),
             @APIResponse(
                     responseCode = "400",
                     description = "Failed while parsing the provided RSQL string, please verify the correct syntax.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @APIResponse(
                     responseCode = "500",
                     description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
-    public Response searchSboms(
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public Page<SbomSearchRecord> searchSboms(
             @Valid @BeanParam PaginationParameters paginationParams,
             @QueryParam("query") String rsqlQuery,
             @DefaultValue("creationTime=desc=") @QueryParam("sort") String sort) {
 
-        try {
-            Page<BaseSbomRecord> sboms = sbomService.searchSbomRecordsByQueryPaginated(
-                    paginationParams.getPageIndex(),
-                    paginationParams.getPageSize(),
-                    rsqlQuery,
-                    sort);
-            return Response.status(Status.OK).entity(mapSbomRecordPage(sboms)).build();
-        } catch (IllegalArgumentException iae) {
-            return Response.status(Status.BAD_REQUEST).entity(iae.getMessage()).build();
-        } catch (RSQLParserException rsqlExc) {
-            return Response.status(Status.BAD_REQUEST)
-                    .entity("Failed while parsing the provided RSQL string, please verify the correct syntax")
-                    .build();
-        }
+        Page<BaseSbomRecord> sboms = sbomService.searchSbomRecordsByQueryPaginated(
+                paginationParams.getPageIndex(),
+                paginationParams.getPageSize(),
+                rsqlQuery,
+                sort);
+
+        return mapper.toSbomSearchRecordPage(sboms);
+    }
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML })
+    @Operation(
+            summary = "Generate SBOM based on the PNC build",
+            description = "SBOM base generation for a particular PNC build Id offloaded to the service.")
+    @Parameter(name = "buildId", description = "PNC build identifier", example = "ARYT3LBXDVYAC")
+    @Path("/generate/build/{buildId}")
+    @APIResponses({ @APIResponse(
+            responseCode = "202",
+            description = "Schedules generation of a SBOM for a particular PNC buildId. This is an asynchronous call. It does execute the generation behind the scenes.",
+            content = @Content(schema = @Schema(implementation = SbomGenerationRequestRecord.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+
+    })
+    public Response generate(@PathParam("buildId") String buildId, Config config) throws Exception {
+        return Response.accepted(mapper.toSbomRequestRecord(sbomService.generateFromBuild(buildId, config))).build();
     }
 
     @GET
-    @Path("/purl/{purl}")
+    @Path("/sboms/{id}")
+    @Operation(summary = "Get specific SBOM", description = "Get specific SBOM with the provided ID.")
+    @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
+    @APIResponses({ //
+            @APIResponse(
+                    responseCode = "200",
+                    description = "The SBOM",
+                    content = @Content(schema = @Schema(implementation = SbomRecord.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested SBOM could not be found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), //
+    })
+    public SbomRecord getSbomById(@PathParam("id") String sbomId) {
+        return mapper.toSbomRecord(doGetSbomById(sbomId));
+    }
+
+    @GET
+    @Path("/sboms/{id}/bom")
+    @Operation(
+            summary = "Get the BOM content of particular SBOM",
+            description = "Get the BOM content of particular SBOM")
+    @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
+    @APIResponses({ //
+            @APIResponse(
+                    responseCode = "200",
+                    description = "The BOM in CycloneDX format",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested SBOM could not be found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public JsonNode getBomById(@PathParam("id") String sbomId) {
+        return doGetBomById(sbomId);
+    }
+
+    @GET
+    @Path("/sboms/purl/{purl}")
     @Operation(summary = "Get specific SBOM", description = "Find latest generated SBOM for a given purl.")
     @Parameter(
             name = "purl",
             description = "Package URL identifier",
             example = "scheme:type/namespace/name@version?qualifiers#subpath")
-    @APIResponses({
-            @APIResponse(
-                    responseCode = "200",
-                    description = "The SBOM",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "400",
-                    description = "Could not parse provided arguments",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "404",
-                    description = "Requested SBOM could not be found",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "500",
-                    description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response findByPurl(@PathParam("purl") String purl) {
-        Sbom sbom = sbomService.findByPurl(purl);
-
-        if (sbom == null) {
-            return Response.status(Status.NOT_FOUND).build();
-        }
-
-        return Response.status(Status.OK).entity(mapSbom(sbom)).build();
+    @APIResponses({ @APIResponse(responseCode = "200", description = "The SBOM"),
+            @APIResponse(responseCode = "400", description = "Could not parse provided arguments"),
+            @APIResponse(responseCode = "404", description = "Requested SBOM could not be found"),
+            @APIResponse(responseCode = "500", description = "Internal server error"), })
+    public SbomRecord getSbomByPurl(@PathParam("purl") String purl) {
+        return mapper.toSbomRecord(doGetSbomByPurl(purl));
     }
 
     @GET
-    @Path("/purl/{purl}/bom")
+    @Path("/sboms/purl/{purl}/bom")
     @Operation(
             summary = "Get the BOM content of particular SBOM identified by provided purl",
             description = "Returns the CycloneDX BOM content of particular SBOM identified by provided purl")
@@ -166,28 +224,77 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
     @APIResponses({
             @APIResponse(
                     responseCode = "200",
-                    description = "The CycloneDX BOM",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+                    description = "The BOM in CycloneDX format",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @APIResponse(responseCode = "400", description = "Could not parse provided arguments"),
+            @APIResponse(responseCode = "404", description = "Requested SBOM could not be found"),
+            @APIResponse(responseCode = "500", description = "Internal server error"), })
+    public JsonNode getBomByPurl(@PathParam("purl") String purl) {
+        return doGetBomByPurl(purl);
+    }
+
+    @GET
+    @Path("/sboms/requests")
+    @Operation(
+            summary = "List SBOM generation requests",
+            description = "Paginated list of SBOM generation requests using RSQL advanced search.")
+    @Parameter(
+            name = "query",
+            description = "A RSQL query to search the generation requests",
+            examples = { @ExampleObject(
+                    name = "Find all SBOM generation requests with provided buildId",
+                    value = "buildId=eq=ABCDEFGHIJKLM") })
+    @Parameter(
+            name = "sort",
+            description = "Optional RSQL sort",
+            examples = { @ExampleObject(name = "Order generation requests by id in ascending order", value = "id=asc="),
+                    @ExampleObject(
+                            name = "Order generation requests by creation time in descending order",
+                            value = "creationTime=desc=") })
+    @APIResponses({
+            @APIResponse(
+                    responseCode = "200",
+                    description = "List of SBOM generation requests in the system for a specified RSQL query."),
             @APIResponse(
                     responseCode = "400",
-                    description = "Could not parse provided arguments",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "404",
-                    description = "Requested SBOM could not be found",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+                    description = "Failed while parsing the provided RSQL string, please verify the correct syntax.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @APIResponse(
                     responseCode = "500",
                     description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response getBomByPurl(@PathParam("purl") String purl) {
-        Sbom sbom = sbomService.findByPurl(purl);
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public Page<SbomGenerationRequestRecord> searchGenerationRequests(
+            @Valid @BeanParam PaginationParameters paginationParams,
+            @QueryParam("query") String rsqlQuery,
+            @DefaultValue("creationTime=desc=") @QueryParam("sort") String sort) {
 
-        if (sbom == null) {
-            return Response.status(Status.NOT_FOUND).build();
-        }
+        Page<SbomGenerationRequest> requests = sbomService.searchSbomRequestsByQueryPaginated(
+                paginationParams.getPageIndex(),
+                paginationParams.getPageSize(),
+                rsqlQuery,
+                sort);
 
-        return Response.status(Status.OK).entity(sbom.getCycloneDxBom()).build();
+        return mapper.toSbomRequestRecordPage(requests);
+    }
+
+    @GET
+    @Path("/sboms/requests/{id}")
+    @Operation(
+            summary = "Get specific SBOM generation request",
+            description = "Get specific SBOM generation request with the provided ID.")
+    @Parameter(name = "id", description = "SBOM generation request identifier", example = "88CA2291D4014C6")
+    @APIResponses({ @APIResponse(responseCode = "200", description = "The generation request"),
+            @APIResponse(responseCode = "400", description = "Could not parse provided arguments"),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested generation request could not be found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public SbomGenerationRequestRecord getGenerationRequestById(@PathParam("id") String generationRequestId) {
+        return mapper.toSbomRequestRecord(doGetSbomGenerationRequestById(generationRequestId));
     }
 
     @POST
@@ -195,8 +302,8 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
             summary = "Resend UMB notification message for a completed SBOM",
             description = "Force the resending of the UMB notification message for an already generated SBOM.")
     @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
-    @Path("{id}/notify")
-    @APIResponses({ @APIResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+    @Path("/sboms/{id}/notify")
+    @APIResponses({ @APIResponse(responseCode = "200"),
             @APIResponse(
                     responseCode = "404",
                     description = "Requested SBOM could not be found",
@@ -211,9 +318,9 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
             return Response.status(Status.METHOD_NOT_ALLOWED).build();
         }
 
-        Sbom sbom = doGetBomById(sbomId);
+        Sbom sbom = doGetSbomById(sbomId);
         sbomService.notifyCompleted(sbom);
-        return Response.status(Status.OK).build();
+        return Response.ok().build();
     }
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
@@ -17,32 +17,30 @@
  */
 package org.jboss.sbomer.service.feature.sbom.rest.v1alpha3;
 
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.jboss.sbomer.core.SchemaValidator.ValidationResult;
-import org.jboss.sbomer.core.config.OperationConfigSchemaValidator;
-import org.jboss.sbomer.core.config.SbomerConfigProvider;
-import org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord;
-import org.jboss.sbomer.core.errors.ValidationException;
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord;
+import org.jboss.sbomer.core.dto.v1alpha3.SbomRecord;
+import org.jboss.sbomer.core.errors.ErrorResponse;
 import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
 import org.jboss.sbomer.core.features.sbom.config.runtime.OperationConfig;
-import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
-import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.core.utils.PaginationParameters;
 import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
-import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
-import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
-import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.mapper.V1Alpha3Mapper;
-import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.rest.api.AbstractApiProvider;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
 
 import jakarta.annotation.security.PermitAll;
@@ -63,99 +61,22 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import lombok.extern.slf4j.Slf4j;
 
-@Path("/api/v1alpha3/sboms")
+@Path("/api/v1alpha3")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 @Tag(name = "v1alpha3", description = "v1alpha3 API endpoints")
 @PermitAll
 @Slf4j
-public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1alpha2.SBOMResource {
-
-    @Inject
-    protected OperationConfigSchemaValidator operationConfigSchemaValidator;
-
+public class SBOMResource extends AbstractApiProvider {
     @Inject
     V1Alpha3Mapper mapper;
 
     @Inject
     FeatureFlags featureFlags;
 
-    @Override
-    protected Object mapSbom(Sbom sbom) {
-        return mapper.toSbomRecord(sbom);
-    }
-
-    @Override
-    protected Object mapSbomRequest(SbomGenerationRequest sbomGenerationRequest) {
-        return mapper.toSbomRequestRecord(sbomGenerationRequest);
-    }
-
-    @Override
-    protected Object mapSbomRequestPage(Page<SbomGenerationRequest> sbomRequests) {
-        return mapper.toSbomRequestRecordPage(sbomRequests);
-    }
-
-    @Override
-    protected Object mapSbomRecordPage(Page<BaseSbomRecord> sbomRecords) {
-        return sbomRecords;
-    }
-
     @GET
-    @Path("{id}")
-    @Operation(summary = "Get specific SBOM", description = "Get specific SBOM with the provided ID.")
-    @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
-    @APIResponses({
-            @APIResponse(
-                    responseCode = "200",
-                    description = "The SBOM",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "400",
-                    description = "Could not parse provided arguments",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "404",
-                    description = "Requested SBOM could not be found",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "500",
-                    description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response getById(@PathParam("id") String sbomId) {
-
-        return super.getById(sbomId); // mapSbom with v1
-    }
-
-    @POST
-    @Consumes({ MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML })
-    @Operation(
-            summary = "Generate SBOM based on the PNC build",
-            description = "SBOM base generation for a particular PNC build Id offloaded to the service.")
-    @Parameter(name = "buildId", description = "PNC build identifier", example = "ARYT3LBXDVYAC")
-    @Path("/generate/build/{buildId}")
-    @APIResponses({ @APIResponse(
-            responseCode = "202",
-            description = "Schedules generation of a SBOM for a particular PNC buildId. This is an asynchronous call. It does execute the generation behind the scenes.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "500",
-                    description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
-
-    public Response generate(@PathParam("buildId") String buildId, Config config) throws Exception {
-        if (featureFlags.isDryRun()) {
-            log.warn(
-                    "Skipping creating new Generation Request for buildId '{}' because of SBOMer running in dry-run mode",
-                    buildId);
-            return Response.status(Status.METHOD_NOT_ALLOWED).build();
-        }
-
-        return super.generate(buildId, config);
-    }
-
-    @GET
-    @Path("/requests")
+    @Path("/sboms/requests")
     @Operation(
             summary = "List SBOM generation requests",
             description = "Paginated list of SBOM generation requests using RSQL advanced search.")
@@ -185,16 +106,20 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
                     responseCode = "500",
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
-    public Response searchGenerationRequests(
+    public Page<SbomGenerationRequestRecord> searchGenerationRequests(
             @Valid @BeanParam PaginationParameters paginationParams,
             @QueryParam("query") String rsqlQuery,
             @DefaultValue("creationTime=desc=") @QueryParam("sort") String sort) {
-
-        return super.searchGenerationRequests(paginationParams, rsqlQuery, sort);
+        Page<SbomGenerationRequest> requests = sbomService.searchSbomRequestsByQueryPaginated(
+                paginationParams.getPageIndex(),
+                paginationParams.getPageSize(),
+                rsqlQuery,
+                sort);
+        return mapper.toSbomRequestRecordPage(requests);
     }
 
     @GET
-    @Path("/requests/{id}")
+    @Path("/sboms/requests/{id}")
     @Operation(
             summary = "Get specific SBOM generation request",
             description = "Get specific SBOM generation request with the provided ID.")
@@ -216,13 +141,13 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
                     responseCode = "500",
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response getGenerationRequestById(@PathParam("id") String id) {
-
-        return super.getGenerationRequestById(id);
+    public SbomGenerationRequestRecord getGenerationRequestById(@PathParam("id") String generationRequestId) {
+        return mapper.toSbomRequestRecord(doGetSbomGenerationRequestById(generationRequestId));
     }
 
     @GET
-    @Operation(summary = "List SBOMs", description = "List paginated SBOMs using RSQL advanced search.")
+    @Path("/sboms")
+    @Operation(summary = "Search SBOMs", description = "List paginated SBOMs using RSQL advanced search.")
     @Parameter(
             name = "query",
             description = "A RSQL query to search the SBOMs",
@@ -239,29 +164,134 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
                             name = "Order SBOMs by creation time in descending order",
                             value = "creationTime=desc=") })
     @APIResponses({
-            @APIResponse(
-                    responseCode = "200",
-                    description = "List of SBOMs in the system for a specified RSQL query.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            @APIResponse(responseCode = "200", description = "List of SBOMs in the system for a specified RSQL query."),
             @APIResponse(
                     responseCode = "400",
                     description = "Failed while parsing the provided RSQL string, please verify the correct syntax.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @APIResponse(
                     responseCode = "500",
                     description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
-    public Response searchSboms(
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public Page<BaseSbomRecord> searchSboms(
             @Valid @BeanParam PaginationParameters paginationParams,
             @QueryParam("query") String rsqlQuery,
             @DefaultValue("creationTime=desc=") @QueryParam("sort") String sort) {
 
-        return super.searchSboms(paginationParams, rsqlQuery, sort);
+        Page<BaseSbomRecord> sboms = sbomService.searchSbomRecordsByQueryPaginated(
+                paginationParams.getPageIndex(),
+                paginationParams.getPageSize(),
+                rsqlQuery,
+                sort);
+
+        return mapper.toSbomSearchRecordPage(sboms);
+    }
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML })
+    @Operation(
+            summary = "Generate SBOM based on the PNC build",
+            description = "SBOM base generation for a particular PNC build Id offloaded to the service.")
+    @Parameter(name = "buildId", description = "PNC build identifier", example = "ARYT3LBXDVYAC")
+    @Path("/sboms/generate/build/{buildId}")
+    @APIResponses({ @APIResponse(
+            responseCode = "202",
+            description = "Schedules generation of a SBOM for a particular PNC buildId. This is an asynchronous call. It does execute the generation behind the scenes.",
+            content = @Content(schema = @Schema(implementation = SbomGenerationRequestRecord.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+
+    })
+    public Response generate(@PathParam("buildId") String buildId, Config config) throws Exception {
+        if (featureFlags.isDryRun()) {
+            log.warn(
+                    "Skipping creating new Generation Request for buildId '{}' because of SBOMer running in dry-run mode",
+                    buildId);
+            return Response.status(Status.METHOD_NOT_ALLOWED).build();
+        }
+
+        return Response.accepted(mapper.toSbomRequestRecord(sbomService.generateFromBuild(buildId, config))).build();
     }
 
     @GET
-    @Path("/purl/{purl}")
+    @Path("/sboms/{id}")
+    @Operation(summary = "Get specific SBOM", description = "Get specific SBOM with the provided ID.")
+    @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
+    @APIResponses({ //
+            @APIResponse(
+                    responseCode = "200",
+                    description = "The SBOM",
+                    content = @Content(schema = @Schema(implementation = SbomRecord.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested SBOM could not be found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), //
+    })
+    public SbomRecord getSbomById(@PathParam("id") String sbomId) {
+        return mapper.toSbomRecord(doGetSbomById(sbomId));
+    }
+
+    @GET
+    @Path("/sboms/{id}/bom")
+    @Operation(
+            summary = "Get the BOM content of particular SBOM",
+            description = "Get the BOM content of particular SBOM")
+    @Parameter(name = "id", description = "SBOM identifier", example = "429305915731435500")
+    @APIResponses({ //
+            @APIResponse(
+                    responseCode = "200",
+                    description = "The BOM in CycloneDX format",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Could not parse provided arguments",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Requested SBOM could not be found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))), })
+    public JsonNode getBomById(@PathParam("id") String sbomId) {
+        return doGetBomById(sbomId);
+    }
+
+    @GET
+    @Path("/sboms/purl/{purl}")
     @Operation(summary = "Get specific SBOM", description = "Find latest generated SBOM for a given purl.")
+    @Parameter(
+            name = "purl",
+            description = "Package URL identifier",
+            example = "scheme:type/namespace/name@version?qualifiers#subpath")
+    @APIResponses({ @APIResponse(responseCode = "200", description = "The SBOM"),
+            @APIResponse(responseCode = "400", description = "Could not parse provided arguments"),
+            @APIResponse(responseCode = "404", description = "Requested SBOM could not be found"),
+            @APIResponse(responseCode = "500", description = "Internal server error"), })
+    public SbomRecord getSbomByPurl(@PathParam("purl") String purl) {
+        return mapper.toSbomRecord(doGetSbomByPurl(purl));
+    }
+
+    @GET
+    @Path("/sboms/purl/{purl}/bom")
+    @Operation(
+            summary = "Get the BOM content of particular SBOM identified by provided purl",
+            description = "Returns the CycloneDX BOM content of particular SBOM identified by provided purl")
     @Parameter(
             name = "purl",
             description = "Package URL identifier",
@@ -269,23 +299,13 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
     @APIResponses({
             @APIResponse(
                     responseCode = "200",
-                    description = "The SBOM",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "400",
-                    description = "Could not parse provided arguments",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "404",
-                    description = "Requested SBOM could not be found",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)),
-            @APIResponse(
-                    responseCode = "500",
-                    description = "Internal server error",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON)), })
-    public Response findByPurl(@PathParam("purl") String purl) {
-
-        return super.findByPurl(purl);
+                    description = "The BOM in CycloneDX format",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @APIResponse(responseCode = "400", description = "Could not parse provided arguments"),
+            @APIResponse(responseCode = "404", description = "Requested SBOM could not be found"),
+            @APIResponse(responseCode = "500", description = "Internal server error"), })
+    public JsonNode getBomByPurl(@PathParam("purl") String purl) {
+        return doGetBomByPurl(purl);
     }
 
     @POST
@@ -297,11 +317,11 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
             name = "operationId",
             description = "PNC Deliverable Analysis operation identifier",
             example = "A5WL3DFZ3AIAA")
-    @Path("/generate/operation/{operationId}")
+    @Path("/sboms/generate/operation/{operationId}")
     @APIResponses({ @APIResponse(
             responseCode = "202",
             description = "Schedules generation of a SBOM for a particular PNC operationId. This is an asynchronous call. It does execute the generation behind the scenes.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON)),
+            content = @Content(schema = @Schema(implementation = SbomGenerationRequestRecord.class))),
             @APIResponse(
                     responseCode = "500",
                     description = "Internal server error",
@@ -309,50 +329,8 @@ public class SBOMResource extends org.jboss.sbomer.service.feature.sbom.rest.v1a
 
     public Response generateFromOperation(@PathParam("operationId") String operationId, OperationConfig config)
             throws Exception {
-        if (featureFlags.isDryRun()) {
-            log.warn(
-                    "Skipping creating new Generation Request for operationId '{}' because of SBOMer running in dry-run mode",
-                    operationId);
-            return Response.status(Status.METHOD_NOT_ALLOWED).build();
-        }
-
-        log.info("New generation request for operation id '{}'", operationId);
-        log.debug("Creating GenerationRequest Kubernetes resource...");
-
-        GenerationRequest req = new GenerationRequestBuilder()
-                .withNewDefaultMetadata(operationId, GenerationRequestType.OPERATION)
-                .endMetadata()
-                .withIdentifier(operationId)
-                .withType(GenerationRequestType.OPERATION)
-                .withStatus(SbomGenerationStatus.NEW)
+        return Response.accepted(mapper.toSbomRequestRecord(sbomService.generateFromOperation(operationId, config)))
                 .build();
 
-        if (config != null) {
-            log.debug("Received product configuration...");
-            SbomerConfigProvider sbomerConfigProvider = SbomerConfigProvider.getInstance();
-            sbomerConfigProvider.adjust(config);
-            config.setOperationId(operationId);
-
-            ValidationResult validationResult = operationConfigSchemaValidator.validate(config);
-
-            if (!validationResult.isValid()) {
-                throw new ValidationException("Provided operation config is not valid", validationResult.getErrors());
-            }
-
-            // Because the config is valid, use it and set the status to initialized
-            req.setStatus(SbomGenerationStatus.NEW);
-            req.setConfig(ObjectMapperProvider.yaml().writeValueAsString(config));
-        }
-
-        log.debug("ConfigMap to create: '{}'", req);
-
-        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(req);
-
-        kubernetesClient.configMaps().resource(req).create();
-
-        log.debug("ZipGenerationRequest Kubernetes resource '{}' created for operation '{}'", req.getId(), operationId);
-
-        return Response.status(Status.ACCEPTED).entity(mapSbomRequest(sbomGenerationRequest)).build();
     }
-
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomRepository.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomRepository.java
@@ -20,7 +20,7 @@ package org.jboss.sbomer.service.feature.sbom.service;
 import java.time.Instant;
 import java.util.List;
 
-import org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -20,12 +20,24 @@ package org.jboss.sbomer.service.feature.sbom.service;
 import java.util.List;
 import java.util.Set;
 
-import org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord;
+import org.jboss.sbomer.core.SchemaValidator.ValidationResult;
+import org.jboss.sbomer.core.config.ConfigSchemaValidator;
+import org.jboss.sbomer.core.config.OperationConfigSchemaValidator;
+import org.jboss.sbomer.core.config.SbomerConfigProvider;
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
+import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.errors.ValidationException;
+import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
+import org.jboss.sbomer.core.features.sbom.config.runtime.OperationConfig;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.core.features.sbom.utils.UrlUtils;
 import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
@@ -33,6 +45,9 @@ import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.rest.QueryParameters;
 import org.jboss.sbomer.service.feature.sbom.rest.RestUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -50,6 +65,9 @@ import lombok.extern.slf4j.Slf4j;
 public class SbomService {
 
     @Inject
+    SbomerConfig sbomerConfig;
+
+    @Inject
     SbomRepository sbomRepository;
 
     @Inject
@@ -62,7 +80,14 @@ public class SbomService {
     NotificationService notificationService;
 
     @Inject
-    SbomerConfig sbomerConfig;
+
+    protected KubernetesClient kubernetesClient;
+
+    @Inject
+    protected OperationConfigSchemaValidator operationConfigSchemaValidator;
+
+    @Inject
+    protected ConfigSchemaValidator configSchemaValidator;
 
     @WithSpan
     public long countSboms() {
@@ -157,6 +182,104 @@ public class SbomService {
         }
 
         return new Page<>(parameters.getPageIndex(), parameters.getPageSize(), totalPages, count, content);
+    }
+
+    @WithSpan
+    public SbomGenerationRequest generateFromOperation(
+            @SpanAttribute(value = "operationId") String operationId,
+            OperationConfig config) {
+        log.info("New generation request for operation id '{}'", operationId);
+        log.debug("Creating GenerationRequest Kubernetes resource...");
+
+        GenerationRequest req = new GenerationRequestBuilder()
+                .withNewDefaultMetadata(operationId, GenerationRequestType.OPERATION)
+                .endMetadata()
+                .withIdentifier(operationId)
+                .withType(GenerationRequestType.OPERATION)
+                .withStatus(SbomGenerationStatus.NEW)
+                .build();
+
+        if (config != null) {
+            log.debug("Received product configuration...");
+            SbomerConfigProvider sbomerConfigProvider = SbomerConfigProvider.getInstance();
+            sbomerConfigProvider.adjust(config);
+            config.setOperationId(operationId);
+
+            ValidationResult validationResult = operationConfigSchemaValidator.validate(config);
+
+            if (!validationResult.isValid()) {
+                throw new ValidationException("Provided operation config is not valid", validationResult.getErrors());
+            }
+
+            // Because the config is valid, use it and set the status to initialized
+            req.setStatus(SbomGenerationStatus.NEW);
+            try {
+                req.setConfig(ObjectMapperProvider.yaml().writeValueAsString(config));
+            } catch (JsonProcessingException e) {
+                throw new ApplicationException("Unable to serialize provided configuration into YAML", e);
+            }
+        }
+
+        log.debug("ConfigMap to create: '{}'", req);
+
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(req);
+
+        kubernetesClient.configMaps().resource(req).create();
+
+        log.debug("ZipGenerationRequest Kubernetes resource '{}' created for operation '{}'", req.getId(), operationId);
+
+        return sbomGenerationRequest;
+    }
+
+    @WithSpan
+    public SbomGenerationRequest generateFromBuild(@SpanAttribute(value = "buildId") String buildId, Config config) {
+        try {
+            MDCUtils.addBuildContext(buildId);
+
+            log.info("New generation request for build id '{}'", buildId);
+            log.debug("Creating GenerationRequest Kubernetes resource...");
+
+            GenerationRequest req = new GenerationRequestBuilder()
+                    .withNewDefaultMetadata(buildId, GenerationRequestType.BUILD)
+                    .endMetadata()
+                    .withIdentifier(buildId)
+                    .withStatus(SbomGenerationStatus.NEW)
+                    .build();
+
+            if (config != null) {
+                log.debug("Received product configuration...");
+
+                SbomerConfigProvider sbomerConfigProvider = SbomerConfigProvider.getInstance();
+                sbomerConfigProvider.adjust(config);
+                config.setBuildId(buildId);
+
+                ValidationResult validationResult = configSchemaValidator.validate(config);
+
+                if (!validationResult.isValid()) {
+                    throw new ValidationException("Provided config is not valid", validationResult.getErrors());
+                }
+
+                // We still need to ensure whether the provided config is valid and if we need to set some defaults.
+                // This is why we set it to INITIALIZING and not INITIALIZED
+                req.setStatus(SbomGenerationStatus.INITIALIZING);
+
+                try {
+                    req.setConfig(ObjectMapperProvider.json().writeValueAsString(config));
+                } catch (JsonProcessingException e) {
+                    throw new ApplicationException("Unable to serialize provided configuration into JSON", e);
+                }
+            }
+
+            SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(req);
+
+            kubernetesClient.configMaps().resource(req).create();
+
+            log.debug("GenerationRequest Kubernetes resource '{}' created for build '{}'", req.getId(), buildId);
+
+            return sbomGenerationRequest;
+        } finally {
+            MDCUtils.removeBuildContext();
+        }
     }
 
     /**

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SBOMServiceTestIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SBOMServiceTestIT.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.jboss.sbomer.core.dto.v1alpha3.BaseSbomRecord;
+import org.jboss.sbomer.core.dto.BaseSbomRecord;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.rest.QueryParameters;

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/rest/ErrorResourcesIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/rest/ErrorResourcesIT.java
@@ -46,6 +46,20 @@ public class ErrorResourcesIT {
     SbomService sbomService;
 
     @Test
+    void testHandlingNotFoundResource() {
+        RestAssured.given()
+                .when()
+                .get("/api/alph/sms/doesnotexist")
+                .then()
+                .statusCode(404)
+                .body("resource", CoreMatchers.is("/api/alph/sms/doesnotexist"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Not Found"))
+                .body("message", CoreMatchers.is("Requested resource '/api/alph/sms/doesnotexist' was not found"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
     void testHandlingNotFoundSbom() {
         RestAssured.given()
                 .when()

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/rest/ErrorResourcesIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/rest/ErrorResourcesIT.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.test.integ.feature.sbom.rest;
+
+import static org.mockito.Mockito.doThrow;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.spi.Failure;
+import org.jboss.sbomer.service.feature.sbom.service.SbomService;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.restassured.RestAssured;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Ensures that we can handle errors properly.
+ */
+@QuarkusTest
+@WithKubernetesTestServer
+public class ErrorResourcesIT {
+
+    @InjectSpy
+    SbomService sbomService;
+
+    @Test
+    void testHandlingNotFoundSbom() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/doesnotexist")
+                .then()
+                .statusCode(404)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/doesnotexist"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Not Found"))
+                .body("message", CoreMatchers.is("SBOM with id 'doesnotexist' not found"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testHandlingUnauthorized() {
+        // This doesn't make sense, but what we want to test is handling of any NotAuthorizedException
+        doThrow(NotAuthorizedException.class).when(sbomService).get("unauthorized");
+
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/unauthorized")
+                .then()
+                .statusCode(401)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/unauthorized"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Unauthorized"))
+                .body(
+                        "message",
+                        CoreMatchers.is("Access to '/api/v1alpha2/sboms/unauthorized' resource is not authorized!"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testHandlingForbidden() {
+        // This doesn't make sense, but what we want to test is handling of any ForbiddenException
+        doThrow(ForbiddenException.class).when(sbomService).get("forbidden");
+
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/forbidden")
+                .then()
+                .statusCode(403)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/forbidden"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Forbidden"))
+                .body("message", CoreMatchers.is("Access to '/api/v1alpha2/sboms/forbidden' resource is forbidden!"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testHandlingNotAllowed() {
+        // This doesn't make sense, but what we want to test is handling of any NotAllowedException
+        doThrow(NotAllowedException.class).when(sbomService).get("notallowed");
+
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/notallowed")
+                .then()
+                .statusCode(405)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/notallowed"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Method Not Allowed"))
+                .body(
+                        "message",
+                        CoreMatchers.is(
+                                "Requesting resource '/api/v1alpha2/sboms/notallowed' using 'GET' method is not allowed. Please consult API documentation."))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testIllegalParameters() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms?sort=123")
+                .then()
+                .statusCode(400)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Bad Request"))
+                .body(
+                        "message",
+                        CoreMatchers.is(
+                                "An error occurred while parsing the RSQL query, please make sure you use correct syntax"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testResteasyInternalFailure() {
+        // This doesn't make sense, but what we want to test is handling of any Failure
+        Failure failure = new Failure("This is a message", Response.status(500).build());
+
+        doThrow(failure).when(sbomService).get("internalfailure");
+
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/internalfailure")
+                .then()
+                .statusCode(500)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/internalfailure"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Internal Server Error"))
+                .body(
+                        "message",
+                        CoreMatchers.is(
+                                "An error occurred while processing your request, please contact administrator providing the 'errorId'"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testDefaultExceptionMapper() {
+        // This doesn't make sense, but what we want to test handling of an exception that we don't handle
+        // explicitly
+        doThrow(NotAcceptableException.class).when(sbomService).get("NotAcceptable");
+
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms/NotAcceptable")
+                .then()
+                .statusCode(500)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms/NotAcceptable"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Internal Server Error"))
+                .body(
+                        "message",
+                        CoreMatchers.is(
+                                "An error occurred while processing your request, please contact administrator providing the 'errorId'"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+
+    @Test
+    void testInvalidRSQL() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1alpha2/sboms?query=asd")
+                .then()
+                .statusCode(400)
+                .body("resource", CoreMatchers.is("/api/v1alpha2/sboms"))
+                .body("errorId", CoreMatchers.isA(String.class))
+                .body("error", CoreMatchers.is("Bad Request"))
+                .body(
+                        "message",
+                        CoreMatchers.is(
+                                "An error occurred while parsing the RSQL query, please make sure you use correct syntax"))
+                .body("$", Matchers.not(Matchers.hasKey("errors")));
+    }
+}


### PR DESCRIPTION
There are two changes that are both related to error handling:

1. The SBOMer CLI returning appropriate exit codes that make it possible to understand what went wrong by just looking at the exit code.
    * Adds new exception classes that are mapped to exit codes
    * Adds more tests for CLI
    * Introduction of `SBOMER_CLI_FAILURE_REASON_PATH` which (if set) will
      make SBOMer CLI populate it with a JSON content providing more
      information on why the execution failed. Initial implementation, may
      change. Example:
      
        ```json
        {
          "message": "Could not retrieve PNC build 'aaaA4WLAOY3BJIAA'",
          "exitCode": 33
        }
        ```
2. SBOMer service API improvements like unified error messages and proper JSON output always.
    * API: A unified `ErrorResponse` object is return in any type of error. we provide more information in cases we can.
    * API: Introduction of `AbstractExceptionMapper` class to simplify handling of errors. Probably can be still improved.
    * API representation was updated to that Swagger presents schemas and examples properly.