### PR TITLE
fix(SBOMER-76): use --legacy-scm-locator by default when using Domino generator

### DIFF
--- a/cli/src/main/resources/mapping/prod/product-mapping.yaml
+++ b/cli/src/main/resources/mapping/prod/product-mapping.yaml
@@ -36,7 +36,7 @@
             productVariant: 8Base-MW-RHBQ-2.13
       generator:
         type: maven-domino
-        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm"
+        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm --legacy-scm-locator"
     # TODO: Enable these when we know what are the Errata Tool coordinates
     # - generator:
     #     type: maven-domino
@@ -57,7 +57,7 @@
             productVariant: 8Base-MW-RHBQ-3.2
       generator:
         type: maven-domino
-        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm"
+        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm --legacy-scm-locator"
 "436":
   products:
     - processors:

--- a/cli/src/main/resources/mapping/prod/product-mapping.yaml
+++ b/cli/src/main/resources/mapping/prod/product-mapping.yaml
@@ -26,38 +26,6 @@
             productVariant: 8Base-RHTESTPRODUCT-1.1
       generator:
         type: maven-cyclonedx
-"382":
-  products:
-    - processors:
-        - type: redhat-product
-          errata:
-            productName: RHBQ
-            productVersion: Middleware-RHBQ-2.13
-            productVariant: 8Base-MW-RHBQ-2.13
-      generator:
-        type: maven-domino
-        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm --legacy-scm-locator"
-    # TODO: Enable these when we know what are the Errata Tool coordinates
-    # - generator:
-    #     type: maven-domino
-    #     args: "--config-file .domino/manifest/quarkus-camel-bom-config.json --warn-on-missing-scm"
-    # - generator:
-    #     type: maven-domino
-    #     args: "--config-file .domino/manifest/quarkus-optaplanner-bom-bom.json --warn-on-missing-scm"
-    # - generator:
-    #     type: maven-domino
-    #     args: "--config-file .domino/manifest/quarkus-qpid-jms-bom-bom.json --warn-on-missing-scm"
-"484":
-  products:
-    - processors:
-        - type: redhat-product
-          errata:
-            productName: RHBQ
-            productVersion: Middleware-RHBQ-3.2
-            productVariant: 8Base-MW-RHBQ-3.2
-      generator:
-        type: maven-domino
-        args: "--config-file .domino/manifest/quarkus-bom-config.json --warn-on-missing-scm --legacy-scm-locator"
 "436":
   products:
     - processors:

--- a/core/src/main/resources/META-INF/sbomer-config.yaml
+++ b/core/src/main/resources/META-INF/sbomer-config.yaml
@@ -23,7 +23,7 @@ sbomer:
     generators:
       maven-domino:
         default-version: "0.0.104"
-        default-args: "--warn-on-missing-scm"
+        default-args: "--warn-on-missing-scm --legacy-scm-locator"
       maven-cyclonedx:
         default-version: "2.7.9"
         default-args: "--batch-mode"

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
@@ -41,7 +41,7 @@ public class SbomerConfigProviderTest {
                 "--batch-mode",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_CYCLONEDX).defaultArgs());
         assertEquals(
-                "--warn-on-missing-scm",
+                "--warn-on-missing-scm --legacy-scm-locator",
                 defaultGenerationConfig.generators().get(GeneratorType.MAVEN_DOMINO).defaultArgs());
         assertEquals("-info", defaultGenerationConfig.generators().get(GeneratorType.GRADLE_CYCLONEDX).defaultArgs());
     }


### PR DESCRIPTION
Default SCM locator used by Domino is slow and has problems when deployed in a constrined environment not allowing to connect to not-whitelisted hosts.

https://issues.redhat.com/browse/SBOMER-76