### PR TITLE
feat: sbom generation request names contain id

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -93,11 +93,8 @@ public class PncNotificationHandler {
         if (isSuccessfulPersistentBuild(messageBody)) {
             log.info("Triggering automated SBOM generation for PNC build '{}'' ...", messageBody.getBuild().getId());
 
-            GenerationRequest req = new GenerationRequestBuilder()
-                    .withNewDefaultMetadata(messageBody.getBuild().getId(), GenerationRequestType.BUILD)
-                    .endMetadata()
+            GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.BUILD)
                     .withIdentifier(messageBody.getBuild().getId())
-                    .withType(GenerationRequestType.BUILD)
                     .withStatus(SbomGenerationStatus.NEW)
                     .build();
 
@@ -130,11 +127,8 @@ public class PncNotificationHandler {
         if (isFinishedAnalysis(messageBody)) {
 
             log.info("Triggering automated SBOM generation for PNC build '{}'' ...", messageBody.getOperationId());
-            GenerationRequest req = new GenerationRequestBuilder()
-                    .withNewDefaultMetadata(messageBody.getOperationId(), GenerationRequestType.OPERATION)
-                    .endMetadata()
+            GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.OPERATION)
                     .withIdentifier(messageBody.getOperationId())
-                    .withType(GenerationRequestType.OPERATION)
                     .withStatus(SbomGenerationStatus.NEW)
                     .build();
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
@@ -20,18 +20,31 @@ package org.jboss.sbomer.service.feature.sbom.k8s.model;
 import java.util.Optional;
 
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
 import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
 
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 
 public class GenerationRequestBuilder extends GenerationRequestFluent<GenerationRequestBuilder>
         implements VisitableBuilder<GenerationRequest, GenerationRequestBuilder> {
 
+    public GenerationRequestBuilder(GenerationRequestType type) {
+        withId(RandomStringIdGenerator.generate());
+        withType(type);
+    }
+
     @Override
     public GenerationRequest build() {
-        addToData(GenerationRequest.KEY_ID, RandomStringIdGenerator.generate());
+        withNewMetadataLike(
+                new ObjectMetaBuilder().withGenerateName("sbom-request-" + getId().toLowerCase() + "-")
+                        .withLabels(Labels.defaultLabelsToMap(getType()))
+                        .build())
+                .endMetadata();
+
+        addToData(GenerationRequest.KEY_ID, getId());
         addToData(GenerationRequest.KEY_IDENTIFIER, getIdentifier());
         addToData(GenerationRequest.KEY_REASON, getReason());
         addToData(GenerationRequest.KEY_ENV_CONFIG, getEnvConfig());

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
@@ -19,10 +19,8 @@ package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
-import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
 
 import io.fabric8.kubernetes.api.model.ConfigMapFluent;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 
 @SuppressWarnings(value = "unchecked")
 public class GenerationRequestFluent<A extends GenerationRequestFluent<A>> extends ConfigMapFluent<A> {
@@ -35,15 +33,6 @@ public class GenerationRequestFluent<A extends GenerationRequestFluent<A>> exten
     private String config;
     private String envConfig;
     private GenerationResult result;
-
-    public ConfigMapFluent<A>.MetadataNested<A> withNewDefaultMetadata(
-            String identifier,
-            GenerationRequestType sbomGenerationType) {
-        return withNewMetadataLike(
-                new ObjectMetaBuilder().withGenerateName("sbom-request-" + identifier.toLowerCase() + "-")
-                        .withLabels(Labels.defaultLabelsToMap(sbomGenerationType))
-                        .build());
-    }
 
     public A withType(GenerationRequestType type) {
         this.type = type;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -191,11 +191,8 @@ public class SbomService {
         log.info("New generation request for operation id '{}'", operationId);
         log.debug("Creating GenerationRequest Kubernetes resource...");
 
-        GenerationRequest req = new GenerationRequestBuilder()
-                .withNewDefaultMetadata(operationId, GenerationRequestType.OPERATION)
-                .endMetadata()
+        GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.OPERATION)
                 .withIdentifier(operationId)
-                .withType(GenerationRequestType.OPERATION)
                 .withStatus(SbomGenerationStatus.NEW)
                 .build();
 
@@ -239,10 +236,7 @@ public class SbomService {
             log.info("New generation request for build id '{}'", buildId);
             log.debug("Creating GenerationRequest Kubernetes resource...");
 
-            GenerationRequest req = new GenerationRequestBuilder()
-                    .withNewDefaultMetadata(buildId, GenerationRequestType.BUILD)
-                    .endMetadata()
-                    .withIdentifier(buildId)
+            GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.BUILD).withIdentifier(buildId)
                     .withStatus(SbomGenerationStatus.NEW)
                     .build();
 

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
@@ -18,8 +18,8 @@
 package org.jboss.sbomer.service.test.integ.feature.sbom.k8s.reconciler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -32,9 +32,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
@@ -61,11 +58,13 @@ import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunStatusBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.InjectMock;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Class responsible for testing reconciliation workflow for the generation phase.
@@ -100,15 +99,18 @@ public class GenerationPhaseGenerationRequestReconcilerIT {
     KubernetesServer mockServer;
 
     private GenerationRequest dummyGenerationRequest() throws IOException {
-        return new GenerationRequestBuilder().withNewMetadata()
-                .withName("test-generation-request")
-                .endMetadata()
+        GenerationRequest generationRequest = new GenerationRequestBuilder(GenerationRequestType.BUILD)
                 .withIdentifier("AABBCC")
-                .withType(GenerationRequestType.BUILD)
                 .withStatus(SbomGenerationStatus.GENERATING)
                 .withConfig(TestResources.asString("configs/multi-product.yaml"))
                 .withEnvConfig(TestResources.asString("configs/env-config.yaml"))
                 .build();
+
+        // For test we need to set a stable name
+        generationRequest.getMetadata().setName("test-generation-request");
+
+        return generationRequest;
+
     }
 
     private TaskRun dummyTaskRun() {

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationRequestReconcilerIT.java
@@ -23,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.net.URL;
 import java.util.List;
 
-import jakarta.inject.Inject;
-
 import org.awaitility.Awaitility;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
@@ -38,6 +36,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 @Disabled("This doesn't work, because we are not starting Tekton properly, we need to think about different ways of running integration tests")
@@ -59,12 +58,7 @@ public class GenerationRequestReconcilerIT {
     void testReconciler() {
         operator.start();
 
-        GenerationRequest request = new GenerationRequestBuilder()
-                .withNewDefaultMetadata("AABBCC", GenerationRequestType.BUILD)
-                .withName("test")
-                .endMetadata()
-                .withIdentifier("AABBCC")
-                .withType(GenerationRequestType.BUILD)
+        GenerationRequest request = new GenerationRequestBuilder(GenerationRequestType.BUILD).withIdentifier("AABBCC")
                 .build();
 
         GenerationRequest created = client.resource(request).create();

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/InitializationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/InitializationPhaseGenerationRequestReconcilerIT.java
@@ -68,11 +68,7 @@ public class InitializationPhaseGenerationRequestReconcilerIT {
     GenerationRequestReconciler controller;
 
     private GenerationRequest dummyInitializationRequest(SbomGenerationStatus status) throws IOException {
-        return new GenerationRequestBuilder().withNewDefaultMetadata("AABBCC", GenerationRequestType.BUILD)
-                .withName("test")
-                .endMetadata()
-                .withIdentifier("AABBCC")
-                .withType(GenerationRequestType.BUILD)
+        return new GenerationRequestBuilder(GenerationRequestType.BUILD).withIdentifier("AABBCC")
                 .withStatus(status)
                 .build();
     }


### PR DESCRIPTION
Previously the generation request name was based
on the build identifier. This was a bit problematic when we wanted to gather all logs related to it.
Basing it on the `id` makes it much easier.

https://issues.redhat.com/browse/SBOMER-70