### PR TITLE
[SBOMER-29] - Expose API endpoint to request SBOM generation for output from DelAnalyzer

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -216,7 +216,7 @@ public class PncService {
             log.warn("DeliverableAnalyzerOperation with id '{}' was not found in PNC", operationId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "DeliverableAnalyzerOperation could not be retrieved because PNC responded with an error",
                     ex);
         }
@@ -242,7 +242,7 @@ public class PncService {
             log.warn("ProductVersion with id '{}' was not found in PNC", productVersionId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "ProductVersion could not be retrieved because PNC responded with an error",
                     ex);
         }
@@ -269,7 +269,7 @@ public class PncService {
             log.warn("ProductMilestone with id '{}' was not found in PNC", milestoneId);
             return null;
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "ProductMilestone could not be retrieved because PNC responded with an error",
                     ex);
         }
@@ -418,7 +418,7 @@ public class PncService {
         } catch (RemoteResourceNotFoundException ex) {
             throw new ApplicationException("Artifact with purl '{}' was not found in PNC", purl, ex);
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "Artifact with purl '{}' could not be retrieved because PNC responded with an error",
                     purl,
                     ex);
@@ -444,7 +444,7 @@ public class PncService {
                     reportId,
                     ex);
         } catch (RemoteResourceException ex) {
-            throw new ApplicationException(
+            throw new GeneralPncException(
                     "Analyzed Artifacts for the DeliverableAnalyzerReport '{}' could not be retrieved because PNC responded with an error",
                     reportId,
                     ex);

--- a/core/src/main/java/org/jboss/sbomer/core/config/DeliverableAnalysisConfigSchemaValidator.java
+++ b/core/src/main/java/org/jboss/sbomer/core/config/DeliverableAnalysisConfigSchemaValidator.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.core.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.sbomer.core.SchemaValidator;
+import org.jboss.sbomer.core.SchemaValidator.ValidationResult;
+import org.jboss.sbomer.core.errors.ApplicationException;
+import org.jboss.sbomer.core.features.sbom.config.runtime.DeliverableAnalysisConfig;
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * @author Andrea Vibelli
+ */
+@ApplicationScoped
+public class DeliverableAnalysisConfigSchemaValidator implements Validator<DeliverableAnalysisConfig> {
+    /**
+     * Performs validation of a give {@link DeliverableAnalysisConfig} according to the JSON schema.
+     *
+     * @param config The {@link DeliverableAnalysisConfig} object to validate.
+     * @return a {@link ValidationResult} object.
+     */
+    @Override
+    public ValidationResult validate(DeliverableAnalysisConfig config) {
+        if (config == null) {
+            throw new ApplicationException("No configuration provided");
+        }
+
+        String schema;
+
+        try {
+            InputStream is = SchemaValidator.class.getClassLoader()
+                    .getResourceAsStream("schemas/deliverable_analysis_config.json");
+            schema = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new ApplicationException("Could not read the deliverable analysis configuration file schema", e);
+        }
+
+        try {
+            return SchemaValidator.validate(schema, ObjectMapperProvider.json().writeValueAsString(config));
+        } catch (JsonProcessingException e) {
+            throw new ApplicationException("An error occurred while converting configuration file into JSON", e);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/runtime/DeliverableAnalysisConfig.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/runtime/DeliverableAnalysisConfig.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.core.features.sbom.config.runtime;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * SBOMer configuration file to trigger a new PNC deliverable analysis.
+ *
+ * @author Andrea Vibelli
+ */
+@Getter
+@Setter
+@Builder(setterPrefix = "with")
+@Jacksonized
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class DeliverableAnalysisConfig {
+
+    /**
+     * The API version of the configuration file. In case of breaking changes this value will be used to detect the
+     * correct (de)serializer.
+     */
+    @Builder.Default
+    String apiVersion = "sbomer.jboss.org/v1alpha1";
+
+    /**
+     * Milestone identifier for the new deliverable analysis within PNC.
+     */
+    String milestoneId;
+
+    /**
+     * Product configuration Errata metadata.
+     */
+    ErrataConfig errata;
+
+    /**
+     * Deliverables entries for the given operation.
+     */
+    List<String> deliverableUrls;
+}

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/CommandLineParserUtil.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/commandline/CommandLineParserUtil.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.sbomer.core.features.sbom.utils.commandline;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 

--- a/core/src/main/resources/schemas/deliverable_analysis_config.json
+++ b/core/src/main/resources/schemas/deliverable_analysis_config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://jboss.org/sbomer/operation-config.json",
-  "title": "SBOMeruser configuration file",
+  "$id": "https://jboss.org/sbomer/deliverables-analysis-operation-config.json",
+  "title": "SBOMer user configuration file",
   "description": "User-provided configuration file to trigger a PNC deliverable analysis operation",
   "type": "object",
   "properties": {
@@ -44,7 +44,7 @@
     }
   }, 
   "required": [
-    "milestoneId, deliverableUrls"
+    "milestoneId", "deliverableUrls"
   ],
   "additionalProperties": false
 }

--- a/core/src/main/resources/schemas/deliverable_analysis_config.json
+++ b/core/src/main/resources/schemas/deliverable_analysis_config.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jboss.org/sbomer/operation-config.json",
+  "title": "SBOMeruser configuration file",
+  "description": "User-provided configuration file to trigger a PNC deliverable analysis operation",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "Version of the configuration file",
+      "enum": ["sbomer.jboss.org/v1alpha1"]
+    },
+    "milestoneId": {
+      "description": "PNC milestone identifier",
+      "type": "string"
+    },
+    "errata": {
+      "description": "Product information from Errata Tool",
+      "type": "object",
+      "properties": {
+        "productName": {
+          "description": "Errata Tool product name",
+          "type": "string"
+        },
+        "productVersion": {
+          "description": "Errata Tool product version",
+          "type": "string"
+        },
+        "productVariant": {
+          "description": "Errata Tool product variant",
+          "type": "string"
+        }
+      },
+      "required": ["productName", "productVersion", "productVariant"],
+      "additionalProperties": false
+    },
+    "deliverableUrls": {
+      "description": "List of deliverables urls",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "The deliverable url",
+        "additionalProperties": false
+      }
+    }
+  }, 
+  "required": [
+    "milestoneId, deliverableUrls"
+  ],
+  "additionalProperties": false
+}

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/DeliverableAnalysisConfigSchemaValidatorTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/DeliverableAnalysisConfigSchemaValidatorTest.java
@@ -1,0 +1,73 @@
+package org.jboss.sbomer.core.test.unit.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.jboss.sbomer.core.SchemaValidator.ValidationResult;
+import org.jboss.sbomer.core.config.DeliverableAnalysisConfigSchemaValidator;
+import org.jboss.sbomer.core.errors.ApplicationException;
+import org.jboss.sbomer.core.features.sbom.config.runtime.DeliverableAnalysisConfig;
+import org.jboss.sbomer.core.features.sbom.config.runtime.ErrataConfig;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class DeliverableAnalysisConfigSchemaValidatorTest {
+    DeliverableAnalysisConfigSchemaValidator validator = new DeliverableAnalysisConfigSchemaValidator();
+
+    private DeliverableAnalysisConfig minimalDeliverableAnalysisConfig() {
+        String milestoneId = "13";
+        List<String> urls = List.of("http://myurl1.com", "http://myurl2.com");
+
+        return DeliverableAnalysisConfig.builder().withDeliverableUrls(urls).withMilestoneId(milestoneId).build();
+    }
+
+    private DeliverableAnalysisConfig productDeliverableAnalysisConfig() {
+        String milestoneId = "13";
+        List<String> urls = List.of("http://myurl1.com", "http://myurl2.com");
+        ErrataConfig errata = ErrataConfig.builder()
+                .productName("productName")
+                .productVariant("productVariant")
+                .productVersion("productVersion")
+                .build();
+
+        return DeliverableAnalysisConfig.builder()
+                .withDeliverableUrls(urls)
+                .withMilestoneId(milestoneId)
+                .withErrata(errata)
+                .build();
+    }
+
+    @Nested
+    class BeforeAdjustments {
+
+        @Test
+        void shouldGracefullyFailOnNullConfig() {
+            ApplicationException ex = assertThrows(ApplicationException.class, () -> {
+                validator.validate(null);
+            });
+
+            assertEquals("No configuration provided", ex.getMessage());
+        }
+
+        @Test
+        void shouldNotFailOnValidMinimalConfig() {
+
+            DeliverableAnalysisConfig config = minimalDeliverableAnalysisConfig();
+            ValidationResult result = validator.validate(config);
+            assertTrue(result.isValid());
+            assertTrue(result.getErrors().isEmpty());
+        }
+
+        @Test
+        void shouldNotFailOnValidProductConfig() {
+
+            DeliverableAnalysisConfig config = productDeliverableAnalysisConfig();
+            ValidationResult result = validator.validate(config);
+            assertTrue(result.isValid());
+            assertTrue(result.getErrors().isEmpty());
+        }
+    }
+}

