### PR TITLE
chore: update dependency org.jboss.pnc:rest-client-jakarta to v2.7.5

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -69,28 +69,6 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client-jakarta</artifactId>
       <version>${version.pnc-rest}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.pnc</groupId>
-          <artifactId>pnc-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-common</artifactId>
-      <version>${version.pnc-common}</version>
-      <classifier>jakarta</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.commonjava.maven.ext</groupId>
-          <artifactId>pom-manipulation-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.pnc</groupId>
-          <artifactId>pnc-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,24 +62,6 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client-jakarta</artifactId>
       <version>${version.pnc-rest}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.pnc</groupId>
-          <artifactId>pnc-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-common</artifactId>
-      <version>${version.pnc-common}</version>
-      <classifier>jakarta</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.commonjava.maven.ext</groupId>
-          <artifactId>pom-manipulation-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <version.cyclonedx>8.0.3</version.cyclonedx>
         <version.lombok>1.18.32</version.lombok>
         <version.pnc-common>2.4.1</version.pnc-common>
-        <version.pnc-rest>2.7.4</version.pnc-rest>
+        <version.pnc-rest>2.7.5</version.pnc-rest>
         <version.pnc-api>2.5.1</version.pnc-api>
         <version.quarkus-jgit>3.1.0</version.quarkus-jgit>
         <version.quarkus-unleash>1.6.0</version.quarkus-unleash>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -122,24 +122,6 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client-jakarta</artifactId>
       <version>${version.pnc-rest}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.pnc</groupId>
-          <artifactId>pnc-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-common</artifactId>
-      <version>${version.pnc-common}</version>
-      <classifier>jakarta</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.commonjava.maven.ext</groupId>
-          <artifactId>pom-manipulation-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
And cleanup of unnecessary workarounds.

Closes #422.