### PR TITLE
UMB and S3 fixes

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -255,8 +255,8 @@ public class NotificationService {
         Optional<ExternalReference> pncBuildSystemRef = getExternalReferences(
                 component,
                 ExternalReference.Type.BUILD_SYSTEM).stream()
-                .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_BUILD_ID))
-                .findFirst();
+                        .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_BUILD_ID))
+                        .findFirst();
 
         Build buildPayload = Build.builder()
                 .id(sbom.getIdentifier())
@@ -307,8 +307,8 @@ public class NotificationService {
         Optional<ExternalReference> pncOperationRef = getExternalReferences(
                 component,
                 ExternalReference.Type.BUILD_SYSTEM).stream()
-                .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_OPERATION_ID))
-                .findFirst();
+                        .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_OPERATION_ID))
+                        .findFirst();
 
         Operation operationPayload = Operation.builder()
                 .id(sbom.getIdentifier())

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/producer/NotificationService.java
@@ -255,8 +255,8 @@ public class NotificationService {
         Optional<ExternalReference> pncBuildSystemRef = getExternalReferences(
                 component,
                 ExternalReference.Type.BUILD_SYSTEM).stream()
-                        .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_BUILD_ID))
-                        .findFirst();
+                .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_BUILD_ID))
+                .findFirst();
 
         Build buildPayload = Build.builder()
                 .id(sbom.getIdentifier())
@@ -307,8 +307,8 @@ public class NotificationService {
         Optional<ExternalReference> pncOperationRef = getExternalReferences(
                 component,
                 ExternalReference.Type.BUILD_SYSTEM).stream()
-                        .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_OPERATION_ID))
-                        .findFirst();
+                .filter(r -> r.getComment().equals(SBOM_RED_HAT_PNC_OPERATION_ID))
+                .findFirst();
 
         Operation operationPayload = Operation.builder()
                 .id(sbom.getIdentifier())

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
@@ -38,7 +38,6 @@ import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
 import org.jboss.sbomer.service.feature.s3.S3StorageHandler;
 import org.jboss.sbomer.service.feature.sbom.config.GenerationRequestControllerConfig;
 import org.jboss.sbomer.service.feature.sbom.features.generator.AbstractController;
-import org.jboss.sbomer.service.feature.sbom.features.umb.producer.NotificationService;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
@@ -114,9 +113,6 @@ public class BuildController extends AbstractController {
 
     @Inject
     SbomRepository sbomRepository;
-
-    @Inject
-    NotificationService notificationService;
 
     ObjectMapper objectMapper = ObjectMapperProvider.yaml();
 
@@ -345,9 +341,6 @@ public class BuildController extends AbstractController {
                         GenerationResult.ERR_GENERATION,
                         "Generation failed. One or more generated SBOMs failed validation. See logs for more information.");
             }
-
-            // TODO: Move this to reconcileFinished method
-            notificationService.notifyCompleted(sboms);
 
             return updateRequest(
                     generationRequest,

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
@@ -106,9 +106,6 @@ public class BuildController extends AbstractController {
     }
 
     @Inject
-    S3StorageHandler s3LogHandler;
-
-    @Inject
     GenerationRequestControllerConfig controllerConfig;
 
     @Inject
@@ -330,7 +327,6 @@ public class BuildController extends AbstractController {
         if (failedTaskRuns.isEmpty()) {
             try {
                 sboms = storeSboms(generationRequest);
-                s3LogHandler.storeFiles(generationRequest);
             } catch (ValidationException e) {
                 // There was an error when validating the entity, most probably the SBOM is not valid
                 log.error("Unable to validate generated SBOM", e);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomRepository.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomRepository.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.jboss.sbomer.core.dto.BaseSbomRecord;
 import org.jboss.sbomer.core.features.sbom.config.Config;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.rest.QueryParameters;
@@ -59,6 +60,16 @@ public class SbomRepository extends CriteriaAwareRepository<Sbom> {
                             generationRequest.<GenerationRequestType> get("type").as(String.class),
                             generationRequest.<Instant> get("creationTime")));
         });
+    }
+
+    /**
+     * Returns list of manifests which are the output of the {@link GenerationRequest} with the provided identifier.
+     *
+     * @param generationRequestId
+     * @return
+     */
+    public List<Sbom> findSbomsByGenerationRequest(String generationRequestId) {
+        return find("generationRequest.id = ?1", generationRequestId).list();
     }
 
     @Transactional

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.sbomer.service.test.integ.feature.sbom;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -139,6 +140,18 @@ class SbomRepositoryIT {
         assertEquals("416640206274228224", sbom.getId());
         assertEquals("ARYT3LBXDVYAC", sbom.getIdentifier());
         assertEquals(GenerationRequestType.BUILD, sbom.getGenerationRequest().getType());
+    }
+
+    @Test
+    void testFindByGenerationIdEmpty() {
+        List<Sbom> sboms = sbomRepository.findSbomsByGenerationRequest("NOTTHERE");
+        assertTrue(sboms.isEmpty());
+    }
+
+    @Test
+    void testFindByGenerationIdSingle() {
+        List<Sbom> sboms = sbomRepository.findSbomsByGenerationRequest("AASSBB");
+        assertEquals(1, sboms.size());
     }
 
     @Test


### PR DESCRIPTION
This PR contains fixes for two things:

1. UMB notifications are send only after manifests are persisted in the database which makes it possible to handle case where failure in sending messages could prevent from updating the generation status
2. Storing in S3 is enabled for failed generations as well.

https://issues.redhat.com/browse/SBOMER-102
https://issues.redhat.com/browse/SBOMER-99