### PR TITLE
fix: handle lack of purl in artifacts

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
@@ -122,12 +122,19 @@ public class DefaultProcessor implements Processor {
                 String oldPurl = component.getPurl();
                 String newPurl = artifact.getPurl();
 
-                // It looks like we found the artifact with a hash-only query, but the purl query failed on us.
-                // This means that the purl most probably is incorrect in the manifest, so let's update it.
-                log.debug("Updating component's purl from '{}' to '{}'", oldPurl, newPurl);
-                component.setPurl(newPurl);
+                if (newPurl == null) {
+                    log.warn(
+                            "The PNC artifact '{}' does not have a purl set, we cannot update the purl in the component, leaving it as is: '{}'",
+                            artifact.getId(),
+                            oldPurl);
+                } else {
+                    // It looks like we found the artifact with a hash-only query, but the purl query failed on us.
+                    // This means that the purl most probably is incorrect in the manifest, so let's update it.
+                    log.debug("Updating component's purl from '{}' to '{}'", oldPurl, newPurl);
+                    component.setPurl(newPurl);
 
-                purlRelocations.put(oldPurl, newPurl);
+                    purlRelocations.put(oldPurl, newPurl);
+                }
             }
 
             log.info(

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/PncService.java
@@ -409,7 +409,7 @@ public class PncService {
 
         } catch (RemoteResourceException ex) {
             throw new GeneralPncException(
-                    "Querying artifact failed, PNC responded with an error, query: query: '{}'",
+                    "Querying artifact failed, PNC responded with an error, query: '{}'",
                     rsql,
                     ex);
         }


### PR DESCRIPTION
In case the artifact does not have a purl set, don't fail and use the old purl. Log a warning as well.