### PR TITLE
[SBOMER-83]: Expand support for manifesting different products deliverables

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/ExceptionHandler.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/ExceptionHandler.java
@@ -38,7 +38,11 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
         cmd.getErr().println();
         cmd.getErr().println(cmd.getColorScheme().errorText("🛑 Ooops, an error occurred!"));
         cmd.getErr().println();
-        cmd.getErr().println(cmd.getColorScheme().errorText(ex.getMessage()));
+
+        if (ex.getMessage() != null) {
+            cmd.getErr().println(cmd.getColorScheme().errorText(ex.getMessage()));
+        }
+
         cmd.getErr().println();
 
         if (ex instanceof ClientException) {

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/Adjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/Adjuster.java
@@ -15,21 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.features.sbom.enums;
+package org.jboss.sbomer.cli.feature.sbom.adjuster;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cyclonedx.model.Bom;
 
-/**
- * Supported generator implementations.
- *
- * @author Marek Goldmann
- */
-public enum GeneratorType {
-    @JsonProperty("maven-cyclonedx")
-    MAVEN_CYCLONEDX, @JsonProperty("maven-domino")
-    MAVEN_DOMINO, @JsonProperty("gradle-cyclonedx")
-    GRADLE_CYCLONEDX, @JsonProperty("nodejs-cyclonedx")
-    NODEJS_CYCLONEDX, @JsonProperty("cyclonedx-operation")
-    CYCLONEDX_OPERATION, @JsonProperty("image-syft")
-    IMAGE_SYFT
+public interface Adjuster {
+    public default Bom adjust(Bom bom) {
+        return bom;
+    }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
@@ -49,7 +49,6 @@ public class SyftImageAdjuster implements Adjuster {
                     "Moving '{}' properties from metadata to main component",
                     bom.getMetadata().getProperties().size());
 
-            System.out.println(bom.getMetadata().getProperties().toString());
             productComponent.getProperties().addAll(bom.getMetadata().getProperties());
             bom.getMetadata().setProperties(null);
         }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
@@ -53,6 +53,16 @@ public class SyftImageAdjuster implements Adjuster {
             bom.getMetadata().setProperties(null);
         }
 
+        // Remove all components that are not on the paths we are interested in
+        bom.getComponents().removeIf(c -> {
+            return c.getProperties()
+                    .stream()
+                    // TODO: this is hardocded and needs to be customizable
+                    .filter(p -> p.getName().equals("syft:location:0:path") && p.getValue().startsWith("/opt"))
+                    .findAny()
+                    .isEmpty();
+        });
+
         // Cleanup main component
         cleanupComponent(productComponent);
 
@@ -67,16 +77,6 @@ public class SyftImageAdjuster implements Adjuster {
                         .append("@")
                         .append(UrlUtils.urlencode(productComponent.getVersion()))
                         .toString());
-
-        // Remove all components that are not on the paths we are interested in
-        bom.getComponents().removeIf(c -> {
-            return c.getProperties()
-                    .stream()
-                    // TODO: this is hardocded and needs to be customizable
-                    .filter(p -> p.getName().equals("sbomer:location:0:path") && p.getValue().startsWith("/opt"))
-                    .findAny()
-                    .isEmpty();
-        });
 
         // Populate dependencies section with components
         populateDependencies(bom);

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
@@ -1,0 +1,164 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.adjuster;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Dependency;
+import org.cyclonedx.model.Property;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.core.features.sbom.utils.UrlUtils;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+
+@ApplicationScoped
+@Slf4j
+public class SyftImageAdjuster implements Adjuster {
+    @Override
+    public Bom adjust(Bom bom) {
+        Component productComponent = bom.getMetadata().getComponent();
+
+        // Initialize properties for main component, if not done so yet
+        if (productComponent.getProperties() == null) {
+            productComponent.setProperties(new ArrayList<>());
+        }
+
+        // If there are properties in the metadata field of the manifest, move these into the main component's
+        // properties.
+        if (bom.getMetadata().getProperties() != null) {
+            log.debug(
+                    "Moving '{}' properties from metadata to main component",
+                    bom.getMetadata().getProperties().size());
+
+            System.out.println(bom.getMetadata().getProperties().toString());
+            productComponent.getProperties().addAll(bom.getMetadata().getProperties());
+            bom.getMetadata().setProperties(null);
+        }
+
+        // Cleanup main component
+        cleanupComponent(productComponent);
+
+        // ...and all other components
+        bom.getComponents().forEach(component -> {
+            cleanupComponent(component);
+        });
+
+        // Set the purl for the main component
+        productComponent.setPurl(
+                new StringBuilder("pkg:oci/").append(productComponent.getName().split("/")[2])
+                        .append("@")
+                        .append(UrlUtils.urlencode(productComponent.getVersion()))
+                        .toString());
+
+        // Remove all components that are not on the paths we are interested in
+        bom.getComponents().removeIf(c -> {
+            return c.getProperties()
+                    .stream()
+                    // TODO: this is hardocded and needs to be customizable
+                    .filter(p -> p.getName().equals("sbomer:location:0:path") && p.getValue().startsWith("/opt"))
+                    .findAny()
+                    .isEmpty();
+        });
+
+        // Populate dependencies section with components
+        populateDependencies(bom);
+
+        return bom;
+    }
+
+    private void populateDependencies(Bom bom) {
+        List<Dependency> dependencies = new ArrayList<>();
+
+        Dependency product = SbomUtils.createDependency(bom.getMetadata().getComponent().getPurl());
+
+        dependencies.add(product);
+
+        // For each component, if it's not already in the dependencies, add it to both: dependency list as well as a
+        // dependency to the main product dependency
+        bom.getComponents().forEach(c -> {
+            if (dependencies.stream().anyMatch(d -> d.getRef().equals(c.getPurl()))) {
+                return;
+            }
+
+            Dependency dependency = SbomUtils.createDependency(c.getPurl());
+            dependencies.add(dependency);
+            product.addDependency(dependency);
+
+        });
+
+        bom.setDependencies(dependencies);
+    }
+
+    private void cleanupComponent(Component component) {
+        log.debug("Cleaning up component '{}'", component.getPurl());
+
+        // Remove CPE, we don't use it now
+        component.setCpe(null);
+        // Remove BOM ref, we don't use it now
+        component.setBomRef(null);
+
+        if (component.getProperties() != null) {
+            List<String> supportedPropsPrefixes = List.of(
+                    "sbomer:package:language",
+                    "sbomer:package:type",
+                    "sbomer:location:0:path",
+                    "sbomer:image:labels");
+
+            // Adjust property names
+            component.getProperties().forEach(p -> {
+                String newName = p.getName().replace("syft:", "sbomer:");
+
+                log.debug("Adjusting property name from '{}' to '{}'", p.getName(), newName);
+
+                p.setName(newName);
+            });
+
+            // Remove properties we don't care about
+            component.getProperties().removeIf(prop -> {
+                boolean supportedProp = supportedPropsPrefixes.stream()
+                        .anyMatch(prefix -> prop.getName().startsWith(prefix));
+
+                if (!supportedProp) {
+                    log.debug(
+                            "Property '{}' with value '{}' is not on the supported properties list, removing...",
+                            prop.getName(),
+                            prop.getValue());
+                }
+
+                return !supportedProp;
+            });
+
+            // Adjust purl for Java components
+            Property propType = SbomUtils.findPropertyWithNameInComponent("sbomer:package:type", component)
+                    .orElse(null);
+
+            if (component.getPurl() != null && propType != null && propType.getValue().equals("java-archive")) {
+                log.debug(
+                        "Adjusting purl for the '{}' Java component by adding '?type=jar' suffix...",
+                        component.getPurl());
+                component.setPurl(component.getPurl() + "?type=jar");
+            }
+        }
+
+        log.debug("Component '{}' adjusted", component.getPurl());
+    }
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGenerateCommand.java
@@ -42,8 +42,8 @@ import org.jboss.sbomer.cli.feature.sbom.command.mixin.GeneratorToolMixin;
 import org.jboss.sbomer.cli.feature.sbom.model.Sbom;
 import org.jboss.sbomer.cli.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.cli.feature.sbom.service.PncService;
-import org.jboss.sbomer.core.config.SbomerConfigProvider;
 import org.jboss.sbomer.core.config.DefaultGenerationConfig.DefaultGeneratorConfig;
+import org.jboss.sbomer.core.config.SbomerConfigProvider;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.runtime.ProductConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GeneratorType;
@@ -57,7 +57,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import picocli.CommandLine;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/DefaultProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/DefaultProcessCommand.java
@@ -17,38 +17,18 @@
  */
 package org.jboss.sbomer.cli.feature.sbom.command;
 
-import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_BREW_BUILD_ID;
-import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_ENVIRONMENT_IMAGE;
-import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_PNC_BUILD_ID;
-
-import java.util.Optional;
+import java.nio.file.Path;
 
 import org.cyclonedx.model.Bom;
-import org.cyclonedx.model.Component;
-import org.cyclonedx.model.ExternalReference;
-import org.cyclonedx.model.Hash;
-import org.jboss.pnc.build.finder.koji.KojiBuild;
-import org.jboss.pnc.dto.Artifact;
-import org.jboss.sbomer.cli.feature.sbom.service.KojiService;
-import org.jboss.sbomer.cli.feature.sbom.service.PncService;
+import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
 import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
-import org.jboss.sbomer.core.features.sbom.utils.RhVersionPattern;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
+import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPublisher;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setSupplier;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.addMrrc;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.hasExternalReference;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHash;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setArtifactMetadata;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPncBuildMetadata;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setBrewBuildMetadata;
-
-@Slf4j
 @Command(
         mixinStandardHelpOptions = true,
         name = "default",
@@ -56,113 +36,29 @@ import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setBrewBuildMe
 public class DefaultProcessCommand extends AbstractProcessCommand {
 
     @ParentCommand
+    @Getter
     ProcessCommand parent;
 
     @Inject
-    protected PncService pncService;
-
-    @Inject
-    protected KojiService kojiService;
-
-    /**
-     * Performs processing for a given {@link Component}.
-     *
-     * @param component
-     */
-    protected void processComponent(Component component) {
-        if (!RhVersionPattern.isRhVersion(component.getVersion()) && !RhVersionPattern.isRhPurl(component.getPurl())) {
-            log.info("Component unknown to PNC found, purl: '{}', skipping processing", component.getPurl());
-            return;
-        }
-
-        log.debug("Component with Red Hat version found, purl: {}", component.getPurl());
-
-        setPublisher(component);
-        setSupplier(component);
-        addMrrc(component);
-
-        // If the component does not have "pnc-build-id" nor "pnc-environment-image" nor "brew-build-id", query it
-        if (!hasExternalReference(component, ExternalReference.Type.BUILD_SYSTEM, SBOM_RED_HAT_PNC_BUILD_ID)
-                && !hasExternalReference(component, ExternalReference.Type.BUILD_META, SBOM_RED_HAT_ENVIRONMENT_IMAGE)
-                && !hasExternalReference(component, ExternalReference.Type.BUILD_SYSTEM, SBOM_RED_HAT_BREW_BUILD_ID)) {
-
-            Optional<String> sha256 = getHash(component, Hash.Algorithm.SHA_256);
-            Artifact artifact = pncService
-                    .getArtifact(getParent().getParent().getParent().getBuildId(), component.getPurl(), sha256);
-
-            if (artifact == null) {
-                log.warn(
-                        "Artifact with purl '{}' was not found in PNC, skipping processing for this artifact",
-                        component.getPurl());
-                return;
-            }
-
-            log.info(
-                    "Starting processing of Red Hat component '{}' with PNC artifact '{}'...",
-                    component.getPurl(),
-                    artifact.getId());
-
-            // Add artifact metadata (PNC url)
-            setArtifactMetadata(component, artifact, pncService.getApiUrl());
-
-            // Add build-related information, if we found a build in PNC
-            if (artifact.getBuild() != null) {
-                log.debug(
-                        "Component '{}' was built in PNC, adding enrichment from PNC build '{}'",
-                        component.getPurl(),
-                        artifact.getBuild().getId());
-
-                setPncBuildMetadata(component, artifact.getBuild(), pncService.getApiUrl());
-            } else {
-                // Lookup the build in Brew, as the artifact was found in PNC but without a build attached
-                log.debug(
-                        "Component '{}' was not built in PNC, will search in Brew the corresponding artifact '{}'",
-                        component.getPurl(),
-                        artifact.getPublicUrl());
-                processBrewBuild(component, artifact);
-            }
-        } else {
-            log.debug(
-                    "Component with purl '{}' is already enriched, skipping further processing for this component",
-                    component.getPurl());
-        }
-    }
-
-    protected void processBrewBuild(Component component, Artifact artifact) {
-        KojiBuild brewBuild = kojiService.findBuild(artifact);
-        if (brewBuild != null) {
-
-            log.debug(
-                    "Component '{}' was built in Brew, adding enrichment from Brew build '{}'",
-                    component.getPurl(),
-                    brewBuild.getBuildInfo().getId());
-
-            setBrewBuildMetadata(
-                    component,
-                    String.valueOf(brewBuild.getBuildInfo().getId()),
-                    brewBuild.getSource(),
-                    kojiService.getConfig().getKojiWebURL().toString());
-        } else {
-            log.debug("Component '{}' was not built in Brew, cannot add any enrichment!", component.getPurl());
-        }
-    }
+    DefaultProcessor defaultProcessor;
 
     @Override
     public ProcessorType getImplementationType() {
-        return ProcessorType.DEFAULT;
+        return defaultProcessor.getType();
     }
 
     @Override
     public Bom doProcess(Bom bom) {
-        if (bom.getMetadata() != null && bom.getMetadata().getComponent() != null) {
-            processComponent(bom.getMetadata().getComponent());
-        }
-        if (bom.getComponents() != null) {
-            for (Component c : bom.getComponents()) {
-                processComponent(c);
-            }
-        }
+        return defaultProcessor.process(bom);
+    }
 
-        return bom;
+    @Override
+    protected Path manifestPath() {
+        return parent.getParent().getParent().getOutput();
+    }
+
+    @Override
+    protected void addContext() {
+        MDCUtils.addBuildContext(parent.getParent().getParent().getBuildId());
     }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/RedHatProductProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/RedHatProductProcessCommand.java
@@ -20,19 +20,20 @@ package org.jboss.sbomer.cli.feature.sbom.command;
 import static org.jboss.sbomer.core.features.sbom.Constants.PROPERTY_ERRATA_PRODUCT_NAME;
 import static org.jboss.sbomer.core.features.sbom.Constants.PROPERTY_ERRATA_PRODUCT_VARIANT;
 import static org.jboss.sbomer.core.features.sbom.Constants.PROPERTY_ERRATA_PRODUCT_VERSION;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.addPropertyIfMissing;
 
-import jakarta.inject.Inject;
+import java.nio.file.Path;
 
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.jboss.sbomer.cli.feature.sbom.service.PncService;
 import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 
+import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
-
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.addPropertyIfMissing;
 
 @Command(
         mixinStandardHelpOptions = true,
@@ -69,5 +70,15 @@ public class RedHatProductProcessCommand extends AbstractProcessCommand {
         addPropertyIfMissing(component, PROPERTY_ERRATA_PRODUCT_VARIANT, productVariant);
 
         return bom;
+    }
+
+    @Override
+    protected Path manifestPath() {
+        return parent.getParent().getParent().getOutput();
+    }
+
+    @Override
+    protected void addContext() {
+        MDCUtils.addBuildContext(parent.getParent().getParent().getBuildId());
     }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/SbomCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/SbomCommand.java
@@ -17,10 +17,11 @@
  */
 package org.jboss.sbomer.cli.feature.sbom.command;
 
-import jakarta.inject.Inject;
-
 import org.jboss.sbomer.cli.FeatureTopCommand;
+import org.jboss.sbomer.cli.feature.sbom.command.adjust.AdjustCommand;
+import org.jboss.sbomer.cli.feature.sbom.command.process.StandaloneProcessCommand;
 
+import jakarta.inject.Inject;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -31,7 +32,8 @@ import picocli.CommandLine.Spec;
         name = "sbom",
         aliases = { "s" },
         description = "SBOM generation",
-        subcommands = { AutoCommand.class, GenerateCommand.class, GenerateOperationCommand.class })
+        subcommands = { AutoCommand.class, GenerateCommand.class, GenerateOperationCommand.class,
+                StandaloneProcessCommand.class, AdjustCommand.class })
 public class SbomCommand implements FeatureTopCommand {
 
     @Spec

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/AdjustCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/AdjustCommand.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.command.adjust;
+
+import java.nio.file.Path;
+
+import org.jboss.sbomer.cli.feature.sbom.command.PathConverter;
+
+import lombok.Getter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ScopeType;
+
+@Command(
+        mixinStandardHelpOptions = true,
+        name = "adjust",
+        description = "Adjust previously generated manifest so that it can be processed by SBOMer",
+        subcommands = { SyftImageAdjustCommand.class },
+        subcommandsRepeatable = true)
+public class AdjustCommand {
+
+    @Getter
+    @Option(
+            names = { "-p", "--path" },
+            required = true,
+            paramLabel = "FILE",
+            description = "Location of the manifest file which should be adjusted",
+            converter = PathConverter.class,
+            scope = ScopeType.INHERIT)
+    Path path;
+
+    @Getter
+    @Option(
+            names = { "-o", "--output" },
+            defaultValue = "bom.json",
+            paramLabel = "FILE",
+            description = "Location of the adjusted manifest",
+            converter = PathConverter.class,
+            scope = ScopeType.INHERIT)
+    Path outputPath;
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
@@ -15,27 +15,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.cli.test.utils;
+package org.jboss.sbomer.cli.feature.sbom.command.adjust;
 
-import org.cyclonedx.model.Component;
-import org.jboss.pnc.dto.Artifact;
-import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.cli.feature.sbom.adjuster.SyftImageAdjuster;
+import org.jboss.sbomer.core.features.sbom.enums.GeneratorType;
 
-import jakarta.enterprise.inject.Alternative;
-import lombok.extern.slf4j.Slf4j;
+import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
 
-@Alternative
-@Slf4j
 @Command(
         mixinStandardHelpOptions = true,
-        name = "default",
-        description = "Process the SBOM with enrichments applied to known CycloneDX fields")
-public class DefaultProcessCommandMockAlternative extends DefaultProcessor {
+        name = "syft-image",
+        description = "Adjust the Syft manifest output for a container image")
+public class SyftImageAdjustCommand extends AbstractAdjustCommand {
+
+    @Inject
+    SyftImageAdjuster adjuster;
 
     @Override
-    protected void processBrewBuild(Component component, Artifact artifact) {
-        log.debug("Mocked component '{}' was not built in Brew, cannot add any enrichment!", component.getPurl());
+    protected GeneratorType getGeneratorType() {
+        return GeneratorType.IMAGE_SYFT;
     }
 
+    @Override
+    protected Bom doAdjust(Bom bom) {
+        return adjuster.adjust(bom);
+    }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/process/StandaloneDefaultProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/process/StandaloneDefaultProcessCommand.java
@@ -15,27 +15,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.cli.test.utils;
+package org.jboss.sbomer.cli.feature.sbom.command.process;
 
-import org.cyclonedx.model.Component;
-import org.jboss.pnc.dto.Artifact;
+import java.nio.file.Path;
+
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.cli.feature.sbom.command.AbstractProcessCommand;
 import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
+import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
 
-import jakarta.enterprise.inject.Alternative;
-import lombok.extern.slf4j.Slf4j;
+import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
 
-@Alternative
-@Slf4j
 @Command(
         mixinStandardHelpOptions = true,
         name = "default",
         description = "Process the SBOM with enrichments applied to known CycloneDX fields")
-public class DefaultProcessCommandMockAlternative extends DefaultProcessor {
+public class StandaloneDefaultProcessCommand extends AbstractProcessCommand {
+
+    @ParentCommand
+    StandaloneProcessCommand parent;
+
+    @Inject
+    DefaultProcessor defaultProcessor;
 
     @Override
-    protected void processBrewBuild(Component component, Artifact artifact) {
-        log.debug("Mocked component '{}' was not built in Brew, cannot add any enrichment!", component.getPurl());
+    public ProcessorType getImplementationType() {
+        return defaultProcessor.getType();
     }
 
+    @Override
+    public Bom doProcess(Bom bom) {
+        return defaultProcessor.process(bom);
+    }
+
+    @Override
+    protected Path manifestPath() {
+        return parent.getManifestPath();
+    }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/process/StandaloneProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/process/StandaloneProcessCommand.java
@@ -15,27 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.cli.test.utils;
+package org.jboss.sbomer.cli.feature.sbom.command.process;
 
-import org.cyclonedx.model.Component;
-import org.jboss.pnc.dto.Artifact;
-import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
+import java.nio.file.Path;
 
-import jakarta.enterprise.inject.Alternative;
-import lombok.extern.slf4j.Slf4j;
+import org.jboss.sbomer.cli.feature.sbom.command.PathConverter;
+
+import lombok.Getter;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ScopeType;
 
-@Alternative
-@Slf4j
 @Command(
         mixinStandardHelpOptions = true,
-        name = "default",
-        description = "Process the SBOM with enrichments applied to known CycloneDX fields")
-public class DefaultProcessCommandMockAlternative extends DefaultProcessor {
+        name = "process",
+        aliases = { "p" },
+        description = "Process SBOM using selected processor",
+        subcommands = { StandaloneDefaultProcessCommand.class },
+        subcommandsRepeatable = true)
+public class StandaloneProcessCommand {
 
-    @Override
-    protected void processBrewBuild(Component component, Artifact artifact) {
-        log.debug("Mocked component '{}' was not built in Brew, cannot add any enrichment!", component.getPurl());
-    }
+    @Getter
+    @Option(
+            names = { "-p", "--path" },
+            description = "Path to generated manifest file in CycloneDX JSON format",
+            converter = PathConverter.class,
+            scope = ScopeType.INHERIT)
+    Path manifestPath;
 
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
@@ -1,0 +1,218 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.processor;
+
+import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_BREW_BUILD_ID;
+import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_ENVIRONMENT_IMAGE;
+import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_PNC_BUILD_ID;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.addMrrc;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHash;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.hasExternalReference;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setArtifactMetadata;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setBrewBuildMetadata;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPncBuildMetadata;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPublisher;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setSupplier;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.Hash;
+import org.jboss.pnc.build.finder.koji.KojiBuild;
+import org.jboss.pnc.dto.Artifact;
+import org.jboss.sbomer.cli.feature.sbom.service.KojiService;
+import org.jboss.sbomer.cli.feature.sbom.service.PncService;
+import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@ApplicationScoped
+@Slf4j
+public class DefaultProcessor implements Processor {
+
+    @Inject
+    protected PncService pncService;
+
+    @Inject
+    protected KojiService kojiService;
+
+    private Map<String, String> purlRelocations = new HashMap<>();
+
+    /**
+     * Performs processing for a given {@link Component}.
+     *
+     * @param component
+     */
+    protected void processComponent(Bom bom, Component component) {
+        log.debug("Processing '{}'...", component.getPurl());
+
+        if (component.getPurl() == null) {
+            log.info("Component '{}' does not have a purl", component.getName());
+            return;
+        }
+
+        if (component.getVersion() == null) {
+            log.info("Component '{}' does not have a version", component.getName());
+            return;
+        }
+
+        // If the component does not have "pnc-build-id" nor "pnc-environment-image" nor "brew-build-id", query it
+        if (!hasExternalReference(component, ExternalReference.Type.BUILD_SYSTEM, SBOM_RED_HAT_PNC_BUILD_ID)
+                && !hasExternalReference(component, ExternalReference.Type.BUILD_META, SBOM_RED_HAT_ENVIRONMENT_IMAGE)
+                && !hasExternalReference(component, ExternalReference.Type.BUILD_SYSTEM, SBOM_RED_HAT_BREW_BUILD_ID)) {
+
+            Optional<String> sha256 = getHash(component, Hash.Algorithm.SHA_256);
+            Optional<String> sha1 = getHash(component, Hash.Algorithm.SHA1);
+            Optional<String> md5 = getHash(component, Hash.Algorithm.MD5);
+
+            // First try to look up the artifact with the purl given and with optional SHA256 hash to filter out results
+            // Even though we may have different hashes, we specifically specify only SHA256 here.
+            Artifact artifact = pncService.getArtifact(component.getPurl(), sha256, Optional.empty(), Optional.empty());
+
+            // Artifact wasn't found, we will try lookup using different methods
+            if (artifact == null) {
+                log.debug(
+                        "Artifact with purl '{}' wasn't found in PNC, using different methods to receive it",
+                        component.getPurl());
+
+                if (hasAnyHash(sha256, sha1, md5)) {
+                    log.debug(
+                            "There is at least one hash available: sha256 '{}', sha1 '{}', md5 '{}'",
+                            sha256.orElse(null),
+                            sha1.orElse(null),
+                            md5.orElse(null));
+
+                    log.debug("Looking up '{}' artifact in PNC using hashes only", component.getPurl());
+
+                    // Let's try a lookup with hashes only, because the generated purl can be wrongly constructed
+                    artifact = pncService.getArtifact(null, sha256, sha1, md5);
+                }
+
+                // No luck, let's try to see if we can find hashes in build-meta external references
+                if (artifact == null) {
+                    log.debug(
+                            "Artifact with purl '{}' wasn't found in PNC using hash-only lookup, giving up",
+                            component.getPurl());
+                    return;
+                }
+
+                String oldPurl = component.getPurl();
+                String newPurl = artifact.getPurl();
+
+                // It looks like we found the artifact with a hash-only query, but the purl query failed on us.
+                // This means that the purl most probably is incorrect in the manifest, so let's update it.
+                log.debug("Updating component's purl from '{}' to '{}'", oldPurl, newPurl);
+                component.setPurl(newPurl);
+
+                purlRelocations.put(oldPurl, newPurl);
+            }
+
+            log.info(
+                    "Starting processing of Red Hat component '{}' with PNC artifact '{}'...",
+                    component.getPurl(),
+                    artifact.getId());
+
+            setPublisher(component);
+            setSupplier(component);
+            addMrrc(component);
+
+            // Add artifact metadata (PNC url)
+            setArtifactMetadata(component, artifact, pncService.getApiUrl());
+
+            // Add build-related information, if we found a build in PNC
+            if (artifact.getBuild() != null) {
+                log.debug(
+                        "Component '{}' was built in PNC, adding enrichment from PNC build '{}'",
+                        component.getPurl(),
+                        artifact.getBuild().getId());
+
+                setPncBuildMetadata(component, artifact.getBuild(), pncService.getApiUrl());
+            } else {
+                // Lookup the build in Brew, as the artifact was found in PNC but without a build attached
+                log.debug(
+                        "Component '{}' was not built in PNC, will search in Brew the corresponding artifact '{}'",
+                        component.getPurl(),
+                        artifact.getPublicUrl());
+                processBrewBuild(component, artifact);
+            }
+        } else {
+            log.debug(
+                    "Component with purl '{}' is already enriched, skipping further processing for this component",
+                    component.getPurl());
+        }
+    }
+
+    private boolean hasAnyHash(Optional<String> sha256, Optional<String> sha1, Optional<String> md5) {
+        if (sha256.orElse(null) == null && sha1.orElse(null) == null && md5.orElse(null) == null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected void processBrewBuild(Component component, Artifact artifact) {
+        KojiBuild brewBuild = kojiService.findBuild(artifact);
+        if (brewBuild != null) {
+
+            log.debug(
+                    "Component '{}' was built in Brew, adding enrichment from Brew build '{}'",
+                    component.getPurl(),
+                    brewBuild.getBuildInfo().getId());
+
+            setBrewBuildMetadata(
+                    component,
+                    String.valueOf(brewBuild.getBuildInfo().getId()),
+                    brewBuild.getSource(),
+                    kojiService.getConfig().getKojiWebURL().toString());
+        } else {
+            log.debug("Component '{}' was not built in Brew, cannot add any enrichment!", component.getPurl());
+        }
+    }
+
+    @Override
+    public Bom process(Bom bom) {
+        if (bom.getMetadata() != null && bom.getMetadata().getComponent() != null) {
+            processComponent(bom, bom.getMetadata().getComponent());
+        }
+        if (bom.getComponents() != null) {
+            for (Component c : bom.getComponents()) {
+                processComponent(bom, c);
+            }
+        }
+
+        // If there are any purl relcoations, process these.
+        purlRelocations.forEach((oldPurl, newPurl) -> {
+            SbomUtils.updatePurl(bom, oldPurl, newPurl);
+        });
+
+        return bom;
+    }
+
+    @Override
+    public ProcessorType getType() {
+        return ProcessorType.DEFAULT;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
@@ -42,6 +42,7 @@ import org.jboss.pnc.dto.Artifact;
 import org.jboss.sbomer.cli.feature.sbom.service.KojiService;
 import org.jboss.sbomer.cli.feature.sbom.service.PncService;
 import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
+import org.jboss.sbomer.core.features.sbom.utils.RhVersionPattern;
 import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -134,9 +135,13 @@ public class DefaultProcessor implements Processor {
                     component.getPurl(),
                     artifact.getId());
 
-            setPublisher(component);
-            setSupplier(component);
-            addMrrc(component);
+            // In case this is a RH artifact, add more properties.
+            if (RhVersionPattern.isRhVersion(component.getVersion())
+                    || RhVersionPattern.isRhPurl(component.getPurl())) {
+                setPublisher(component);
+                setSupplier(component);
+                addMrrc(component);
+            }
 
             // Add artifact metadata (PNC url)
             setArtifactMetadata(component, artifact, pncService.getApiUrl());

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/Processor.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/Processor.java
@@ -15,21 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.sbomer.core.features.sbom.enums;
+package org.jboss.sbomer.cli.feature.sbom.processor;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.core.features.sbom.enums.ProcessorType;
 
-/**
- * Supported generator implementations.
- *
- * @author Marek Goldmann
- */
-public enum GeneratorType {
-    @JsonProperty("maven-cyclonedx")
-    MAVEN_CYCLONEDX, @JsonProperty("maven-domino")
-    MAVEN_DOMINO, @JsonProperty("gradle-cyclonedx")
-    GRADLE_CYCLONEDX, @JsonProperty("nodejs-cyclonedx")
-    NODEJS_CYCLONEDX, @JsonProperty("cyclonedx-operation")
-    CYCLONEDX_OPERATION, @JsonProperty("image-syft")
-    IMAGE_SYFT
+public interface Processor {
+    public ProcessorType getType();
+
+    public Bom process(Bom bom);
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -419,15 +419,13 @@ public class PncService {
             return null;
         }
 
-        if (remoteArtifacts.size() > 1) {
-            log.debug("Found {} results, returning first", remoteArtifacts.size());
-        }
-
         if (remoteArtifacts.size() == 1) {
             log.debug("Single artifact found, returning it!");
+            return remoteArtifacts.iterator().next();
         }
 
-        return remoteArtifacts.iterator().next();
+        log.debug("Found {} results, returning newest one", remoteArtifacts.size());
+        return remoteArtifacts.getAll().stream().skip(remoteArtifacts.size() - 1).findFirst().get();
     }
 
     /**

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/AlternativePncService.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/AlternativePncService.java
@@ -19,9 +19,6 @@ package org.jboss.sbomer.cli.test.integ.feature.sbom;
 
 import java.util.Optional;
 
-import jakarta.enterprise.inject.Alternative;
-import jakarta.inject.Singleton;
-
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.BuildConfiguration;
@@ -33,6 +30,9 @@ import org.jboss.pnc.enums.BuildProgress;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.sbomer.cli.feature.sbom.service.PncService;
+
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Singleton;
 
 /**
  * Currently unused, but may be in the future.
@@ -71,7 +71,7 @@ public class AlternativePncService extends PncService {
     }
 
     @Override
-    public Artifact getArtifact(String buildId, String purl, Optional<String> sha256) {
+    public Artifact getArtifact(String purl, Optional<String> sha256, Optional<String> sha1, Optional<String> md5) {
         return Artifact.builder()
                 .id("AA1122")
                 .md5("md5")

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/processor/DefaultProcessCommandIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/command/processor/DefaultProcessCommandIT.java
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.inject.Inject;
-
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Commit;
 import org.cyclonedx.model.Component;
@@ -57,8 +55,9 @@ import org.mockito.Mockito;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -148,7 +147,8 @@ public class DefaultProcessCommandIT {
 
             Optional<String> sha256 = SbomUtils.getHash(component, Hash.Algorithm.SHA_256);
             String sha = sha256.isPresent() ? sha256.get() : null;
-            Mockito.when(pncService.getArtifact("BBVVCC", purl, sha256)).thenReturn(generateArtifact(purl, sha));
+            Mockito.when(pncService.getArtifact(purl, sha256, Optional.empty(), Optional.empty()))
+                    .thenReturn(generateArtifact(purl, sha));
         }
 
         DefaultProcessCommand spiedCommand = spy(command);
@@ -202,7 +202,12 @@ public class DefaultProcessCommandIT {
                 "98b67e15e3fe39e4f8721bdcfda99f19e570426d8960f73f8d5fe1414ff2fab3" };
 
         for (int i = 0; i < 3; i++) {
-            Mockito.when(pncService.getArtifact("BBVVCC", componentPurls[i], Optional.of(sha256s[i])))
+            Mockito.when(
+                    pncService.getArtifact(
+                            componentPurls[i],
+                            Optional.of(sha256s[i]),
+                            Optional.empty(),
+                            Optional.empty()))
                     .thenReturn(generateArtifact(componentPurls[i], sha256s[i]));
         }
 
@@ -219,9 +224,10 @@ public class DefaultProcessCommandIT {
 
         Mockito.when(
                 pncService.getArtifact(
-                        "BBVVCC",
                         specialPurl,
-                        Optional.of("122dd093db60b5fafcb428b28569aa72993e2a2c63d3d87b7dcc076bdebd8a71")))
+                        Optional.of("122dd093db60b5fafcb428b28569aa72993e2a2c63d3d87b7dcc076bdebd8a71"),
+                        Optional.empty(),
+                        Optional.empty()))
                 .thenReturn(artifact);
 
         DefaultProcessCommand spiedCommand = spy(command);

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
@@ -1,0 +1,58 @@
+package org.jboss.sbomer.cli.test.integ.feature.sbom.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference.Type;
+import org.cyclonedx.model.Hash;
+import org.cyclonedx.model.Hash.Algorithm;
+import org.cyclonedx.model.Metadata;
+import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
+import org.jboss.sbomer.cli.test.utils.PncWireMock;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+@QuarkusTestResource(PncWireMock.class)
+public class DefaultProcessorIT {
+
+    @Inject
+    DefaultProcessor defaultProcessor;
+
+    @Test
+    void testProcessing() throws JsonProcessingException {
+        // Prepare BOM!
+        Bom bom = new Bom();
+
+        Component component = new Component();
+        component.setPurl("pkg:maven/org.ow2.asm/asm@9.1.0.redhat-00002?type=jar");
+        component.setVersion("9.1.0.redhat-00002");
+        component.setHashes(List.of(new Hash(Algorithm.SHA1, "2cdf6b457191ed82ef3a9d2e579f6d0aa495a533")));
+
+        Metadata metadata = new Metadata();
+        metadata.setComponent(component);
+
+        bom.setMetadata(metadata);
+
+        // Process!
+        defaultProcessor.process(bom);
+
+        assertEquals("Red Hat", component.getSupplier().getName());
+        assertEquals("Red Hat", component.getPublisher());
+        assertEquals("Red Hat", component.getPublisher());
+
+        assertEquals(
+                "https://localhost:12388/pnc-rest/v2/builds/APT4PH2ILMAAA",
+                SbomUtils.getExternalReferences(component, Type.BUILD_SYSTEM, "pnc-build-id").get(0).getUrl());
+    }
+
+}

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
@@ -105,8 +105,8 @@ public class PncServiceIT {
 
         Artifact artifact = service.getArtifact(purl, Optional.empty(), Optional.empty(), Optional.empty());
 
-        assertEquals("asfsasdg", artifact.getSha256());
-        assertEquals("643534523", artifact.getId());
+        assertEquals("cccc", artifact.getSha256());
+        assertEquals("412123", artifact.getId());
     }
 
     @Test

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/service/PncServiceIT.java
@@ -54,8 +54,9 @@ public class PncServiceIT {
     void testFetchArtifact() throws Exception {
         log.info("testFetchArtifact ...");
         Artifact fromPNC = service.getArtifact(
-                "AA",
                 "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final-redhat-1?type=jar",
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
         assertNotNull(fromPNC);
         assertEquals("312123", fromPNC.getId());
@@ -63,7 +64,7 @@ public class PncServiceIT {
 
     @Test
     void testFetchNonExistingArtifact() throws Exception {
-        assertNull(service.getArtifact("AA", "purlnonexisting", Optional.empty()));
+        assertNull(service.getArtifact("purlnonexisting", Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
     @Test
@@ -101,35 +102,11 @@ public class PncServiceIT {
     void testFetchDuplicatedArtifactNoSha256() throws Exception {
         log.info("testFetchDuplicatedArtifact ...");
         String purl = "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@13.0.0.Final-redhat-1?type=jar";
-        try {
-            service.getArtifact("AA", purl, Optional.empty());
-        } catch (IllegalStateException ise) {
-            assertEquals(
-                    "No sha256 was provided, and there should exist only one artifact with purl " + purl,
-                    ise.getMessage());
-        }
-    }
 
-    @Test
-    void testFetchDuplicatedArtifactMatchingSha256() throws Exception {
-        log.info("testFetchDuplicatedArtifactMatchingSha256 ...");
-        String purl = "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@13.0.0.Final-redhat-1?type=jar";
-        String sha256 = "cccc";
-        Artifact fromPNC = service.getArtifact("AA", purl, Optional.of(sha256));
-        assertNotNull(fromPNC);
-        assertEquals("412123", fromPNC.getId());
-    }
+        Artifact artifact = service.getArtifact(purl, Optional.empty(), Optional.empty(), Optional.empty());
 
-    @Test
-    void testFetchDuplicatedArtifactNonMatchingSha256() throws Exception {
-        log.info("testFetchDuplicatedArtifactNonMatchingSha256 ...");
-        String purl = "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@13.0.0.Final-redhat-1?type=jar";
-        String sha256 = "xxxx";
-        try {
-            service.getArtifact("AA", purl, Optional.of(sha256));
-        } catch (IllegalStateException ise) {
-            assertEquals("No matching artifact found with purl " + purl + " and sha256 " + sha256, ise.getMessage());
-        }
+        assertEquals("asfsasdg", artifact.getSha256());
+        assertEquals("643534523", artifact.getId());
     }
 
     @Test

--- a/cli/src/test/resources/mappings/pnc/artifact-exists.json
+++ b/cli/src/test/resources/mappings/pnc/artifact-exists.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/builds/AA/artifacts/dependencies?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%401.0.0.Final-redhat-1?type%3Djar%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%401.0.0.Final-redhat-1?type%3Djar%22"
   },
   "response": {
     "status": 200,

--- a/cli/src/test/resources/mappings/pnc/artifact-log4j.json
+++ b/cli/src/test/resources/mappings/pnc/artifact-log4j.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/builds/ARYT3LBXDVYAC/artifacts/dependencies?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.apache.logging.log4j%2Flog4j%402.19.0.redhat-00001?type%3Dpom%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.apache.logging.log4j%2Flog4j%402.19.0.redhat-00001?type%3Dpom%22"
   },
   "response": {
     "status": 200,

--- a/cli/src/test/resources/mappings/pnc/artifact-not-exiting.json
+++ b/cli/src/test/resources/mappings/pnc/artifact-not-exiting.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/builds/AA/artifacts/dependencies?pageSize=100&pageIndex=0&q=purl%3D%3D%22purlnonexisting%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22purlnonexisting%22"
   },
   "response": {
     "status": 200,

--- a/cli/src/test/resources/mappings/pnc/artifact-queries/asm-hash.json
+++ b/cli/src/test/resources/mappings/pnc/artifact-queries/asm-hash.json
@@ -1,0 +1,121 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=sha1%3D%3D2cdf6b457191ed82ef3a9d2e579f6d0aa495a533"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "pageIndex": 0,
+      "pageSize": 50,
+      "totalPages": 1,
+      "totalHits": 1,
+      "content": [
+        {
+          "id": "7429724",
+          "identifier": "org.ow2.asm:asm:jar:9.1.0.redhat-00002",
+          "purl": "pkg:maven/org.ow2.asm/asm@9.1.0.redhat-00002?type=jar",
+          "artifactQuality": "NEW",
+          "buildCategory": "STANDARD",
+          "md5": "5837ea599ca93f52ca338c073466a650",
+          "sha1": "2cdf6b457191ed82ef3a9d2e579f6d0aa495a533",
+          "sha256": "799609fa88a6b3c5f7686f16cb6b7e5eccf7ba1788c13cc4ad9b35c77c26e318",
+          "filename": "asm-9.1.0.redhat-00002.jar",
+          "deployPath": "/org/ow2/asm/asm/9.1.0.redhat-00002/asm-9.1.0.redhat-00002.jar",
+          "importDate": null,
+          "originUrl": null,
+          "size": 127573,
+          "deployUrl": "https://indy-gateway.indy.svc.cluster.local/api/content/maven/hosted/pnc-builds/org/ow2/asm/asm/9.1.0.redhat-00002/asm-9.1.0.redhat-00002.jar",
+          "publicUrl": "https://indy.psi.redhat.com/api/content/maven/hosted/pnc-builds/org/ow2/asm/asm/9.1.0.redhat-00002/asm-9.1.0.redhat-00002.jar",
+          "creationTime": null,
+          "modificationTime": "2023-11-21T15:19:45.943Z",
+          "qualityLevelReason": "Added as delivered artifact for milestone 2538",
+          "targetRepository": {
+            "id": "3550",
+            "temporaryRepo": false,
+            "identifier": "indy-maven",
+            "repositoryType": "MAVEN",
+            "repositoryPath": "/api/content/maven/hosted/pnc-builds/"
+          },
+          "build": {
+            "id": "APT4PH2ILMAAA",
+            "submitTime": "2022-02-15T13:14:44.897Z",
+            "startTime": "2022-02-15T13:14:44.902Z",
+            "endTime": "2022-02-15T13:19:28.427Z",
+            "progress": "FINISHED",
+            "status": "SUCCESS",
+            "buildContentId": "build-APT4PH2ILMAAA",
+            "temporaryBuild": false,
+            "alignmentPreference": null,
+            "scmUrl": "https://code.engineering.redhat.com/gerrit/asm.git",
+            "scmRevision": "37ac9118ebb0f4ab95a7a70a50ab5b6b697833b8",
+            "scmTag": "9.1.0.redhat-00002",
+            "buildOutputChecksum": "1184128f875a89de3ff2524778c7fff7",
+            "lastUpdateTime": "2022-02-15T13:19:28.669Z",
+            "scmBuildConfigRevision": null,
+            "scmBuildConfigRevisionInternal": null,
+            "project": {
+              "id": "10",
+              "name": "asm",
+              "description": null,
+              "issueTrackerUrl": null,
+              "projectUrl": "http://asm.ow2.org/",
+              "engineeringTeam": null,
+              "technicalLeader": null
+            },
+            "scmRepository": {
+              "id": "442",
+              "internalUrl": "git@gitlab.cee.redhat.com:pnc-workspace/asm/asm.git",
+              "externalUrl": "https://gitlab.ow2.org/asm/asm.git",
+              "preBuildSyncEnabled": true
+            },
+            "environment": {
+              "id": "301",
+              "name": "OpenJDK 11.0; Mvn 3.6.0; Gradle 6.8.3; Kotlin 1.4.32",
+              "description": "OpenJDK 11.0; Mvn 3.6.0; Gradle 6.8.3; Kotlin 1.4.32 [builder-rhel-7-j11-mvn3.6.0-gradle6.8.3-kotlin1.4.32:1.0.3]",
+              "systemImageRepositoryUrl": "quay.io/rh-newcastle",
+              "systemImageId": "builder-rhel-7-j11-mvn3.6.0-gradle6.8.3-kotlin1.4.32:1.0.3",
+              "attributes": {
+                "MAVEN": "3.6.0",
+                "JDK": "11",
+                "OS": "Linux",
+                "DEPRECATION_REPLACEMENT": "455",
+                "GRADLE": "6.8.3",
+                "Kotlin": "1.4.32"
+              },
+              "systemImageType": "DOCKER_IMAGE",
+              "deprecated": true,
+              "hidden": false
+            },
+            "attributes": {
+              "BREW_BUILD_VERSION": "9.1.0.redhat-00002",
+              "BUILD_OUTPUT_OK": "true",
+              "BREW_BUILD_NAME": "org.ow2.asm:asm"
+            },
+            "user": { "id": "225", "username": "eleandro" },
+            "buildConfigRevision": {
+              "id": "7214",
+              "rev": 2578014,
+              "name": "asm-9.1.0",
+              "buildScript": "gradle --info  build publish -x test",
+              "scmRevision": "5a0c71f88bc4e52b8b4b2bd1d66bdcaf166ac152",
+              "creationTime": "2022-02-15T11:47:41.540Z",
+              "modificationTime": "2022-02-15T13:14:41.705Z",
+              "buildType": "GRADLE",
+              "defaultAlignmentParams": "--info -DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DignoreUnresolvableDependencies=true",
+              "brewPullActive": false
+            },
+            "productMilestone": null,
+            "groupBuild": null,
+            "noRebuildCause": null
+          },
+          "creationUser": null,
+          "modificationUser": { "id": "48", "username": "mstefank" }
+        }
+      ]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/cli/src/test/resources/mappings/pnc/artifact-queries/asm-wrong-purl.json
+++ b/cli/src/test/resources/mappings/pnc/artifact-queries/asm-wrong-purl.json
@@ -1,14 +1,14 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22purlnonexisting%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.ow2.asm%2Fasm%409.1.0.redhat-00002?type%3Djar%22"
   },
   "response": {
     "status": 200,
     "jsonBody": {
       "pageIndex": 0,
-      "pageSize": 100,
-      "totalPages": 0,
+      "pageSize": 50,
+      "totalPages": 1,
       "totalHits": 0,
       "content": []
     },

--- a/cli/src/test/resources/mappings/pnc/multiple-artifact-exists-with-sha.json
+++ b/cli/src/test/resources/mappings/pnc/multiple-artifact-exists-with-sha.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%4013.0.0.Final-redhat-1?type%3Djar%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%4013.0.0.Final-redhat-1?type%3Djar%22%2Csha256%3D%3Dcccc"
   },
   "response": {
     "status": 200,
@@ -16,7 +16,7 @@
           "deployPath": "/org/jboss/logging/commons-logging-jboss-logging/13.0.0.Final-redhat-1/commons-logging-jboss-logging-13.0.0.Final-redhat-1.jar",
           "deployUrl": "https://indy",
           "filename": "commons-logging-jboss-logging-13.0.0.Final-redhat-1.jar",
-          "id": "643534523",
+          "id": "312123",
           "identifier": "org.jboss.logging:commons-logging-jboss-logging:jar:13.0.0.Final-redhat-1",
           "importDate": "2018-10-29T21:56:22.900Z",
           "md5": "d97849379b5a00b5a5bc3154fff658fd",
@@ -27,7 +27,7 @@
           "purl": "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@13.0.0.Final-redhat-1?type=jar",
           "qualityLevelReason": null,
           "sha1": "aaaa",
-          "sha256": "asfsasdg",
+          "sha256": "bbbb",
           "size": 17614,
           "targetRepository": {
             "id": "1789",

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/enums/GenerationRequestType.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/enums/GenerationRequestType.java
@@ -18,7 +18,7 @@
 package org.jboss.sbomer.core.features.sbom.enums;
 
 public enum GenerationRequestType {
-    BUILD, OPERATION;
+    BUILD, OPERATION, CONTAINERIMAGE;
 
     public static GenerationRequestType fromName(String type) {
         return GenerationRequestType.valueOf(type.toUpperCase());

--- a/core/src/test/resources/mappings/artifact-exists.json
+++ b/core/src/test/resources/mappings/artifact-exists.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/builds/ARYT3LBXDVYAC/artifacts/dependencies?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%401.0.0.Final-redhat-1?type%3Djar%22"
+    "url": "/pnc-rest/v2/artifacts?pageSize=100&pageIndex=0&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%401.0.0.Final-redhat-1?type%3Djar%22"
   },
   "response": {
     "status": 200,

--- a/core/src/test/resources/mappings/multiple-artifact-exists.json
+++ b/core/src/test/resources/mappings/multiple-artifact-exists.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/pnc-rest/v2/builds/ARYT3LBXDVYAC/artifacts/dependencies?pageIndex=0&pageSize=100&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%4013.0.0.Final-redhat-1?type%3Djar%22"
+    "url": "/pnc-rest/v2/artifacts?pageIndex=0&pageSize=100&q=purl%3D%3D%22pkg%3Amaven%2Forg.jboss.logging%2Fcommons-logging-jboss-logging%4013.0.0.Final-redhat-1?type%3Djar%22"
   },
   "response": {
     "status": 200,

--- a/images/sbomer-generator/install.sh
+++ b/images/sbomer-generator/install.sh
@@ -22,9 +22,17 @@ set -o pipefail
 
 SBOMER_JDK_VERSION="17.0.10-tem"
 NODEJS_VERSION="lts/iron"
+SYFT_VERSION="1.4.1"
 
 # SBOMer functions
 source "${HOME}/func.sh"
+
+function install_syft() {
+    local version=${1}
+
+    mkdir -p ${HOME}/syft
+    curl -s -L https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_linux_amd64.tar.gz | tar xvz -C "${HOME}/syft"
+}
 
 install_sdk
 install_nvm
@@ -32,6 +40,7 @@ install_nvm
 # Activate nvm and sdk
 source "${HOME}/.bashrc"
 
+install_syft "${SYFT_VERSION}"
 # Install Java 17 -- required to run SBOMer itself
 install_java "${SBOMER_JDK_VERSION}"
 # Install nodejs -- it will be done only once

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
@@ -1,0 +1,384 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.generator;
+
+import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.service.feature.sbom.config.GenerationRequestControllerConfig;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
+import org.jboss.sbomer.service.feature.sbom.model.Sbom;
+import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.service.SbomRepository;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractController implements Reconciler<GenerationRequest>,
+        EventSourceInitializer<GenerationRequest>, Cleaner<GenerationRequest> {
+
+    @Inject
+    SbomRepository sbomRepository;
+
+    @Inject
+    protected GenerationRequestControllerConfig controllerConfig;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    protected abstract UpdateControl<GenerationRequest> updateRequest(
+            GenerationRequest generationRequest,
+            SbomGenerationStatus status,
+            GenerationResult result,
+            String reason);
+
+    /**
+     * Returns the {@link TaskRun} having the specified {@link SbomGenerationPhase} from the given {@link TaskRun}
+     * {@link Set}.
+     *
+     * @param taskRuns
+     * @param phase
+     * @return The {@link TaskRun} or {@code null} if not found.
+     */
+    protected TaskRun findTaskRun(Set<TaskRun> taskRuns, SbomGenerationPhase phase) {
+        Optional<TaskRun> taskRun = findTaskRuns(taskRuns, phase).stream().findFirst();
+
+        return taskRun.orElse(null);
+    }
+
+    /**
+     * Returns a set of {@link TaskRun}s having the specified {@link SbomGenerationPhase} from the given {@link TaskRun}
+     * {@link Set}.
+     *
+     * @param taskRuns
+     * @param phase
+     * @return The {@link Set} containing {@link TaskRun} or empty set if not found.
+     */
+    protected Set<TaskRun> findTaskRuns(Set<TaskRun> taskRuns, SbomGenerationPhase phase) {
+        return taskRuns.stream().filter(tr -> {
+            if (Objects.equals(tr.getMetadata().getLabels().get(Labels.LABEL_PHASE), phase.name().toLowerCase())) {
+                return true;
+            }
+
+            return false;
+        }).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * <p>
+     * Stores the generated manifest in the database which results in creation of a new {@link Sbom} entity.
+     * </p>
+     *
+     * <p>
+     * Additionally updates the database entity with the current state of the {@link GenerationRequest}.
+     * </p>
+     *
+     * @param generationRequest
+     * @param bom
+     * @return
+     */
+    protected Sbom storeSbom(GenerationRequest generationRequest, Bom bom) {
+        // First, update the status of the GenerationRequest entity.
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
+
+        log.info(
+                "Storing generated manifest for the GenerationRequest '{}'",
+                generationRequest.getMetadata().getName());
+
+        // Create the Sbom entity
+        Sbom sbom = Sbom.builder()
+                .withId(RandomStringIdGenerator.generate())
+                .withIdentifier(generationRequest.getIdentifier())
+                .withSbom(SbomUtils.toJsonNode(bom))
+                .withGenerationRequest(sbomGenerationRequest)
+                .build();
+
+        // And store it in the database
+        return sbomRepository.saveSbom(sbom);
+    }
+
+    /**
+     * Checks whether given {@link TaskRun} has finished or not.
+     *
+     * @param taskRun The {@link TaskRun} to check
+     * @return {@code true} if the {@link TaskRun} finished, {@code false} otherwise
+     */
+    protected boolean isFinished(TaskRun taskRun) {
+        if (taskRun.getStatus() != null && taskRun.getStatus().getConditions() != null
+                && taskRun.getStatus().getConditions().size() > 0
+                && (Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "True")
+                        || Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "False"))) {
+
+            log.trace("TaskRun '{}' finished", taskRun.getMetadata().getName());
+            return true;
+        }
+
+        log.trace("TaskRun '{}' still running", taskRun.getMetadata().getName());
+        return false;
+    }
+
+    /**
+     * Checks whether given {@link TaskRun} has finished successfully.
+     *
+     * @param taskRun The {@link TaskRun} to check
+     * @return {@code true} if the {@link TaskRun} finished successfully, {@code false} otherwise or {@code null} in
+     *         case it is still in progress.
+     */
+    protected Boolean isSuccessful(TaskRun taskRun) {
+        if (!isFinished(taskRun)) {
+            log.trace("TaskRun '{}' still in progress", taskRun.getMetadata().getName());
+            return null;
+        }
+
+        if (taskRun.getStatus() != null && taskRun.getStatus().getConditions() != null
+                && taskRun.getStatus().getConditions().size() > 0
+                && Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "True")) {
+            log.trace("TaskRun '{}' finished successfully", taskRun.getMetadata().getName());
+            return true;
+        }
+
+        log.trace("TaskRun '{}' failed", taskRun.getMetadata().getName());
+        return false;
+    }
+
+    @Override
+    public Map<String, EventSource> prepareEventSources(EventSourceContext<GenerationRequest> context) {
+        InformerEventSource<TaskRun, GenerationRequest> ies = new InformerEventSource<>(
+                InformerConfiguration.from(TaskRun.class, context)
+                        .withNamespacesInheritedFromController(context)
+                        .build(),
+                context);
+
+        return Map.of(EVENT_SOURCE_NAME, ies);
+    }
+
+    @Override
+    public DeleteControl cleanup(GenerationRequest resource, Context<GenerationRequest> context) {
+        log.debug("GenerationRequest '{}' was removed from the system", resource.getMetadata().getName());
+        return DeleteControl.defaultDelete();
+    }
+
+    @Override
+    public UpdateControl<GenerationRequest> reconcile(
+            GenerationRequest generationRequest,
+            Context<GenerationRequest> context) throws Exception {
+        MDCUtils.removeContext();
+
+        // No status set set, it should be "NEW", let's do it.
+        // "NEW" starts everything.
+        if (Objects.isNull(generationRequest.getStatus())) {
+            return updateRequest(generationRequest, SbomGenerationStatus.NEW, null, null);
+        }
+
+        Set<TaskRun> secondaryResources = context.getSecondaryResources(TaskRun.class);
+
+        UpdateControl<GenerationRequest> action = null;
+
+        log.debug(
+                "Handling update for GenerationRequest '{}', current status: '{}'",
+                generationRequest.getMetadata().getName(),
+                generationRequest.getStatus());
+
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+
+        switch (generationRequest.getStatus()) {
+            case NEW:
+                action = reconcileNew(generationRequest, secondaryResources);
+                break;
+            case GENERATING:
+                action = reconcileGenerating(generationRequest, secondaryResources);
+                break;
+            case FINISHED:
+                action = reconcileFinished(generationRequest, secondaryResources);
+                break;
+            case FAILED:
+                action = reconcileFailed(generationRequest, secondaryResources);
+                break;
+            default:
+                break;
+        }
+
+        // This would be unexpected.
+        if (action == null) {
+            log.error(
+                    "Unknown status received: '{}'' for GenerationRequest '{}",
+                    generationRequest.getStatus(),
+                    generationRequest.getMetadata().getName());
+            return UpdateControl.noUpdate();
+        }
+
+        // In case resource gets an update, update th DB entity as well
+        if (action.isUpdateResource()) {
+            SbomGenerationRequest.sync(generationRequest);
+        }
+
+        return action;
+    }
+
+    /**
+     * <p>
+     * In case the dependent resource is prepared, the {@link SbomGenerationStatus#NEW} status is transitioned into
+     * {@link SbomGenerationStatus#GENERATING}. In all other cases, the resourse stays in the
+     * {@link SbomGenerationStatus#NEW} status.
+     * </p>
+     */
+    protected UpdateControl<GenerationRequest> reconcileNew(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+        log.debug("Reconcile NEW for '{}'...", generationRequest.getName());
+
+        TaskRun generateTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.GENERATE);
+
+        if (generateTaskRun == null) {
+            return UpdateControl.noUpdate();
+        }
+
+        return updateRequest(generationRequest, SbomGenerationStatus.GENERATING, null, null);
+    }
+
+    /**
+     * <p>
+     * Handling of failed generation.
+     * </p>
+     *
+     * @param generationRequest
+     * @param secondaryResources
+     * @return
+     */
+    protected UpdateControl<GenerationRequest> reconcileFailed(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+        log.debug("Reconcile FAILED for '{}'...", generationRequest.getName());
+
+        // In case the generation request failed, we need to clean up resources so that these are not left forever.
+        // We have all the data elsewhere (logs, cause) so it's safe to do so.
+        cleanupFinishedGenerationRequest(generationRequest);
+
+        return UpdateControl.noUpdate();
+    }
+
+    /**
+     * <p>
+     * Handles finished generation.
+     * </p>
+     *
+     * @param generationRequest
+     * @param secondaryResources
+     * @return
+     */
+    protected UpdateControl<GenerationRequest> reconcileFinished(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("Reconcile FINISHED for '{}'...", generationRequest.getName());
+
+        // notificationService.notifyCompleted(sboms);
+        // At this point al the work is finished and we can clean up the GenerationRequest Kubernetes resource.
+        cleanupFinishedGenerationRequest(generationRequest);
+
+        return UpdateControl.noUpdate();
+    }
+
+    /**
+     * <p>
+     * Handles updates to {@link GenerationRequest} being in progress.
+     * </p>
+     *
+     * @param generationRequest
+     * @param secondaryResources
+     * @return
+     */
+    @Transactional
+    protected abstract UpdateControl<GenerationRequest> reconcileGenerating(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources);
+
+    /**
+     * Removes related to finished {@link GenerationRequest} and its instance as well.
+     *
+     * @param generationRequest
+     */
+    private void cleanupFinishedGenerationRequest(GenerationRequest generationRequest) {
+        if (!controllerConfig.cleanup()) {
+            log.debug(
+                    "The cleanup setting is set to false, skipping cleaning up finished GenerationRequest '{}'",
+                    generationRequest.getName());
+            return;
+        }
+
+        Path workdirPath = Path.of(controllerConfig.sbomDir(), generationRequest.getMetadata().getName());
+
+        log.debug(
+                "Removing '{}' path being the working directory for the finished '{}' GenerationRequest",
+                workdirPath.toAbsolutePath().toString(),
+                generationRequest.getName());
+
+        // It should, but...
+        if (Files.exists(workdirPath)) {
+            try {
+                Files.walk(workdirPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            } catch (IOException e) {
+                log.error(
+                        "An error occurred while removing the '{}' directory",
+                        workdirPath.toAbsolutePath().toString(),
+                        e);
+            }
+        }
+
+        if (Files.exists(workdirPath)) {
+            log.warn("Directory '{}' still exists", workdirPath.toAbsolutePath().toString());
+        } else {
+            log.debug("Directory '{}' removed", workdirPath.toAbsolutePath().toString());
+        }
+
+        kubernetesClient.configMaps().withName(generationRequest.getMetadata().getName()).delete();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
@@ -17,8 +17,6 @@
  */
 package org.jboss.sbomer.service.feature.sbom.features.generator;
 
-import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,6 +62,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AbstractController implements Reconciler<GenerationRequest>,
         EventSourceInitializer<GenerationRequest>, Cleaner<GenerationRequest> {
+
+    public static final String EVENT_SOURCE_NAME = "GenerationRequestEventSource";
 
     @Inject
     SbomRepository sbomRepository;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/SyftImageController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/SyftImageController.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.generator.image.syft.controller;
+
+import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.jboss.sbomer.service.feature.sbom.model.Sbom;
+
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.javaoperatorsdk.operator.api.reconciler.Constants;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import jakarta.validation.ValidationException;
+import lombok.extern.slf4j.Slf4j;
+
+@ControllerConfiguration(
+        labelSelector = "app.kubernetes.io/part-of=sbomer,app.kubernetes.io/component=sbom,app.kubernetes.io/managed-by=sbom,sbomer.jboss.org/type=generation-request,sbomer.jboss.org/generation-request-type=containerimage",
+        namespaces = { Constants.WATCH_CURRENT_NAMESPACE },
+
+        dependents = { @Dependent(
+                type = TaskRunSyftImageGenerateDependentResource.class,
+                useEventSourceWithName = EVENT_SOURCE_NAME)
+
+        })
+@Slf4j
+public class SyftImageController extends AbstractController {
+    @Override
+    protected UpdateControl<GenerationRequest> updateRequest(
+            GenerationRequest generationRequest,
+            SbomGenerationStatus status,
+            GenerationResult result,
+            String reason) {
+
+        if (generationRequest.getStatus() != null) {
+            String label = switch (generationRequest.getStatus()) {
+                case GENERATING -> SbomGenerationPhase.GENERATE.name().toLowerCase();
+                default -> null;
+            };
+
+            if (label != null) {
+                generationRequest.getMetadata().getLabels().put(Labels.LABEL_PHASE, label);
+            }
+        }
+
+        generationRequest.setStatus(status);
+        generationRequest.setResult(result);
+        generationRequest.setReason(reason);
+        return UpdateControl.updateResource(generationRequest);
+    }
+
+    /**
+     * <p>
+     * Handles updates to {@link GenerationRequest} being in progress.
+     * </p>
+     *
+     * @param generationRequest
+     * @param secondaryResources
+     * @return
+     */
+    @Override
+    protected UpdateControl<GenerationRequest> reconcileGenerating(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("Reconcile GENERATING for '{}'...", generationRequest.getName());
+
+        TaskRun generateTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.GENERATE);
+
+        if (generateTaskRun == null) {
+            log.error("There is no generation TaskRun related to GenerationRequest '{}'", generationRequest.getName());
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. Unable to find related TaskRun. See logs for more information.");
+        }
+
+        // In case the TaskRun hasn't finished yet, wait for next update.
+        if (!isFinished(generateTaskRun)) {
+            return UpdateControl.noUpdate();
+        }
+
+        // In case the Task Run is not successfull, fail thge generation
+        if (!isSuccessful(generateTaskRun)) {
+            log.error("Generation failed, the TaskRun returnd failure");
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. TaskRun responsible for generation failed. See logs for more information.");
+        }
+
+        // Construct the path to the manifest
+        Path sbomPath = Path.of(
+                controllerConfig.sbomDir(),
+                generationRequest.getMetadata().getName(),
+
+                generationRequest.getMetadata().getName() + "-" + SbomGenerationPhase.GENERATE.ordinal() + "-"
+                        + SbomGenerationPhase.GENERATE.name().toLowerCase(),
+                "bom.json");
+
+        // Read the generated SBOM JSON file
+        Bom bom = SbomUtils.fromPath(sbomPath);
+
+        // If the manifest could not be read
+        if (bom == null) {
+            log.error("Could not read generated manifest");
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. Generated manifest could not be read. See logs for more information.");
+        }
+
+        Sbom sbom = null;
+
+        try {
+            sbom = storeSbom(generationRequest, bom);
+        } catch (ValidationException e) {
+            // There was an error when validating the entity, most probably the SBOM is not valid
+            log.error("Unable to validate generated SBOM", e);
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_GENERATION,
+                    "Generation failed. One or more generated SBOMs failed validation. See logs for more information.");
+        }
+
+        return updateRequest(
+                generationRequest,
+                SbomGenerationStatus.FINISHED,
+                GenerationResult.SUCCESS,
+                String.format("Generation finished successfully. Generated manifest: %s", sbom.getId()));
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/SyftImageController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/SyftImageController.java
@@ -17,12 +17,13 @@
  */
 package org.jboss.sbomer.service.feature.sbom.features.generator.image.syft.controller;
 
-import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
+import static org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController.EVENT_SOURCE_NAME;
 
 import java.nio.file.Path;
 import java.util.Set;
 
 import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
 import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
 import org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController;
@@ -40,6 +41,23 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * <p>
+ * Reconciler working on the {@link GenerationRequest} entity and the {@link GenerationRequestType#CONTAINERIMAGE} type.
+ * </p>
+ *
+ * <p>
+ * This reconciler acts only on resources marked with following labels (all of them must exist on the resource):
+ *
+ * <ul>
+ * <li>{@code app.kubernetes.io/part-of=sbomer}</li>
+ * <li>{@code app.kubernetes.io/component=sbom}</li>
+ * <li>{@code app.kubernetes.io/managed-by=sbom}</li>
+ * <li>{@code sbomer.jboss.org/generation-request}</li>
+ * <li>{@code sbomer.jboss.org/generation-request-type}</li>
+ * </ul>
+ * </p>
+ */
 @ControllerConfiguration(
         labelSelector = "app.kubernetes.io/part-of=sbomer,app.kubernetes.io/component=sbom,app.kubernetes.io/managed-by=sbom,sbomer.jboss.org/type=generation-request,sbomer.jboss.org/generation-request-type=containerimage",
         namespaces = { Constants.WATCH_CURRENT_NAMESPACE },

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/TaskRunSyftImageGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/TaskRunSyftImageGenerateDependentResource.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.generator.image.syft.controller;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.sbomer.core.errors.ApplicationException;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.GenerateResourceDiscriminator;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+
+import io.fabric8.kubernetes.api.model.Duration;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.tekton.pipeline.v1beta1.ParamBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.ParamValue;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRefBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
+import io.fabric8.tekton.pipeline.v1beta1.WorkspaceBindingBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDNoGCKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@KubernetesDependent(resourceDiscriminator = GenerateResourceDiscriminator.class)
+@Slf4j
+public class TaskRunSyftImageGenerateDependentResource
+        extends CRUDNoGCKubernetesDependentResource<TaskRun, GenerationRequest> {
+
+    public static final String PARAM_COMMAND_CONTAINER_IMAGE = "image";
+    public static final String PARAM_PATHS = "paths";
+    public static final String TASK_SUFFIX = "-generate-image-syft";
+    public static final String SA_SUFFIX = "-sa";
+
+    @ConfigProperty(name = "SBOMER_RELEASE", defaultValue = "sbomer")
+    String release;
+
+    @Inject
+    KubernetesClient client;
+
+    TaskRunSyftImageGenerateDependentResource() {
+        super(TaskRun.class);
+    }
+
+    public TaskRunSyftImageGenerateDependentResource(Class<TaskRun> resourceType) {
+        super(TaskRun.class);
+    }
+
+    @Override
+    protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
+
+        log.debug(
+                "Preparing dependent resource for the '{}' phase related to '{}' GenerationRequest",
+                SbomGenerationPhase.GENERATE,
+                generationRequest.getMetadata().getName());
+        Map<String, String> labels = Labels.defaultLabelsToMap(GenerationRequestType.CONTAINERIMAGE);
+
+        labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.GENERATE.name().toLowerCase());
+        labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+
+        Duration timeout = null;
+
+        try {
+            timeout = Duration.parse("6h");
+        } catch (ParseException e) {
+            throw new ApplicationException("Cannot set timeout", e);
+        }
+
+        return new TaskRunBuilder().withNewMetadata()
+                .withNamespace(generationRequest.getMetadata().getNamespace())
+                .withLabels(labels)
+                .withName(generationRequest.dependentResourceName(SbomGenerationPhase.GENERATE))
+                .withOwnerReferences(
+                        new OwnerReferenceBuilder().withKind(generationRequest.getKind())
+                                .withName(generationRequest.getMetadata().getName())
+                                .withApiVersion(generationRequest.getApiVersion())
+                                .withUid(generationRequest.getMetadata().getUid())
+                                .build())
+                .endMetadata()
+                .withNewSpec()
+                .withServiceAccountName(release + SA_SUFFIX)
+                .withTimeout(timeout)
+                .withParams(
+                        new ParamBuilder().withName(PARAM_COMMAND_CONTAINER_IMAGE)
+                                .withNewValue(generationRequest.getIdentifier())
+                                .build(),
+                        new ParamBuilder().withName(PARAM_PATHS).withValue(new ParamValue(List.of("/opt"))).build()) // TODO
+                .withTaskRef(new TaskRefBuilder().withName(release + TASK_SUFFIX).build())
+
+                .withWorkspaces(
+                        new WorkspaceBindingBuilder().withSubPath(generationRequest.getMetadata().getName())
+                                .withName("data")
+                                .withPersistentVolumeClaim(
+                                        new PersistentVolumeClaimVolumeSourceBuilder().withClaimName(release + "-sboms")
+                                                .build())
+                                .build())
+                .endSpec()
+                .build();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/rest/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/rest/SBOMResource.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.features.generator.image.syft.rest;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.jboss.sbomer.core.dto.v1alpha3.SbomGenerationRequestRecord;
+import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.features.FeatureFlags;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.mapper.V1Alpha3Mapper;
+import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+
+import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.annotation.security.PermitAll;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Path("/api/v1alpha3/generator/syft")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+@PermitAll
+@Slf4j
+public class SBOMResource {
+    @Inject
+    V1Alpha3Mapper mapper;
+
+    @Inject
+    protected KubernetesClient kubernetesClient;
+
+    @Inject
+    FeatureFlags featureFlags;
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML })
+    @Operation(summary = "", description = "")
+    @Path("/image/{name}")
+    @APIResponses({
+            @APIResponse(
+                    responseCode = "202",
+                    description = "Requests manifest generation for a given container image.",
+                    content = @Content(schema = @Schema(implementation = SbomGenerationRequestRecord.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
+    public Response generateFromContainerImage(@PathParam("name") String imageName, Config config) throws Exception {
+        log.info("Requesting new manifest generation for container image: '{}'", imageName);
+
+        GenerationRequest req = new GenerationRequestBuilder(GenerationRequestType.CONTAINERIMAGE)
+                .withIdentifier(imageName)
+                .withStatus(SbomGenerationStatus.NEW)
+                .build();
+
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(req);
+
+        kubernetesClient.configMaps().resource(req).create();
+
+        return Response.accepted(mapper.toSbomRequestRecord(sbomGenerationRequest)).build();
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/GenerationRequestReconciler.java
@@ -19,19 +19,13 @@ package org.jboss.sbomer.service.feature.sbom.k8s.reconciler;
 
 import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.cyclonedx.model.Bom;
 import org.jboss.sbomer.core.errors.ApplicationException;
@@ -43,12 +37,13 @@ import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
 import org.jboss.sbomer.service.feature.sbom.config.GenerationRequestControllerConfig;
+import org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController;
 import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
-import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.IsBuildTypeInitializedCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.IsBuildTypeCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.IsBuildTypeInitializedCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.OperationConfigAvailableCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.OperationConfigMissingCondition;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
@@ -68,19 +63,11 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.tekton.pipeline.v1beta1.Param;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunResult;
-import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
-import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
-import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
-import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
-import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
-import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ValidationException;
@@ -123,8 +110,7 @@ import lombok.extern.slf4j.Slf4j;
                         useEventSourceWithName = EVENT_SOURCE_NAME,
                         reconcilePrecondition = OperationConfigAvailableCondition.class) })
 @Slf4j
-public class GenerationRequestReconciler implements Reconciler<GenerationRequest>,
-        EventSourceInitializer<GenerationRequest>, Cleaner<GenerationRequest> {
+public class GenerationRequestReconciler extends AbstractController {
 
     public static final String EVENT_SOURCE_NAME = "GenerationRequestEventSource";
 
@@ -148,7 +134,8 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
 
     ObjectMapper objectMapper = ObjectMapperProvider.yaml();
 
-    private UpdateControl<GenerationRequest> updateRequest(
+    @Override
+    protected UpdateControl<GenerationRequest> updateRequest(
             GenerationRequest generationRequest,
             SbomGenerationStatus status,
             GenerationResult result,
@@ -185,35 +172,6 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         generationRequest.setResult(result);
         generationRequest.setReason(reason);
         return UpdateControl.updateResource(generationRequest);
-    }
-
-    /**
-     * <p>
-     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#INITIALIZING} or
-     * {@link SbomGenerationStatus#INITIALIZED} if it was really fast :)
-     * </p>
-     *
-     * <p>
-     * For the {@link SbomGenerationStatus#NEW} state we don't need to do anything, just wait.
-     * </p>
-     *
-     * @param generationRequest
-     * @param secondaryResources
-     * @return Action to take on the {@link GenerationRequest} resource.
-     */
-    private UpdateControl<GenerationRequest> reconcileNew(
-            GenerationRequest generationRequest,
-            Set<TaskRun> secondaryResources) {
-
-        log.debug("ReconcileNew ...");
-
-        TaskRun initTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.INIT);
-
-        if (initTaskRun == null) {
-            return UpdateControl.noUpdate();
-        }
-
-        return updateRequest(generationRequest, SbomGenerationStatus.INITIALIZING, null, null);
     }
 
     /**
@@ -340,15 +298,8 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         return updateRequest(generationRequest, SbomGenerationStatus.GENERATING, null, null);
     }
 
-    /**
-     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#FINISHED}
-     *
-     * @param secondaryResources
-     * @param generationRequest
-     *
-     * @return
-     */
-    private UpdateControl<GenerationRequest> reconcileGenerating(
+    @Override
+    protected UpdateControl<GenerationRequest> reconcileGenerating(
             GenerationRequest generationRequest,
             Set<TaskRun> secondaryResources) {
 
@@ -502,47 +453,6 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         log.warn("Marking GenerationRequest '{}' as failed. Reason: {}", generationRequest.getName(), reason);
 
         return updateRequest(generationRequest, SbomGenerationStatus.FAILED, result, reason);
-    }
-
-    /**
-     * Final success status.
-     *
-     * @param secondaryResources
-     * @param generationRequest
-     *
-     * @return
-     */
-    private UpdateControl<GenerationRequest> reconcileFinished(
-            GenerationRequest generationRequest,
-            Set<TaskRun> secondaryResources) {
-
-        log.debug("ReconcileFinished ...");
-
-        // At this point al the work is finished and we can clean up the GenerationRequest Kubernetes resource.
-        cleanupFinishedGenerationRequest(generationRequest);
-
-        return UpdateControl.noUpdate();
-    }
-
-    /**
-     * Final failed status.
-     *
-     * @param secondaryResources
-     * @param generationRequest
-     *
-     * @return
-     */
-    private UpdateControl<GenerationRequest> reconcileFailed(
-            GenerationRequest generationRequest,
-            Set<TaskRun> secondaryResources) {
-
-        log.debug("ReconcileFailed ...");
-
-        // In case the generation request failed, we need to clean up resources so that these are not left forever.
-        // We have all the data elsewhere (logs, cause) so it's safe to do so.
-        cleanupFinishedGenerationRequest(generationRequest);
-
-        return UpdateControl.noUpdate();
     }
 
     /**
@@ -877,126 +787,31 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
     }
 
     /**
-     * Removes related to finished {@link GenerationRequest} and its instance as well.
+     * <p>
+     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#INITIALIZING} or
+     * {@link SbomGenerationStatus#INITIALIZED} if it was really fast :)
+     * </p>
+     *
+     * <p>
+     * For the {@link SbomGenerationStatus#NEW} state we don't need to do anything, just wait.
+     * </p>
      *
      * @param generationRequest
+     * @param secondaryResources
+     * @return Action to take on the {@link GenerationRequest} resource.
      */
-    private void cleanupFinishedGenerationRequest(GenerationRequest generationRequest) {
-        if (!controllerConfig.cleanup()) {
-            log.debug(
-                    "The cleanup setting is set to false, skipping cleaning up finished GenerationRequest '{}'",
-                    generationRequest.getName());
-            return;
+    protected UpdateControl<GenerationRequest> reconcileNew(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("ReconcileNew ...");
+        TaskRun initTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.INIT);
+
+        if (initTaskRun == null) {
+            return UpdateControl.noUpdate();
         }
 
-        Path workdirPath = Path.of(controllerConfig.sbomDir(), generationRequest.getMetadata().getName());
-
-        log.debug(
-                "Removing '{}' path being the working directory for the finished '{}' GenerationRequest",
-                workdirPath.toAbsolutePath().toString(),
-                generationRequest.getName());
-
-        // It should, but...
-        if (Files.exists(workdirPath)) {
-            try {
-                Files.walk(workdirPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-            } catch (IOException e) {
-                log.error(
-                        "An error occurred while removing the '{}' directory",
-                        workdirPath.toAbsolutePath().toString(),
-                        e);
-            }
-        }
-
-        if (Files.exists(workdirPath)) {
-            log.warn("Directory '{}' still exists", workdirPath.toAbsolutePath().toString());
-        } else {
-            log.debug("Directory '{}' removed", workdirPath.toAbsolutePath().toString());
-        }
-
-        kubernetesClient.configMaps().withName(generationRequest.getMetadata().getName()).delete();
-    }
-
-    /**
-     * Returns the {@link TaskRun} having the specified {@link SbomGenerationPhase} from the given {@link TaskRun}
-     * {@link Set}.
-     *
-     * @param taskRuns
-     * @param phase
-     * @return The {@link TaskRun} or {@code null} if not found.
-     */
-    private TaskRun findTaskRun(Set<TaskRun> taskRuns, SbomGenerationPhase phase) {
-        Optional<TaskRun> taskRun = taskRuns.stream().filter(tr -> {
-            if (Objects.equals(tr.getMetadata().getLabels().get(Labels.LABEL_PHASE), phase.name().toLowerCase())) {
-                return true;
-            }
-
-            return false;
-        }).findFirst();
-
-        return taskRun.orElse(null);
-    }
-
-    /**
-     * Returns a set of {@link TaskRun}s having the specified {@link SbomGenerationPhase} from the given {@link TaskRun}
-     * {@link Set}.
-     *
-     * @param taskRuns
-     * @param phase
-     * @return The {@link Set} containing {@link TaskRun} or empty set if not found.
-     */
-    private Set<TaskRun> findTaskRuns(Set<TaskRun> taskRuns, SbomGenerationPhase phase) {
-        return taskRuns.stream().filter(tr -> {
-            if (Objects.equals(tr.getMetadata().getLabels().get(Labels.LABEL_PHASE), phase.name().toLowerCase())) {
-                return true;
-            }
-
-            return false;
-        }).collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Checks whether given {@link TaskRun} has finished successfully.
-     *
-     * @param taskRun The {@link TaskRun} to check
-     * @return {@code true} if the {@link TaskRun} finished successfully, {@code false} otherwise or {@code null} in
-     *         case it is still in progress.
-     */
-    private Boolean isSuccessful(TaskRun taskRun) {
-        if (!isFinished(taskRun)) {
-            log.trace("TaskRun '{}' still in progress", taskRun.getMetadata().getName());
-            return null;
-        }
-
-        if (taskRun.getStatus() != null && taskRun.getStatus().getConditions() != null
-                && taskRun.getStatus().getConditions().size() > 0
-                && Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "True")) {
-            log.trace("TaskRun '{}' finished successfully", taskRun.getMetadata().getName());
-            return true;
-        }
-
-        log.trace("TaskRun '{}' failed", taskRun.getMetadata().getName());
-        return false;
-    }
-
-    /**
-     * Checks whether given {@link TaskRun} has finished or not.
-     *
-     * @param taskRun The {@link TaskRun} to check
-     * @return {@code true} if the {@link TaskRun} finished, {@code false} otherwise
-     */
-    private boolean isFinished(TaskRun taskRun) {
-        if (taskRun.getStatus() != null && taskRun.getStatus().getConditions() != null
-                && taskRun.getStatus().getConditions().size() > 0
-                && (Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "True")
-                        || Objects.equals(taskRun.getStatus().getConditions().get(0).getStatus(), "False"))) {
-
-            log.trace("TaskRun '{}' finished", taskRun.getMetadata().getName());
-            return true;
-        }
-
-        log.trace("TaskRun '{}' still running", taskRun.getMetadata().getName());
-        return false;
+        return updateRequest(generationRequest, SbomGenerationStatus.INITIALIZING, null, null);
     }
 
     @Override
@@ -1096,18 +911,14 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
 
         // In case resource gets an update, update th DB entity as well
         if (action.isUpdateResource()) {
-            sync(generationRequest);
+            SbomGenerationRequest.sync(generationRequest);
         }
 
         return action;
     }
 
-    protected SbomGenerationRequest sync(GenerationRequest generationRequest) {
-        return SbomGenerationRequest.sync(generationRequest);
-    }
-
     protected List<Sbom> storeOperationSboms(GenerationRequest generationRequest) {
-        SbomGenerationRequest sbomGenerationRequest = sync(generationRequest);
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
 
         log.info(
                 "Reading all generated SBOMs for the GenerationRequest '{}'",
@@ -1146,7 +957,7 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
     }
 
     protected List<Sbom> storeSboms(GenerationRequest generationRequest) {
-        SbomGenerationRequest sbomGenerationRequest = sync(generationRequest);
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
 
         log.info(
                 "Reading all generated SBOMs for the GenerationRequest '{}'",
@@ -1290,23 +1101,6 @@ public class GenerationRequestReconciler implements Reconciler<GenerationRequest
         }
 
         return config;
-    }
-
-    @Override
-    public Map<String, EventSource> prepareEventSources(EventSourceContext<GenerationRequest> context) {
-        InformerEventSource<TaskRun, GenerationRequest> ies = new InformerEventSource<>(
-                InformerConfiguration.from(TaskRun.class, context)
-                        .withNamespacesInheritedFromController(context)
-                        .build(),
-                context);
-
-        return Map.of(EVENT_SOURCE_NAME, ies);
-    }
-
-    @Override
-    public DeleteControl cleanup(GenerationRequest resource, Context<GenerationRequest> context) {
-        log.debug("GenerationRequest '{}' was removed from the system", resource.getMetadata().getName());
-        return DeleteControl.defaultDelete();
     }
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
@@ -1,0 +1,739 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.k8s.reconciler;
+
+import static org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController.EVENT_SOURCE_NAME;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.core.errors.ApplicationException;
+import org.jboss.sbomer.core.features.sbom.config.runtime.Config;
+import org.jboss.sbomer.core.features.sbom.config.runtime.OperationConfig;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.service.feature.sbom.config.GenerationRequestControllerConfig;
+import org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController;
+import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.IsBuildTypeCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.IsBuildTypeInitializedCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.OperationConfigAvailableCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.condition.OperationConfigMissingCondition;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunGenerateDependentResource;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunInitDependentResource;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunOperationGenerateDependentResource;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunOperationInitDependentResource;
+import org.jboss.sbomer.service.feature.sbom.model.RandomStringIdGenerator;
+import org.jboss.sbomer.service.feature.sbom.model.Sbom;
+import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.service.SbomRepository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.tekton.pipeline.v1beta1.Param;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunResult;
+import io.javaoperatorsdk.operator.api.reconciler.Constants;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <p>
+ * Reconciler working on the {@link GenerationRequest} entity and the {@link GenerationRequestType#OPERATION} type.
+ * </p>
+ *
+ * <p>
+ * This reconciler acts only on resources marked with following labels (all of them must exist on the resource):
+ *
+ * <ul>
+ * <li>{@code app.kubernetes.io/part-of=sbomer}</li>
+ * <li>{@code app.kubernetes.io/component=sbom}</li>
+ * <li>{@code app.kubernetes.io/managed-by=sbom}</li>
+ * <li>{@code sbomer.jboss.org/generation-request}</li>
+ * <li>{@code sbomer.jboss.org/generation-request-type}</li>
+ * </ul>
+ * </p>
+ */
+@ControllerConfiguration(
+        labelSelector = "app.kubernetes.io/part-of=sbomer,app.kubernetes.io/component=sbom,app.kubernetes.io/managed-by=sbom,sbomer.jboss.org/type=generation-request,sbomer.jboss.org/generation-request-type=operation",
+        namespaces = { Constants.WATCH_CURRENT_NAMESPACE },
+        dependents = {
+                @Dependent(
+                        type = TaskRunOperationInitDependentResource.class,
+                        useEventSourceWithName = EVENT_SOURCE_NAME,
+                        reconcilePrecondition = OperationConfigMissingCondition.class),
+                @Dependent(
+                        type = TaskRunOperationGenerateDependentResource.class,
+                        useEventSourceWithName = EVENT_SOURCE_NAME,
+                        reconcilePrecondition = OperationConfigAvailableCondition.class) })
+@Slf4j
+public class OperationController extends AbstractController {
+
+    List<TaskRunGenerateDependentResource> generations = new ArrayList<>();
+
+    public OperationController() {
+
+    }
+
+    @Inject
+    GenerationRequestControllerConfig controllerConfig;
+
+    @Inject
+    SbomRepository sbomRepository;
+
+    @Inject
+    NotificationService notificationService;
+
+    ObjectMapper objectMapper = ObjectMapperProvider.yaml();
+
+    @Override
+    protected UpdateControl<GenerationRequest> updateRequest(
+            GenerationRequest generationRequest,
+            SbomGenerationStatus status,
+            GenerationResult result,
+            String reason) {
+
+        if (generationRequest.getStatus() != null) {
+            String label = switch (generationRequest.getStatus()) {
+                case INITIALIZING -> SbomGenerationPhase.OPERATIONINIT.name().toLowerCase();
+                case GENERATING -> SbomGenerationPhase.OPERATIONGENERATE.name().toLowerCase();
+                default -> null;
+            };
+
+            if (label != null) {
+                generationRequest.getMetadata().getLabels().put(Labels.LABEL_PHASE, label);
+            }
+        }
+
+        generationRequest.setStatus(status);
+        generationRequest.setResult(result);
+        generationRequest.setReason(reason);
+        return UpdateControl.updateResource(generationRequest);
+    }
+
+    /**
+     * <p>
+     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#INITIALIZING} or
+     * {@link SbomGenerationStatus#INITIALIZED} if it was really fast :)
+     * </p>
+     *
+     * <p>
+     * For the {@link SbomGenerationStatus#NEW} state we don't need to do anything, just wait.
+     * </p>
+     *
+     * @param generationRequest
+     * @param secondaryResources
+     * @return Action to take on the {@link GenerationRequest} resource.
+     */
+    private UpdateControl<GenerationRequest> reconcileOperationNew(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("ReconcileOperationNew ...");
+
+        TaskRun initTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.OPERATIONINIT);
+
+        if (initTaskRun == null) {
+            return UpdateControl.noUpdate();
+        }
+
+        return updateRequest(generationRequest, SbomGenerationStatus.INITIALIZING, null, null);
+    }
+
+    /**
+     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#INITIALIZED}
+     *
+     * @param secondaryResources
+     * @param generationRequest
+     *
+     * @return
+     */
+    private UpdateControl<GenerationRequest> reconcileOperationInitializing(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("ReconcileOperationInitializing ...");
+
+        TaskRun initTaskRun = findTaskRun(secondaryResources, SbomGenerationPhase.OPERATIONINIT);
+
+        if (initTaskRun == null) {
+            log.error(
+                    "There is no initialization TaskRun related to GenerationRequest '{}'",
+                    generationRequest.getName());
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Configuration initialization failed. Unable to find related TaskRun. See logs for more information.");
+        }
+
+        if (!isFinished(initTaskRun)) {
+            return UpdateControl.noUpdate();
+        }
+
+        if (isSuccessful(initTaskRun)) {
+            setOperationConfig(generationRequest, initTaskRun);
+            return updateRequest(generationRequest, SbomGenerationStatus.INITIALIZED, null, null);
+        }
+
+        StringBuilder sb = new StringBuilder("Configuration initialization failed. ");
+
+        GenerationResult result = GenerationResult.ERR_SYSTEM;
+
+        if (initTaskRun.getStatus() != null && initTaskRun.getStatus().getSteps() != null
+                && !initTaskRun.getStatus().getSteps().isEmpty()
+                && initTaskRun.getStatus().getSteps().get(0).getTerminated() != null) {
+
+            Optional<GenerationResult> optResult = GenerationResult
+                    .fromCode(initTaskRun.getStatus().getSteps().get(0).getTerminated().getExitCode());
+
+            if (optResult.isPresent()) {
+                result = optResult.get();
+
+                // At this point the config generation failed, let's try to provide more info on the failure
+                switch (result) {
+                    case ERR_GENERAL:
+                        sb.append("General error occurred. ");
+                        break;
+                    case ERR_CONFIG_INVALID:
+                        sb.append("Configuration validation failed. ");
+                        break;
+                    case ERR_CONFIG_MISSING:
+                        sb.append("Could not find configuration. ");
+                        break;
+                    case ERR_SYSTEM:
+                        sb.append("System error occurred. ");
+                        break;
+                    default:
+                        // In case we don't have a mapped exit code, we assume it is a system error
+                        result = GenerationResult.ERR_SYSTEM;
+                        sb.append("Unexpected error occurred. ");
+                        break;
+                }
+            } else {
+                log.warn(
+                        "Unknown exit code received from the finished '{}' TaskRun: {}",
+                        initTaskRun.getMetadata().getName(),
+                        initTaskRun.getStatus().getSteps().get(0).getTerminated().getExitCode());
+                result = GenerationResult.ERR_SYSTEM;
+                sb.append("Unknown exit code received. ");
+            }
+        } else {
+            sb.append("System failure. ");
+        }
+
+        String reason = sb.append("See logs for more information.").toString();
+
+        log.warn("GenerationRequest '{}' failed. {}", generationRequest.getName(), reason);
+
+        return updateRequest(generationRequest, SbomGenerationStatus.FAILED, result, reason);
+    }
+
+    /**
+     * Possible next statuses: {@link SbomGenerationStatus#PREPARING}
+     *
+     * @param secondaryResources
+     * @param generationRequest
+     *
+     * @return
+     */
+    private UpdateControl<GenerationRequest> reconcileOperationInitialized(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("ReconcileOperationInitialized ...");
+
+        OperationConfig config = generationRequest.toOperationConfig();
+        if (config == null) {
+            log.error(
+                    "Product configuration from GenerationRequest '{}' could not be read",
+                    generationRequest.getName());
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. Could not read product configuration");
+        }
+
+        if (generationRequest.getDeliverableUrls() == null || generationRequest.getDeliverableUrls().isEmpty()) {
+            log.error("There are no deliverables to process in GenerationRequest '{}'", generationRequest.getName());
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. No deliverable available");
+        }
+
+        Set<TaskRun> generateTaskRuns = findTaskRuns(secondaryResources, SbomGenerationPhase.OPERATIONGENERATE);
+        if (generateTaskRuns.isEmpty()) {
+            return UpdateControl.noUpdate();
+        }
+
+        return updateRequest(generationRequest, SbomGenerationStatus.GENERATING, null, null);
+    }
+
+    /**
+     * Possible next statuses: {@link SbomGenerationStatus#FAILED}, {@link SbomGenerationStatus#FINISHED}
+     *
+     * @param secondaryResources
+     * @param generationRequest
+     *
+     * @return
+     */
+    protected UpdateControl<GenerationRequest> reconcileGenerating(
+            GenerationRequest generationRequest,
+            Set<TaskRun> secondaryResources) {
+
+        log.debug("ReconcileOperationGenerating ...");
+
+        OperationConfig config = generationRequest.toOperationConfig();
+        if (config == null) {
+            log.error(
+                    "Product configuration from GenerationRequest '{}' could not be read",
+                    generationRequest.getName());
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. Could not read product configuration");
+        }
+
+        if (generationRequest.getDeliverableUrls() == null || generationRequest.getDeliverableUrls().isEmpty()) {
+            log.error("There are no deliverables to process in GenerationRequest '{}'", generationRequest.getName());
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. No deliverable available");
+        }
+
+        Set<TaskRun> generateTaskRuns = findTaskRuns(secondaryResources, SbomGenerationPhase.OPERATIONGENERATE);
+
+        // This should not happen, because if we updated already the status to SbomGenerationStatus.GENERATING, then
+        // there was a TaskRun already. But it could be deleted manually(?). In such case we set the status to FAILED.
+        if (generateTaskRuns.isEmpty()) {
+            log.error(
+                    "Marking GenerationRequest '{}' as failed: no generation TaskRuns were found, but at least one was expected.",
+                    generationRequest.getName());
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FAILED,
+                    GenerationResult.ERR_SYSTEM,
+                    "Generation failed. Expected one or more running TaskRun related to generation. None found. See logs for more information.");
+        }
+
+        log.debug(
+                "Found {} TaskRuns related to GenerationRequest '{}'",
+                generateTaskRuns.size(),
+                generationRequest.getName());
+
+        // Check for still running tasks
+        List<TaskRun> stillRunning = generateTaskRuns.stream().filter(tr -> !isFinished(tr)).toList();
+
+        // If there are tasks that hasn't finished yet, we need to wait.
+        if (!stillRunning.isEmpty()) {
+            log.debug(
+                    "Skipping update of GenerationRequest '{}', because {} TaskRuns are still running: {}",
+                    generationRequest.getName(),
+                    stillRunning.size(),
+                    stillRunning.stream().map(tr -> tr.getMetadata().getName()).toArray());
+            return UpdateControl.noUpdate();
+        }
+
+        // Get list of failed TaskRuns
+        List<TaskRun> failedTaskRuns = generateTaskRuns.stream().filter(tr -> !isSuccessful(tr)).toList();
+
+        // If all tasks finished successfully
+        if (failedTaskRuns.isEmpty()) {
+
+            List<Sbom> sboms = storeOperationSboms(generationRequest);
+            notificationService.notifyOperationCompleted(sboms);
+
+            return updateRequest(
+                    generationRequest,
+                    SbomGenerationStatus.FINISHED,
+                    GenerationResult.SUCCESS,
+                    String.format(
+                            "Generation finished successfully. Generated SBOMs: %s",
+                            sboms.stream().map(sbom -> sbom.getId()).toArray()));
+        }
+
+        StringBuilder sb = new StringBuilder("Generation failed. ");
+        GenerationResult result = GenerationResult.ERR_SYSTEM;
+
+        for (TaskRun taskRun : failedTaskRuns) {
+            Param deliverableIndexParam = getParamValue(
+                    taskRun,
+                    TaskRunOperationGenerateDependentResource.PARAM_COMMAND_DELIVERABLE_INDEX_NAME);
+
+            sb.append("Deliverable with index '")
+                    .append(deliverableIndexParam.getValue().getStringVal())
+                    .append("' (TaskRun '")
+                    .append(taskRun.getMetadata().getName())
+                    .append("') failed: ");
+
+            if (taskRun.getStatus() != null && taskRun.getStatus().getSteps() != null
+                    && !taskRun.getStatus().getSteps().isEmpty()
+                    && taskRun.getStatus().getSteps().get(0).getTerminated() != null) {
+
+                Optional<GenerationResult> optResult = GenerationResult
+                        .fromCode(taskRun.getStatus().getSteps().get(0).getTerminated().getExitCode());
+
+                if (optResult.isPresent()) {
+                    result = optResult.get();
+                }
+
+                switch (result) {
+                    case ERR_GENERAL:
+                        sb.append("general error occurred. ");
+                        break;
+                    case ERR_CONFIG_INVALID:
+                        sb.append("product configuration failure. ");
+                        break;
+                    case ERR_INDEX_INVALID:
+                        Param param = getParamValue(taskRun, "index");
+
+                        if (param == null) {
+                            sb.append("could not find the 'index' parameter. ");
+                        } else {
+                            sb.append("invalid product index: ")
+                                    .append(deliverableIndexParam.getValue().getStringVal())
+                                    .append(" (should be between 1 and ")
+                                    .append(config.getDeliverableUrls().size())
+                                    .append("). ");
+                        }
+
+                        break;
+                    case ERR_GENERATION:
+                        sb.append("an error occurred while generating the SBOM. ");
+                        break;
+                    default:
+                        result = GenerationResult.ERR_SYSTEM;
+                        sb.append("unexpected error occurred. ");
+                        break;
+                }
+            } else {
+                sb.append("system failure. ");
+            }
+
+        }
+
+        // When we have more than one task failed, we need set the result to be a multi-failure
+        if (failedTaskRuns.size() > 1) {
+            result = GenerationResult.ERR_MULTI;
+        }
+
+        String reason = sb.append("See logs for more information.").toString();
+
+        log.warn("Marking GenerationRequest '{}' as failed. Reason: {}", generationRequest.getName(), reason);
+
+        return updateRequest(generationRequest, SbomGenerationStatus.FAILED, result, reason);
+    }
+
+    private Param getParamValue(TaskRun taskRun, String paramName) {
+        Optional<Param> param = taskRun.getSpec()
+                .getParams()
+                .stream()
+                .filter(p -> p.getName().equals(paramName))
+                .findFirst();
+
+        return param.orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public UpdateControl<GenerationRequest> reconcile(
+            GenerationRequest generationRequest,
+            Context<GenerationRequest> context) throws Exception {
+
+        MDCUtils.removeContext();
+
+        // No status set set, it should be "NEW", let's do it.
+        // "NEW" starts everything.
+        if (Objects.isNull(generationRequest.getStatus())) {
+            return updateRequest(generationRequest, SbomGenerationStatus.NEW, null, null);
+        }
+
+        // Fetch any secondary resources (Tekton TaskRuns) that are related to the primary resource (GenerationRequest)
+        // There may be between 0 or more TaskRuns related to the GenerationRequest:
+        // 0 In case these were not created yet,
+        // 1 in case the initialization or environment config tasks are running
+        // 2 or more in case the generation is running
+        Set<TaskRun> secondaryResources = context.getSecondaryResources(TaskRun.class);
+
+        UpdateControl<GenerationRequest> action = null;
+
+        log.debug(
+                "Handling update for GenerationRequest '{}', current status: '{}'",
+                generationRequest.getMetadata().getName(),
+                generationRequest.getStatus());
+
+        switch (generationRequest.getStatus()) {
+            case NEW:
+                action = reconcileOperationNew(generationRequest, secondaryResources);
+                break;
+            case INITIALIZING:
+                action = reconcileOperationInitializing(generationRequest, secondaryResources);
+                break;
+            case INITIALIZED:
+                action = reconcileOperationInitialized(generationRequest, secondaryResources);
+                break;
+            case GENERATING:
+                action = reconcileGenerating(generationRequest, secondaryResources);
+                break;
+            case FINISHED:
+                action = reconcileFinished(generationRequest, secondaryResources);
+                break;
+            case FAILED:
+                action = reconcileFailed(generationRequest, secondaryResources);
+                break;
+            default:
+        }
+
+        // This would be unexpected.
+        if (action == null) {
+            if (generationRequest.getStatus().equals(SbomGenerationStatus.NO_OP)) {
+                log.info(
+                        "No operation status received: '{}' for GenerationRequest '{}', doing nothing!",
+                        generationRequest.getStatus(),
+                        generationRequest.getMetadata().getName());
+            } else {
+                log.error(
+                        "Unknown status received: '{}' for GenerationRequest '{}'",
+                        generationRequest.getStatus(),
+                        generationRequest.getMetadata().getName());
+            }
+            return UpdateControl.noUpdate();
+        }
+
+        // In case resource gets an update, update th DB entity as well
+        if (action.isUpdateResource()) {
+            SbomGenerationRequest.sync(generationRequest);
+        }
+
+        return action;
+    }
+
+    protected List<Sbom> storeOperationSboms(GenerationRequest generationRequest) {
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
+
+        log.info(
+                "Reading all generated SBOMs for the GenerationRequest '{}'",
+                generationRequest.getMetadata().getName());
+
+        OperationConfig config = SbomUtils.fromJsonOperationConfig(sbomGenerationRequest.getConfig());
+
+        List<Sbom> sboms = new ArrayList<>();
+
+        for (int i = 0; i < config.getDeliverableUrls().size(); i++) {
+            log.info("Reading SBOM for index '{}'", i);
+            Path sbomPath = Path.of(
+                    controllerConfig.sbomDir(),
+                    generationRequest.getMetadata().getName(),
+                    generationRequest.getMetadata().getName() + "-" + SbomGenerationPhase.OPERATIONGENERATE.ordinal()
+                            + "-" + SbomGenerationPhase.OPERATIONGENERATE.name().toLowerCase() + "-" + i,
+                    "bom.json");
+
+            // Read the generated SBOM JSON file
+            Bom bom = SbomUtils.fromPath(sbomPath);
+
+            // Create the Sbom entity
+            Sbom sbom = Sbom.builder()
+                    .withId(RandomStringIdGenerator.generate())
+                    .withIdentifier(generationRequest.getIdentifier())
+                    .withSbom(SbomUtils.toJsonNode(bom))
+                    .withGenerationRequest(sbomGenerationRequest)
+                    .withConfigIndex(i)
+                    .build();
+
+            // And store it in the database
+            sboms.add(sbomRepository.saveSbom(sbom));
+        }
+
+        return sboms;
+    }
+
+    protected List<Sbom> storeSboms(GenerationRequest generationRequest) {
+        SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
+
+        log.info(
+                "Reading all generated SBOMs for the GenerationRequest '{}'",
+                generationRequest.getMetadata().getName());
+
+        Config config = SbomUtils.fromJsonConfig(sbomGenerationRequest.getConfig());
+
+        List<Sbom> sboms = new ArrayList<>();
+
+        for (int i = 0; i < config.getProducts().size(); i++) {
+            log.info("Reading SBOM for index '{}'", i);
+
+            Path sbomPath = Path.of(
+                    controllerConfig.sbomDir(),
+                    generationRequest.getMetadata().getName(),
+
+                    generationRequest.getMetadata().getName() + "-" + SbomGenerationPhase.GENERATE.ordinal() + "-"
+                            + SbomGenerationPhase.GENERATE.name().toLowerCase() + "-" + i,
+                    "bom.json");
+
+            // Read the generated SBOM JSON file
+            Bom bom = SbomUtils.fromPath(sbomPath);
+
+            // Create the Sbom entity
+            Sbom sbom = Sbom.builder()
+                    .withId(RandomStringIdGenerator.generate())
+                    .withIdentifier(generationRequest.getIdentifier())
+                    .withSbom(SbomUtils.toJsonNode(bom))
+                    .withGenerationRequest(sbomGenerationRequest)
+                    .withConfigIndex(i)
+                    .build();
+
+            // And store it in the database
+            sboms.add(sbomRepository.saveSbom(sbom));
+        }
+
+        return sboms;
+    }
+
+    private Config setConfig(GenerationRequest generationRequest, TaskRun taskRun) {
+        log.debug("Handling result of the initialization task");
+
+        if (taskRun.getStatus() == null) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have status sub-resource despite it is expected",
+                    taskRun.getMetadata().getName());
+
+        }
+
+        if (taskRun.getStatus().getTaskResults() == null || taskRun.getStatus().getTaskResults().isEmpty()) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have any results despite it is expected to have one",
+                    taskRun.getMetadata().getName());
+        }
+
+        Optional<TaskRunResult> configResult = taskRun.getStatus()
+                .getTaskResults()
+                .stream()
+                .filter(result -> Objects.equals(result.getName(), TaskRunInitDependentResource.RESULT_NAME))
+                .findFirst();
+
+        if (configResult.isEmpty()) {
+            throw new ApplicationException(
+                    "Could not find the '{}' result within the TaskRun '{}'",
+                    TaskRunInitDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName());
+        }
+
+        String configVal = configResult.get().getValue().getStringVal();
+        Config config;
+
+        try {
+            config = objectMapper.readValue(configVal.getBytes(), Config.class);
+        } catch (IOException e) {
+            throw new ApplicationException(
+                    "Could not parse the '{}' result within the TaskRun '{}': {}",
+                    TaskRunInitDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName(),
+                    configVal);
+        }
+
+        log.debug("Runtime config from TaskRun '{}' parsed: {}", taskRun.getMetadata().getName(), config);
+
+        try {
+            generationRequest.setConfig(objectMapper.writeValueAsString(config));
+        } catch (JsonProcessingException e) {
+            log.error("Unable to serialize product configuration", e);
+        }
+
+        return config;
+    }
+
+    private OperationConfig setOperationConfig(GenerationRequest generationRequest, TaskRun taskRun) {
+        log.debug("Handling result of the initialization task");
+
+        if (taskRun.getStatus() == null) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have status sub-resource despite it is expected",
+                    taskRun.getMetadata().getName());
+
+        }
+
+        if (taskRun.getStatus().getTaskResults() == null || taskRun.getStatus().getTaskResults().isEmpty()) {
+            throw new ApplicationException(
+                    "TaskRun '{}' does not have any results despite it is expected to have one",
+                    taskRun.getMetadata().getName());
+        }
+
+        Optional<TaskRunResult> configResult = taskRun.getStatus()
+                .getTaskResults()
+                .stream()
+                .filter(result -> Objects.equals(result.getName(), TaskRunOperationInitDependentResource.RESULT_NAME))
+                .findFirst();
+
+        if (configResult.isEmpty()) {
+            throw new ApplicationException(
+                    "Could not find the '{}' result within the TaskRun '{}'",
+                    TaskRunOperationInitDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName());
+        }
+
+        String configVal = configResult.get().getValue().getStringVal();
+        OperationConfig config;
+
+        try {
+            config = ObjectMapperProvider.json().readValue(configVal.getBytes(), OperationConfig.class);
+        } catch (IOException e) {
+            throw new ApplicationException(
+                    "Could not parse the '{}' result within the TaskRun '{}': {}",
+                    TaskRunInitDependentResource.RESULT_NAME,
+                    taskRun.getMetadata().getName(),
+                    configVal);
+        }
+
+        log.debug("Runtime config from TaskRun '{}' parsed: {}", taskRun.getMetadata().getName(), config);
+
+        try {
+            generationRequest.setConfig(objectMapper.writeValueAsString(config));
+        } catch (JsonProcessingException e) {
+            log.error("Unable to serialize product configuration", e);
+        }
+
+        return config;
+    }
+
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/AbstractResourceDiscriminator.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/AbstractResourceDiscriminator.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.sbomer.service.feature.sbom.k8s.resources;
 
-import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler.EVENT_SOURCE_NAME;
+import static org.jboss.sbomer.service.feature.sbom.k8s.reconciler.BuildController.EVENT_SOURCE_NAME;
 
 import java.util.Optional;
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/rest/v1alpha3/SBOMResource.java
@@ -349,11 +349,9 @@ public class SBOMResource extends AbstractApiProvider {
                     responseCode = "500",
                     description = "Internal server error",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)) })
-
     public Response generateNewOperation(DeliverableAnalysisConfig config) throws Exception {
 
         return Response.accepted(mapper.toSbomRequestRecord(sbomService.generateNewOperation(config))).build();
 
     }
-
 }

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseGenerationRequestReconcilerIT.java
@@ -41,7 +41,7 @@ import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
-import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.BuildController;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -93,7 +93,7 @@ public class GenerationPhaseGenerationRequestReconcilerIT {
     GenerationRequestControllerConfig controllerConfig;
 
     @Inject
-    GenerationRequestReconciler controller;
+    BuildController controller;
 
     @KubernetesTestServer
     KubernetesServer mockServer;

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/InitializationPhaseGenerationRequestReconcilerIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/InitializationPhaseGenerationRequestReconcilerIT.java
@@ -37,7 +37,7 @@ import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
-import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.GenerationRequestReconciler;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.BuildController;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.TaskRunInitDependentResource;
 import org.junit.jupiter.api.Test;
@@ -65,7 +65,7 @@ import io.quarkus.test.junit.QuarkusTest;
 public class InitializationPhaseGenerationRequestReconcilerIT {
 
     @Inject
-    GenerationRequestReconciler controller;
+    BuildController controller;
 
     private GenerationRequest dummyInitializationRequest(SbomGenerationStatus status) throws IOException {
         return new GenerationRequestBuilder(GenerationRequestType.BUILD).withIdentifier("AABBCC")


### PR DESCRIPTION
This does add support for the Syft generator. Currently it's usage is
limited to manifesting products located within container images.

Notable changes:

Default processor was moved out of command and it is now a separate
entity. This makes it possible to use it across different commands and
not only.

The default processor is now processing every component found in the
manifest, not only the ones with `-redhat` suffix. This will increase
the time of generation, but we should get even more accurate results.
Other change is that If we cannot find given purl within PNC, we will be
using hashes (if available) to lookup artifacts.

The container image manifest generator is capable of generating
manifests for Application Services products that are shipped in
container images. Currently it support only products that are located
under the `/opt` directory. In the future this will be configurable.

The `redhat` processor is not applied for these manifests for now. It
will be enabled at a later stage.

This change introduces "Adjuster" concept. Adjuster is a processor that
runs after generation and processes the outout of the generator to a
format that is understandable by SBOMer. Adjuster can do some light
tweaks or entirely rewrite the manifest. Main use case if to enable use
of external generators. In this specific case we have the Syft
generator. It's output is processed, properties are renamed and moved.

Introduction of adjuster and standa-alone generators required to change
the CLI of SBOMer. Now instead of running the generation and then
processing we run adjustment nad processing on an already-existing
manifest which is provided by an external generator.

https://issues.redhat.com/browse/SBOMER-83