--- a/docs/modules/user-guide/pages/api.adoc
+++ b/docs/modules/user-guide/pages/api.adoc
@@ -48,6 +48,43 @@ To request SBOM generation we need to pass the PNC build id:
 $ curl -v -X POST {sbomer-url}/api/{sbomer-latest-api-version}/sboms/generate/build/[PNC_BUILD_ID]
 ----
 
+=== Requesting ZIP SBOM Generation Manually
+
+[NOTE]
+====
+This should not be required in general. SBOMer generates ZIP SBOMs automatically for successful PNC Deliverable Analysis operations. It can
+still be handy if you want to retry a generation.
+====
+
+To request ZIP SBOM generation we need to pass the PNC deliverable analysis operation id:
+
+[source,console,subs="attributes+"]
+----
+$ curl -v -X POST {sbomer-url}/api/{sbomer-latest-api-version}/sboms/generate/operation/[PNC_DELIVERABLE_ANALYSIS_OPERATION_ID]
+----
+
+=== Requesting ZIP Analysis Manually
+
+To request a ZIP deliverable analysis in PNC, which will eventually notify SBOMer of its completion and subsequently trigger a ZIP SBOM generation, we need to pass some required information:
+
+[source,console,subs="attributes+"]
+----
+$ curl -v -X POST {sbomer-url}/api/{sbomer-latest-api-version}/sboms/generate/analysis \ 
+  -H 'accept: application/json' -H 'Content-Type: application/json' \
+  -d '{
+  "apiVersion": "sbomer.jboss.org/v1alpha1",
+  "milestoneId": "$milestoneId",
+  "errata": {
+     "productName": "$productName",
+     "productVersion": "$productVersion",
+     "productVariant": "$productVariant"
+  },
+  "deliverablesUrls": [
+    "$deliverablesUrl"
+  ]
+}'
+----
+
 === Fetching a Specific SBOM
 
 Once the SBOM is generated it becomes available at:

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/PncConfig.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/PncConfig.java
@@ -25,6 +25,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ConfigMapping(prefix = "sbomer.pnc")
 public interface PncConfig {
 
-    @WithDefault("http://localhost:8080/api/v1alpha2/")
+    @WithDefault("localhost")
     String host();
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/PncConfig.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/config/PncConfig.java
@@ -17,23 +17,14 @@
  */
 package org.jboss.sbomer.service.feature.sbom.config;
 
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import java.util.List;
-
-import io.smallrye.config.ConfigMapping;
-
-/**
- * @author Marek Goldmann
- */
 @ApplicationScoped
-@ConfigMapping(prefix = "sbomer")
-public interface SbomerConfig {
-    String apiUrl();
+@ConfigMapping(prefix = "sbomer.pnc")
+public interface PncConfig {
 
-    List<String> purlQualifiersAllowList();
-
-    ControllerConfig controller();
-
-    PncConfig pnc();
+    @WithDefault("http://localhost:8080/api/v1alpha2/")
+    String host();
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.sbomer.service.feature.sbom.features.umb.consumer;
 
+import java.util.List;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jboss.pnc.api.enums.BuildStatus;
 import org.jboss.pnc.api.enums.BuildType;
@@ -30,13 +32,16 @@ import org.jboss.sbomer.service.feature.sbom.features.umb.consumer.model.PncDelA
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -125,12 +130,28 @@ public class PncNotificationHandler {
         }
 
         if (isFinishedAnalysis(messageBody)) {
-
+            GenerationRequest req = null;
             log.info("Triggering automated SBOM generation for PNC build '{}'' ...", messageBody.getOperationId());
-            GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.OPERATION)
-                    .withIdentifier(messageBody.getOperationId())
-                    .withStatus(SbomGenerationStatus.NEW)
-                    .build();
+
+            List<SbomGenerationRequest> pendingRequests = SbomGenerationRequest
+                    .findPendingRequests(messageBody.getOperationId());
+
+            // If there are no pending generation requests create a new ConfigMap
+            if (pendingRequests.isEmpty()) {
+                req = new GenerationRequestBuilder(GenerationRequestType.OPERATION)
+                        .withIdentifier(messageBody.getOperationId())
+                        .withStatus(SbomGenerationStatus.NEW)
+                        .build();
+
+            } else {
+                // Otherwise get the oldest pending generation request and create a new ConfigMap with the existing id
+                SbomGenerationRequest pendingRequest = pendingRequests.get(0);
+                req = new GenerationRequestBuilder(GenerationRequestType.OPERATION)
+                        .withIdentifier(messageBody.getOperationId())
+                        .withStatus(SbomGenerationStatus.NEW)
+                        .withId(pendingRequest.getId())
+                        .build();
+            }
 
             log.debug("ConfigMap to create: '{}'", req);
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationStatus.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/SbomGenerationStatus.java
@@ -18,7 +18,7 @@
 package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 public enum SbomGenerationStatus {
-    NEW, INITIALIZING, INITIALIZED, GENERATING, FINISHED, FAILED;
+    NO_OP, NEW, INITIALIZING, INITIALIZED, GENERATING, FINISHED, FAILED;
 
     public static SbomGenerationStatus fromName(String phase) {
         return SbomGenerationStatus.valueOf(phase.toUpperCase());
@@ -29,7 +29,7 @@ public enum SbomGenerationStatus {
     }
 
     public boolean isOlderThan(SbomGenerationStatus desiredStatus) {
-        if (desiredStatus == null) {
+        if (desiredStatus == null || desiredStatus.equals(NO_OP)) {
             return false;
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
@@ -1080,10 +1080,17 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
 
         // This would be unexpected.
         if (action == null) {
-            log.error(
-                    "Unknown status received: '{}'' for GenerationRequest '{}",
-                    generationRequest.getStatus(),
-                    generationRequest.getMetadata().getName());
+            if (generationRequest.getStatus().equals(SbomGenerationStatus.NO_OP)) {
+                log.info(
+                        "No operation status received: '{}' for GenerationRequest '{}', doing nothing!",
+                        generationRequest.getStatus(),
+                        generationRequest.getMetadata().getName());
+            } else {
+                log.error(
+                        "Unknown status received: '{}' for GenerationRequest '{}'",
+                        generationRequest.getStatus(),
+                        generationRequest.getMetadata().getName());
+            }
             return UpdateControl.noUpdate();
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.model;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -198,6 +199,17 @@ public class SbomGenerationRequest extends PanacheEntityBase {
                 generationRequest.getMetadata().getName());
 
         return sbomGenerationRequest;
+    }
+
+    @Transactional
+    public static List<SbomGenerationRequest> findPendingRequests(String operationId) {
+        return SbomGenerationRequest
+                .find(
+                        "type = ?1 and identifier = ?2 and status = ?3 order by creationTime asc",
+                        GenerationRequestType.OPERATION,
+                        operationId,
+                        SbomGenerationStatus.NO_OP)
+                .list();
     }
 
     @PrePersist

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
@@ -32,6 +32,7 @@ import org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord;
 import org.jboss.sbomer.core.dto.v1alpha3.SbomRecord;
 import org.jboss.sbomer.core.errors.ErrorResponse;
 import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
+import org.jboss.sbomer.core.features.sbom.config.runtime.DeliverableAnalysisConfig;
 import org.jboss.sbomer.core.features.sbom.config.runtime.OperationConfig;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
 import org.jboss.sbomer.core.utils.PaginationParameters;
@@ -333,4 +334,26 @@ public class SBOMResource extends AbstractApiProvider {
                 .build();
 
     }
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML })
+    @Operation(
+            summary = "Triggers a PNC Deliverable Analysis using the provided information",
+            description = "Triggers a PNC Deliverable Analysis using the provided information.")
+    @Path("/sboms/generate/analysis")
+    @APIResponses({ @APIResponse(
+            responseCode = "202",
+            description = "Schedules a new PNC operation of type deliverable analysis. This is an asynchronous call. PNC will start the deliverable analysis from the provided configuration and will notify the end of the analysis asynchronously.",
+            content = @Content(schema = @Schema(implementation = SbomGenerationRequestRecord.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
+
+    public Response generateNewOperation(DeliverableAnalysisConfig config) throws Exception {
+
+        return Response.accepted(mapper.toSbomRequestRecord(sbomService.generateNewOperation(config))).build();
+
+    }
+
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/PncClientsWrapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/PncClientsWrapper.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.service;
+
+import java.util.List;
+
+import org.jboss.pnc.client.Configuration;
+import org.jboss.pnc.client.Configuration.ConfigurationBuilder;
+import org.jboss.pnc.client.ProductMilestoneClient;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.dto.DeliverableAnalyzerOperation;
+import org.jboss.pnc.dto.requests.DeliverablesAnalysisRequest;
+import org.jboss.sbomer.core.errors.ClientException;
+import org.jboss.sbomer.service.feature.sbom.config.SbomerConfig;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+public class PncClientsWrapper {
+
+    @Inject
+    SbomerConfig sbomerConfig;
+
+    ProductMilestoneClient productMilestoneClient;
+
+    @PostConstruct
+    void init() {
+        productMilestoneClient = new ProductMilestoneClient(getConfiguration());
+    }
+
+    @PreDestroy
+    void cleanup() {
+        productMilestoneClient.close();
+    }
+
+    /**
+     * Setup basic configuration to be able to talk to PNC.
+     *
+     *
+     * @return
+     */
+    public Configuration getConfiguration() {
+        ConfigurationBuilder configurationBuilder = Configuration.builder()
+                .host(sbomerConfig.pnc().host())
+                .protocol("http");
+        return configurationBuilder.build();
+    }
+
+    /**
+     * Triggers a new Deliverable Analysis operation in PNC for the specified milestone and urls.
+     *
+     * @param milestoneId The milestone identifier for the new deliverable analysis operation
+     * @param deliverableUrls The list of deliverable URLs to be analyzed
+     * @return The {@link DeliverableAnalyzerOperation} object identifying the new operation
+     */
+    public DeliverableAnalyzerOperation analyzeDeliverables(String milestoneId, List<String> deliverableUrls) {
+        DeliverablesAnalysisRequest request = DeliverablesAnalysisRequest.builder()
+                .deliverablesUrls(deliverableUrls)
+                .runAsScratchAnalysis(false)
+                .build();
+        try {
+            log.info(
+                    "Triggering new deliverable analysis operation for the milestone {} and urls '{}'",
+                    milestoneId,
+                    deliverableUrls);
+            return productMilestoneClient.analyzeDeliverables(milestoneId, request);
+        } catch (RemoteResourceException ex) {
+            throw new ClientException(
+                    "A Deliverable Analysis Operation could not be started because PNC responded with an error",
+                    ex);
+        }
+    }
+
+}

--- a/service/src/main/resources/application-dev.yaml
+++ b/service/src/main/resources/application-dev.yaml
@@ -36,6 +36,10 @@ quarkus:
 
 sbomer:
   api-url: "http://localhost:8080/api/v1alpha2/"
+  pnc:
+    ## (required)
+    ## Hostname of the PNC service
+    # host:
 
   purl-qualifiers-allow-list:
     - repository_url

--- a/service/src/main/resources/application-prod.yaml
+++ b/service/src/main/resources/application-prod.yaml
@@ -31,6 +31,10 @@ mp:
 
 sbomer:
   api-url: "https://${SBOMER_ROUTE_HOST}/api/v1alpha2/"
+  pnc:
+    ## (required)
+    ## Hostname of the PNC service
+    # host:
 
   purl-qualifiers-allow-list:
     - repository_url

--- a/service/src/main/resources/application-test.yaml
+++ b/service/src/main/resources/application-test.yaml
@@ -38,6 +38,10 @@ sbomer:
       sbom-dir: "/tmp/sbomer"
 
   api-url: "http://localhost:8080/api/v1alpha2/"
+  pnc:
+    ## (required)
+    ## Hostname of the PNC service
+    # host:
 
   purl-qualifiers-allow-list:
     - repository_url


### PR DESCRIPTION
This replaces https://github.com/project-ncl/sbomer/pull/471.

@goldmann This PR is meant to expose a new REST API to trigger a new Deliverable Analysis operation in PNC.

- The REST API will create an entry in the DB containing the Product Config metadata and the identifier of the new operation created in PNC via the PncService. It will not create any ConfigMap because there would be nothing to do anyway, as the creation of the new analysis in PNC will send back a UMB notification once finished. Until then, there is nothing to do
- Once a UMB notification is received, if there is a pending requests in the DB which a matching operation Id, it will be used to create a new ConfigMap with the same id, otherwise a new ConfigMap will be created.

