### PR TITLE
feat(SBOMER-91): add RPM content support for container images

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
@@ -37,6 +37,9 @@ public class SyftImageAdjustCommand extends AbstractAdjustCommand {
     @Option(names = "--path-filter")
     List<String> paths = new ArrayList<>();
 
+    @Option(names = "--rpms", defaultValue = "false", negatable = true)
+    private boolean rpms;
+
     @Override
     protected GeneratorType getGeneratorType() {
         return GeneratorType.IMAGE_SYFT;
@@ -44,7 +47,7 @@ public class SyftImageAdjustCommand extends AbstractAdjustCommand {
 
     @Override
     protected Bom doAdjust(Bom bom, Path workDir) {
-        SyftImageAdjuster adjuster = new SyftImageAdjuster(paths);
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(paths, rpms);
 
         return adjuster.adjust(bom, workDir);
     }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
@@ -1,0 +1,74 @@
+package org.jboss.sbomer.cli.test.unit.feature.sbom.adjust;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.cyclonedx.model.Bom;
+import org.jboss.sbomer.cli.feature.sbom.adjuster.SyftImageAdjuster;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.core.test.TestResources;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SyftImageAdjusterTest {
+
+    @TempDir
+    File tmpDir;
+
+    Bom bom = null;
+
+    SyftImageAdjusterTest() throws IOException {
+        this.bom = SbomUtils.fromString(TestResources.asString("boms/image.json"));
+
+    }
+
+    @BeforeEach
+    void init() throws IOException {
+        Files.writeString(Path.of(tmpDir.getAbsolutePath(), "skopeo.json"), TestResources.asString("skopeo.json"));
+    }
+
+    @Test
+    void removeAllRpms() throws IOException {
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(null, false);
+
+        Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
+
+        assertEquals(
+                "pkg:oci/amq-streams-console-ui-rhel9@sha256%3Af63b27a29c032843941b15567ebd1f37f540160e8066ac74c05367134c2ff3aa?repository_url=registry.com&os=linux&arch=amd64&tag=2.7.0-8.1718294415",
+                adjusted.getMetadata().getComponent().getPurl());
+        assertEquals(33, adjusted.getComponents().size());
+    }
+
+    @Test
+    void removeAllRpmsLeavePrefix() throws IOException {
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(List.of("/app"), false);
+
+        Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
+
+        assertEquals(23, adjusted.getComponents().size());
+    }
+
+    @Test
+    void preserveRpms() throws IOException {
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(null, true);
+
+        Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
+
+        assertEquals(192, adjusted.getComponents().size());
+    }
+
+    @Test
+    void preserveRpmsWithPrefix() throws IOException {
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(List.of("/app"), true);
+
+        Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
+
+        assertEquals(182, adjusted.getComponents().size());
+    }
+}

--- a/cli/src/test/resources/boms/image.json
+++ b/cli/src/test/resources/boms/image.json
@@ -1,0 +1,11310 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:07cb03cc-c0a5-4667-b22a-7f17a797e413",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-07-16T17:43:17+02:00",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "anchore",
+          "name": "syft",
+          "version": "1.6.0"
+        }
+      ]
+    },
+    "component": {
+      "bom-ref": "3893910a10b83660",
+      "type": "container",
+      "name": "registry.com/rh-osbs/amq-streams-console-ui-rhel9",
+      "version": "2.7.0-8.1718294415"
+    },
+    "properties": [
+      { "name": "syft:image:labels:architecture", "value": "x86_64" },
+      {
+        "name": "syft:image:labels:build-date",
+        "value": "2024-06-13T16:02:24"
+      },
+      {
+        "name": "syft:image:labels:com.redhat.component",
+        "value": "amqstreams-console-ui-container"
+      },
+      {
+        "name": "syft:image:labels:com.redhat.license_terms",
+        "value": "https://www.redhat.com/agreements"
+      },
+      {
+        "name": "syft:image:labels:description",
+        "value": "AMQ Streams Console UI"
+      },
+      { "name": "syft:image:labels:distribution-scope", "value": "public" },
+      { "name": "syft:image:labels:io.buildah.version", "value": "1.29.0" },
+      {
+        "name": "syft:image:labels:io.k8s.description",
+        "value": "AMQ Streams Console UI"
+      },
+      {
+        "name": "syft:image:labels:io.k8s.display-name",
+        "value": "AMQ Streams Console UI"
+      },
+      {
+        "name": "syft:image:labels:io.openshift.tags",
+        "value": "messaging,amq,jboss"
+      },
+      { "name": "syft:image:labels:licenses", "value": "/root/licenses" },
+      {
+        "name": "syft:image:labels:maintainer",
+        "value": "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
+      },
+      {
+        "name": "syft:image:labels:name",
+        "value": "amq-streams/console-ui-rhel9"
+      },
+      { "name": "syft:image:labels:release", "value": "8.1718294415" },
+      {
+        "name": "syft:image:labels:summary",
+        "value": "AMQ Streams Console UI"
+      },
+      {
+        "name": "syft:image:labels:url",
+        "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/amq-streams/console-ui-rhel9/images/2.7.0-8.1718294415"
+      },
+      {
+        "name": "syft:image:labels:vcs-ref",
+        "value": "857cfa99af870e97d4e50ba06b66173f83153694"
+      },
+      { "name": "syft:image:labels:vcs-type", "value": "git" },
+      { "name": "syft:image:labels:vendor", "value": "Red Hat, Inc." },
+      { "name": "syft:image:labels:version", "value": "2.7.0" }
+    ]
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:npm/%40edge-runtime/cookies@4.1.1?package-id=e33df8b58032ba84",
+      "type": "library",
+      "name": "@edge-runtime/cookies",
+      "version": "4.1.1",
+      "licenses": [{ "license": { "id": "MPL-2.0" } }],
+      "cpe": "cpe:2.3:a:\\@edge-runtime\\/cookies:\\@edge-runtime\\/cookies:4.1.1:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/%40edge-runtime/cookies@4.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge-runtime\\/cookies:\\@edge_runtime\\/cookies:4.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/cookies:\\@edge-runtime\\/cookies:4.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/cookies:\\@edge_runtime\\/cookies:4.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge-runtime\\/cookies:4.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge_runtime\\/cookies:4.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/@edge-runtime/cookies/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40edge-runtime/ponyfill@2.4.2?package-id=57fbe3b99e79917e",
+      "type": "library",
+      "name": "@edge-runtime/ponyfill",
+      "version": "2.4.2",
+      "licenses": [{ "license": { "id": "MPL-2.0" } }],
+      "cpe": "cpe:2.3:a:\\@edge-runtime\\/ponyfill:\\@edge-runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/%40edge-runtime/ponyfill@2.4.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge-runtime\\/ponyfill:\\@edge_runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/ponyfill:\\@edge-runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/ponyfill:\\@edge_runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge-runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge_runtime\\/ponyfill:2.4.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/@edge-runtime/ponyfill/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40edge-runtime/primitives@4.1.0?package-id=132272a2edbb4688",
+      "type": "library",
+      "name": "@edge-runtime/primitives",
+      "version": "4.1.0",
+      "licenses": [{ "license": { "id": "MPL-2.0" } }],
+      "cpe": "cpe:2.3:a:\\@edge-runtime\\/primitives:\\@edge-runtime\\/primitives:4.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/%40edge-runtime/primitives@4.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge-runtime\\/primitives:\\@edge_runtime\\/primitives:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/primitives:\\@edge-runtime\\/primitives:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge_runtime\\/primitives:\\@edge_runtime\\/primitives:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge-runtime\\/primitives:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:\\@edge:\\@edge_runtime\\/primitives:4.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/@edge-runtime/primitives/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40next/env@14.2.3?package-id=702802012ea674e2",
+      "type": "library",
+      "author": "Next.js Team <support@vercel.com>",
+      "name": "@next/env",
+      "version": "14.2.3",
+      "description": "Next.js dotenv file loading",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:\\@next\\/env:\\@next\\/env:14.2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/%40next/env@14.2.3",
+      "externalReferences": [
+        { "url": "https://github.com/vercel/next.js", "type": "distribution" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:vercel:\\@next\\/env:14.2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/@next/env/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40swc/helpers@0.5.5?package-id=a71992b2191aaa7e",
+      "type": "library",
+      "author": "강동윤 <kdy1997.dev@gmail.com>",
+      "name": "@swc/helpers",
+      "version": "0.5.5",
+      "description": "External helpers for the swc project.",
+      "licenses": [{ "license": { "id": "Apache-2.0" } }],
+      "cpe": "cpe:2.3:a:\\@swc\\/helpers:\\@swc\\/helpers:0.5.5:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/%40swc/helpers@0.5.5",
+      "externalReferences": [
+        {
+          "url": "git+https://github.com/swc-project/swc.git",
+          "type": "distribution"
+        },
+        { "url": "https://swc.rs", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/@swc/helpers/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.20-2.el9?arch=x86_64&upstream=chkconfig-1.20-2.el9.src.rpm&distro=rhel-9.2&package-id=9981079612400e1b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "alternatives",
+      "version": "1.20-2.el9",
+      "licenses": [{ "license": { "name": "GPLv2" } }],
+      "cpe": "cpe:2.3:a:alternatives:alternatives:1.20-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/alternatives@1.20-2.el9?arch=x86_64&upstream=chkconfig-1.20-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:alternatives:1.20-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "63864" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "chkconfig-1.20-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "audit-libs",
+      "version": "3.0.7-103.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:audit-libs:audit-libs:3.0.7-103.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit-libs:audit_libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit_libs:audit-libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit_libs:audit_libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:audit-libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:audit_libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit:audit-libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:audit:audit_libs:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "103.el9" },
+        { "name": "syft:metadata:size", "value": "307409" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "audit-3.0.7-103.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.2&package-id=506fd4db392edafc",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "basesystem",
+      "version": "11-13.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:basesystem:basesystem:11-13.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:basesystem:11-13.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "13.el9" },
+        { "name": "syft:metadata:size", "value": "0" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "basesystem-11-13.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "bash",
+      "version": "5.1.8-6.el9_1",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:bash:5.1.8-6.el9_1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bash:bash:5.1.8-6.el9_1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9_1" },
+        { "name": "syft:metadata:size", "value": "7738610" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "bash-5.1.8-6.el9_1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/busboy@1.6.0?package-id=dc92a47db010e145",
+      "type": "library",
+      "author": "Brian White <mscdex@mscdex.net>",
+      "name": "busboy",
+      "version": "1.6.0",
+      "description": "A streaming parser for HTML form data for node.js",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:busboy:busboy:1.6.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/busboy@1.6.0",
+      "externalReferences": [
+        { "url": "http://github.com/mscdex/busboy.git", "type": "distribution" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mscdex:busboy:1.6.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/busboy/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "bzip2-libs",
+      "version": "1.0.8-8.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:bzip2-libs:bzip2-libs:1.0.8-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2-libs:bzip2_libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2_libs:bzip2-libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2_libs:bzip2_libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:bzip2-libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:bzip2_libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2:bzip2-libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:bzip2:bzip2_libs:1.0.8-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9" },
+        { "name": "syft:metadata:size", "value": "78740" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "bzip2-1.0.8-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2&package-id=2839d56c3630d08c",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ca-certificates",
+      "version": "2023.2.60_v7.0.306-90.1.el9_2",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:ca-certificates:ca-certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca-certificates:ca_certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca_certificates:ca-certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca_certificates:ca_certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ca-certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ca_certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca:ca-certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ca:ca_certificates:2023.2.60_v7.0.306-90.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "90.1.el9_2" },
+        { "name": "syft:metadata:size", "value": "2354545" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/caniuse-lite@1.0.30001587?package-id=ec8a943da06efb39",
+      "type": "library",
+      "author": "Ben Briggs <beneb.info@gmail.com> (http://beneb.info)",
+      "name": "caniuse-lite",
+      "version": "1.0.30001587",
+      "description": "A smaller version of caniuse-db, with only the essentials!",
+      "licenses": [{ "license": { "id": "CC-BY-4.0" } }],
+      "cpe": "cpe:2.3:a:caniuse-lite:caniuse-lite:1.0.30001587:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/caniuse-lite@1.0.30001587",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:caniuse-lite:caniuse_lite:1.0.30001587:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:caniuse_lite:caniuse-lite:1.0.30001587:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:caniuse_lite:caniuse_lite:1.0.30001587:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:caniuse:caniuse-lite:1.0.30001587:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:caniuse:caniuse_lite:1.0.30001587:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/caniuse-lite/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/checkpolicy@3.5-1.el9?arch=x86_64&upstream=checkpolicy-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=d23d45a6fad2694f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "checkpolicy",
+      "version": "3.5-1.el9",
+      "licenses": [{ "license": { "name": "GPLv2" } }],
+      "cpe": "cpe:2.3:a:checkpolicy:checkpolicy:3.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/checkpolicy@3.5-1.el9?arch=x86_64&upstream=checkpolicy-3.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:checkpolicy:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "1513288" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "checkpolicy-3.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/client-only@0.0.1?package-id=c3647e5c21de1a68",
+      "type": "library",
+      "name": "client-only",
+      "version": "0.0.1",
+      "description": "This is a marker package to indicate that a module can only be used in Client Components.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:client-only:client-only:0.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/client-only@0.0.1",
+      "externalReferences": [
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:client-only:client_only:0.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:client_only:client-only:0.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:client_only:client_only:0.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:client:client-only:0.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:client:client_only:0.0.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/client-only/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "coreutils-single",
+      "version": "8.32-34.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:coreutils-single:coreutils-single:8.32-34.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils-single:coreutils_single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils_single:coreutils-single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils_single:coreutils_single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils:coreutils-single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:coreutils:coreutils_single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:coreutils-single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:coreutils_single:8.32-34.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "34.el9" },
+        { "name": "syft:metadata:size", "value": "1402801" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "coreutils-8.32-34.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=20ce8cc4474b8475",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "cracklib",
+      "version": "2.9.6-27.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:cracklib:cracklib:2.9.6-27.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cracklib:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "27.el9" },
+        { "name": "syft:metadata:size", "value": "251850" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "cracklib-2.9.6-27.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=9d045aaf1b7a68e2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "cracklib-dicts",
+      "version": "2.9.6-27.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:cracklib-dicts:cracklib-dicts:2.9.6-27.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cracklib-dicts:cracklib_dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cracklib_dicts:cracklib-dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cracklib_dicts:cracklib_dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cracklib:cracklib-dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cracklib:cracklib_dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cracklib-dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cracklib_dicts:2.9.6-27.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "27.el9" },
+        { "name": "syft:metadata:size", "value": "9815154" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "cracklib-2.9.6-27.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20221215-1.git9a18988.el9_2.2?arch=noarch&upstream=crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm&distro=rhel-9.2&package-id=c68b022d888d3ed0",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "crypto-policies",
+      "version": "20221215-1.git9a18988.el9_2.2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:crypto-policies:crypto-policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/crypto-policies@20221215-1.git9a18988.el9_2.2?arch=noarch&upstream=crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto-policies:crypto_policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto-policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto_policies:crypto_policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto-policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:crypto:crypto_policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto-policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:crypto_policies:20221215-1.git9a18988.el9_2.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.git9a18988.el9_2.2" },
+        { "name": "syft:metadata:size", "value": "85327" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=9d0c2200e8dd58c7",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "curl-minimal",
+      "version": "7.76.1-23.el9_2.6",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:curl-minimal:curl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl-minimal:curl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl_minimal:curl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl_minimal:curl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:curl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:curl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl:curl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:curl:curl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "23.el9_2.6" },
+        { "name": "syft:metadata:size", "value": "245105" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "curl-7.76.1-23.el9_2.6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm&distro=rhel-9.2&package-id=bdaaa55e55ff53d0",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "cyrus-sasl-lib",
+      "version": "2.1.27-21.el9",
+      "licenses": [{ "license": { "name": "BSD with advertising" } }],
+      "cpe": "cpe:2.3:a:cyrus-sasl-lib:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl-lib:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl_lib:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl_lib:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus-sasl:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus_sasl:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus:cyrus-sasl-lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:cyrus:cyrus_sasl_lib:2.1.27-21.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "21.el9" },
+        { "name": "syft:metadata:size", "value": "2380384" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "cyrus-sasl-2.1.27-21.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=55a4fbd380f817ef",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dbus",
+      "version": "1:1.12.20-7.el9_2.1",
+      "licenses": [{ "license": { "name": "(GPLv2+ or AFL) and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:dbus:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "7.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "0" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dbus-1.12.20-7.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64&upstream=dbus-broker-28-7.el9.src.rpm&distro=rhel-9.2&package-id=9d5ceb40acd1a308",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dbus-broker",
+      "version": "28-7.el9",
+      "licenses": [{ "license": { "name": "ASL 2.0" } }],
+      "cpe": "cpe:2.3:a:dbus-broker:dbus-broker:28-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64&upstream=dbus-broker-28-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus-broker:dbus_broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_broker:dbus-broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_broker:dbus_broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus-broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus_broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus-broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus_broker:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "393994" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dbus-broker-28-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.20-7.el9_2.1?arch=noarch&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=33187b42a382a679",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dbus-common",
+      "version": "1:1.12.20-7.el9_2.1",
+      "licenses": [{ "license": { "name": "(GPLv2+ or AFL) and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:dbus-common:dbus-common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.20-7.el9_2.1?arch=noarch&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus-common:dbus_common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_common:dbus-common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_common:dbus_common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus-common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus_common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus-common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus_common:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "7.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "11394" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dbus-1.12.20-7.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=f7be1f9847973ac6",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dbus-libs",
+      "version": "1:1.12.20-7.el9_2.1",
+      "licenses": [{ "license": { "name": "(GPLv2+ or AFL) and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:dbus-libs:dbus-libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus-libs:dbus_libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_libs:dbus-libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus_libs:dbus_libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus-libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dbus_libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus-libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dbus:dbus_libs:1\\:1.12.20-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "7.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "372990" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dbus-1.12.20-7.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&upstream=dejavu-fonts-2.37-18.el9.src.rpm&distro=rhel-9.2&package-id=b7168bc61a4fdefc",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dejavu-sans-fonts",
+      "version": "2.37-18.el9",
+      "licenses": [
+        { "license": { "name": "Bitstream Vera and Public Domain" } }
+      ],
+      "cpe": "cpe:2.3:a:dejavu-sans-fonts:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&upstream=dejavu-fonts-2.37-18.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans-fonts:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans_fonts:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans_fonts:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu-sans:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu_sans:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dejavu:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dejavu-sans-fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dejavu_sans_fonts:2.37-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "18.el9" },
+        { "name": "syft:metadata:size", "value": "5930958" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dejavu-fonts-2.37-18.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/diffutils@3.7-12.el9?arch=x86_64&upstream=diffutils-3.7-12.el9.src.rpm&distro=rhel-9.2&package-id=174e9478576d794b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "diffutils",
+      "version": "3.7-12.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:diffutils:diffutils:3.7-12.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/diffutils@3.7-12.el9?arch=x86_64&upstream=diffutils-3.7-12.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:diffutils:3.7-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "12.el9" },
+        { "name": "syft:metadata:size", "value": "1467825" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "diffutils-3.7-12.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/distro@1.5.0?package-id=2195710dad45f45c",
+      "type": "library",
+      "author": "Nir Cohen <nir36g@gmail.com>",
+      "name": "distro",
+      "version": "1.5.0",
+      "licenses": [{ "license": { "name": "Apache License, Version 2.0" } }],
+      "cpe": "cpe:2.3:a:nir_cohen_project:python-distro:1.5.0:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/distro@1.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohen_project:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohenproject:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohenproject:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g_project:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g_project:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36gproject:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36gproject:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-distro:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-distro:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_distro:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_distro:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohen_project:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohen:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohen:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohenproject:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g_project:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:distro:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:distro:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36gproject:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-distro:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_distro:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir_cohen:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:distro:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:nir36g:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:distro:1.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/distro-1.5.0-py3.9.egg-info/PKG-INFO"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib/python3.9/site-packages/distro-1.5.0-py3.9.egg-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=5bcc52fe6dc4603d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dnf",
+      "version": "4.14.0-5.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf:dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9_2" },
+        { "name": "syft:metadata:size", "value": "2424936" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dnf-4.14.0-5.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=f88cd17b6d8b189c",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "dnf-data",
+      "version": "4.14.0-5.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:dnf-data:dnf-data:4.14.0-5.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf-data:dnf_data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf_data:dnf-data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf_data:dnf_data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dnf-data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:dnf_data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf:dnf-data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:dnf:dnf_data:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9_2" },
+        { "name": "syft:metadata:size", "value": "39012" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dnf-4.14.0-5.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.188-3.el9?arch=noarch&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=f5df68fdd9282c61",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "elfutils-default-yama-scope",
+      "version": "0.188-3.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ or LGPLv3+" } }],
+      "cpe": "cpe:2.3:a:elfutils-default-yama-scope:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.188-3.el9?arch=noarch&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-default-yama-scope:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default_yama_scope:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default_yama_scope:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-default-yama:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-default-yama:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default_yama:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default_yama:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-default:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-default:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_default:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils-default-yama-scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils_default_yama_scope:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "1810" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "elfutils-0.188-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=c92de458b11b567b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "elfutils-libelf",
+      "version": "0.188-3.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ or LGPLv3+" } }],
+      "cpe": "cpe:2.3:a:elfutils-libelf:elfutils-libelf:0.188-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-libelf:elfutils_libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_libelf:elfutils-libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_libelf:elfutils_libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils-libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils_libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils-libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils_libelf:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "1027568" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "elfutils-0.188-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=e5d44aae1a49bed2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "elfutils-libs",
+      "version": "0.188-3.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ or LGPLv3+" } }],
+      "cpe": "cpe:2.3:a:elfutils-libs:elfutils-libs:0.188-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils-libs:elfutils_libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_libs:elfutils-libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils_libs:elfutils_libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils-libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:elfutils:elfutils_libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils-libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:elfutils_libs:0.188-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "685085" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "elfutils-0.188-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2&package-id=76aa586e0d991726",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "expat",
+      "version": "2.5.0-1.el9_2.1",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:redhat:expat:2.5.0-1.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:expat:expat:2.5.0-1.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "309154" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "expat-2.5.0-1.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-12.1.el9_2?arch=x86_64&upstream=file-5.39-12.1.el9_2.src.rpm&distro=rhel-9.2&package-id=0dfb75c17a8b9423",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "file-libs",
+      "version": "5.39-12.1.el9_2",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:file-libs:file-libs:5.39-12.1.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-12.1.el9_2?arch=x86_64&upstream=file-5.39-12.1.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file-libs:file_libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file_libs:file-libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file_libs:file_libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:file-libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:file_libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file:file-libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:file:file_libs:5.39-12.1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "12.1.el9_2" },
+        { "name": "syft:metadata:size", "value": "8086659" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "file-5.39-12.1.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2&package-id=35a7e322b4354dc8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "filesystem",
+      "version": "3.16-2.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:filesystem:filesystem:3.16-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:filesystem:3.16-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "106" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "filesystem-3.16-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/findutils@4.8.0-5.el9?arch=x86_64&epoch=1&upstream=findutils-4.8.0-5.el9.src.rpm&distro=rhel-9.2&package-id=701b5ca77859ef74",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "findutils",
+      "version": "1:4.8.0-5.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:findutils:findutils:1\\:4.8.0-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/findutils@4.8.0-5.el9?arch=x86_64&epoch=1&upstream=findutils-4.8.0-5.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:findutils:1\\:4.8.0-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "5.el9" },
+        { "name": "syft:metadata:size", "value": "1758430" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "findutils-4.8.0-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm&distro=rhel-9.2&package-id=6cc72f92d4966749",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "fonts-filesystem",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:fonts-filesystem:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts-filesystem:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts_filesystem:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts_filesystem:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts:fonts-filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:fonts:fonts_filesystem:1\\:2.0.5-7.el9.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "7.el9.1" },
+        { "name": "syft:metadata:size", "value": "0" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "fonts-rpm-macros-2.0.5-7.el9.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&upstream=gawk-5.1.0-6.el9.src.rpm&distro=rhel-9.2&package-id=158cf9fdab4d74de",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gawk",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        { "license": { "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD" } }
+      ],
+      "cpe": "cpe:2.3:a:redhat:gawk:5.1.0-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&upstream=gawk-5.1.0-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gawk:gawk:5.1.0-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "1685726" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gawk-5.1.0-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1&upstream=gdbm-1.19-4.el9.src.rpm&distro=rhel-9.2&package-id=761b354e4a426906",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gdbm-libs",
+      "version": "1:1.19-4.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:gdbm-libs:gdbm-libs:1\\:1.19-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1&upstream=gdbm-1.19-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm-libs:gdbm_libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm_libs:gdbm-libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm_libs:gdbm_libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gdbm-libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gdbm_libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm:gdbm-libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gdbm:gdbm_libs:1\\:1.19-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "116306" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gdbm-1.19-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glib2",
+      "version": "2.68.4-6.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:glib2:2.68.4-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glib2:glib2:2.68.4-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "13422726" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glib2-2.68.4-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc",
+      "version": "2.34-60.el9_2.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:redhat:glibc:2.34-60.el9_2.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "60.el9_2.14" },
+        { "name": "syft:metadata:size", "value": "6200891" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-60.el9_2.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc-common",
+      "version": "2.34-60.el9_2.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:glibc-common:glibc-common:2.34-60.el9_2.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-common:glibc_common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_common:glibc-common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_common:glibc_common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc-common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc_common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc-common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc_common:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "60.el9_2.14" },
+        { "name": "syft:metadata:size", "value": "1081377" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-60.el9_2.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=60576fe64fdd7d93",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "glibc-minimal-langpack",
+      "version": "2.34-60.el9_2.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:glibc-minimal-langpack:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal-langpack:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal_langpack:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal_langpack:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc-minimal:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc_minimal:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc-minimal-langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:glibc:glibc_minimal_langpack:2.34-60.el9_2.14:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "60.el9_2.14" },
+        { "name": "syft:metadata:size", "value": "0" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "glibc-2.34-60.el9_2.14.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-10.el9?arch=x86_64&epoch=1&upstream=gmp-6.2.0-10.el9.src.rpm&distro=rhel-9.2&package-id=2bb3b9c7adaedb4e",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gmp",
+      "version": "1:6.2.0-10.el9",
+      "licenses": [{ "license": { "name": "LGPLv3+ or GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:gmp:1\\:6.2.0-10.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-10.el9?arch=x86_64&epoch=1&upstream=gmp-6.2.0-10.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gmp:gmp:1\\:6.2.0-10.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "10.el9" },
+        { "name": "syft:metadata:size", "value": "818100" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gmp-6.2.0-10.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-2.el9_0?arch=x86_64&upstream=gnupg2-2.3.3-2.el9_0.src.rpm&distro=rhel-9.2&package-id=c7a5ba8dd5b92d5b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gnupg2",
+      "version": "2.3.3-2.el9_0",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:gnupg2:gnupg2:2.3.3-2.el9_0:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-2.el9_0?arch=x86_64&upstream=gnupg2-2.3.3-2.el9_0.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gnupg2:2.3.3-2.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9_0" },
+        { "name": "syft:metadata:size", "value": "9247709" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gnupg2-2.3.3-2.el9_0.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64&upstream=gnutls-3.7.6-21.el9_2.3.src.rpm&distro=rhel-9.2&package-id=7456ad8810579504",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gnutls",
+      "version": "3.7.6-21.el9_2.3",
+      "licenses": [{ "license": { "name": "GPLv3+ and LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:gnutls:gnutls:3.7.6-21.el9_2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64&upstream=gnutls-3.7.6-21.el9_2.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gnutls:3.7.6-21.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "21.el9_2.3" },
+        { "name": "syft:metadata:size", "value": "3295019" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gnutls-3.7.6-21.el9_2.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&upstream=gobject-introspection-1.68.0-11.el9.src.rpm&distro=rhel-9.2&package-id=d6335e1922cdb5fb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gobject-introspection",
+      "version": "1.68.0-11.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ and LGPLv2+ and MIT" } }],
+      "cpe": "cpe:2.3:a:gobject-introspection:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&upstream=gobject-introspection-1.68.0-11.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject-introspection:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject_introspection:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject_introspection:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gobject:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gobject-introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:gobject_introspection:1.68.0-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9" },
+        { "name": "syft:metadata:size", "value": "936649" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gobject-introspection-1.68.0-11.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/gpg@1.15.1?package-id=d1006e9458e03d74",
+      "type": "library",
+      "author": "The GnuPG hackers <gnupg-devel@gnupg.org>",
+      "name": "gpg",
+      "version": "1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL2.1+ (the library), GPL2+ (tests and examples)"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:gnupg_hackers_project:python-gpg:1.15.1:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/gpg@1.15.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackers_project:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackersproject:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackersproject:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel_project:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel_project:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_develproject:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_develproject:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackers_project:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackers:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackers:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackersproject:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel_project:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg-devel:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg-devel:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_develproject:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-gpg:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-gpg:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_gpg:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_gpg:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_hackers:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg-devel:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gnupg_devel:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:python-gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:python_gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-gpg:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_gpg:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg:1.15.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.2&package-id=a7a3fe27bace3612",
+      "type": "library",
+      "name": "gpg-pubkey",
+      "version": "5a6340b3-6229229e",
+      "licenses": [{ "license": { "name": "pubkey" } }],
+      "cpe": "cpe:2.3:a:gpg-pubkey:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg-pubkey:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg-pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg_pubkey:5a6340b3-6229229e:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6229229e" },
+        { "name": "syft:metadata:size", "value": "0" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-9.2&package-id=5b3cc47c8015a22a",
+      "type": "library",
+      "name": "gpg-pubkey",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [{ "license": { "name": "pubkey" } }],
+      "cpe": "cpe:2.3:a:gpg-pubkey:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg-pubkey:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg_pubkey:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg-pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpg:gpg_pubkey:fd431d51-4ae0493b:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4ae0493b" },
+        { "name": "syft:metadata:size", "value": "0" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=d155d9e484ba0ca5",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gpgme",
+      "version": "1.15.1-6.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+ and GPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:gpgme:1.15.1-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gpgme:gpgme:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "576065" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gpgme-1.15.1-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/graceful-fs@4.2.11?package-id=eaca30e290aa4093",
+      "type": "library",
+      "name": "graceful-fs",
+      "version": "4.2.11",
+      "description": "A drop-in replacement for fs, making various improvements.",
+      "licenses": [{ "license": { "id": "ISC" } }],
+      "cpe": "cpe:2.3:a:graceful-fs:graceful-fs:4.2.11:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/graceful-fs@4.2.11",
+      "externalReferences": [
+        {
+          "url": "https://github.com/isaacs/node-graceful-fs",
+          "type": "distribution"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:graceful-fs:graceful_fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:graceful_fs:graceful-fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:graceful_fs:graceful_fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:graceful:graceful-fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:graceful:graceful_fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:isaacs:graceful-fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:isaacs:graceful_fs:4.2.11:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/graceful-fs/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "grep",
+      "version": "3.6-5.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:grep:3.6-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:grep:grep:3.6-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9" },
+        { "name": "syft:metadata:size", "value": "857840" },
+        { "name": "syft:metadata:sourceRpm", "value": "grep-3.6-5.el9.src.rpm" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&upstream=gzip-1.12-1.el9.src.rpm&distro=rhel-9.2&package-id=a93b2dc3947152c6",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "gzip",
+      "version": "1.12-1.el9",
+      "licenses": [{ "license": { "name": "GPLv3+ and GFDL" } }],
+      "cpe": "cpe:2.3:a:redhat:gzip:1.12-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&upstream=gzip-1.12-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:gzip:gzip:1.12-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "377013" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gzip-1.12-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64&upstream=ima-evm-utils-1.4-4.el9.src.rpm&distro=rhel-9.2&package-id=204a975cb2bc3ba7",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ima-evm-utils",
+      "version": "1.4-4.el9",
+      "licenses": [{ "license": { "name": "GPLv2" } }],
+      "cpe": "cpe:2.3:a:ima-evm-utils:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64&upstream=ima-evm-utils-1.4-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima-evm-utils:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima_evm_utils:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima_evm_utils:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima-evm:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima-evm:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima_evm:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima_evm:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima:ima-evm-utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ima:ima_evm_utils:1.4-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "151135" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ima-evm-utils-1.4-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2&package-id=81e63cdc65a50d3b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "json-c",
+      "version": "0.14-11.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:json-c:json-c:0.14-11.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json-c:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_c:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_c:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json-c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json_c:0.14-11.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9" },
+        { "name": "syft:metadata:size", "value": "79282" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "json-c-0.14-11.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&upstream=json-glib-1.6.6-1.el9.src.rpm&distro=rhel-9.2&package-id=d6f65de78a805960",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "json-glib",
+      "version": "1.6.6-1.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:json-glib:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&upstream=json-glib-1.6.6-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json-glib:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_glib:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_glib:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json-glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:json_glib:1.6.6-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "555868" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "json-glib-1.6.6-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&upstream=keyutils-1.6.3-1.el9.src.rpm&distro=rhel-9.2&package-id=55d5e42253b50ced",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "keyutils-libs",
+      "version": "1.6.3-1.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ and LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:keyutils-libs:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&upstream=keyutils-1.6.3-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils-libs:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils_libs:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils_libs:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:keyutils:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:keyutils-libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:keyutils_libs:1.6.3-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "55267" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "keyutils-1.6.3-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@28-7.el9?arch=x86_64&upstream=kmod-28-7.el9.src.rpm&distro=rhel-9.2&package-id=1f7352a741116df2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "kmod-libs",
+      "version": "28-7.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:kmod-libs:kmod-libs:28-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/kmod-libs@28-7.el9?arch=x86_64&upstream=kmod-28-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:kmod-libs:kmod_libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:kmod_libs:kmod-libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:kmod_libs:kmod_libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:kmod-libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:kmod_libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:kmod:kmod-libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:kmod:kmod_libs:28-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "134470" },
+        { "name": "syft:metadata:sourceRpm", "value": "kmod-28-7.el9.src.rpm" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.20.1-9.el9_2?arch=x86_64&upstream=krb5-1.20.1-9.el9_2.src.rpm&distro=rhel-9.2&package-id=398c0cd24306adb7",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "krb5-libs",
+      "version": "1.20.1-9.el9_2",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:krb5-libs:krb5-libs:1.20.1-9.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.20.1-9.el9_2?arch=x86_64&upstream=krb5-1.20.1-9.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5-libs:krb5_libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5_libs:krb5-libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5_libs:krb5_libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:krb5-libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:krb5_libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5:krb5-libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:krb5:krb5_libs:1.20.1-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "9.el9_2" },
+        { "name": "syft:metadata:size", "value": "2182856" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "krb5-1.20.1-9.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=96b4e155ff62096d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-core-en",
+      "version": "3.0-16.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:langpacks-core-en:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-en:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_en:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_en:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-core-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_core_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "16.el9" },
+        { "name": "syft:metadata:size", "value": "398" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=75c54bdb853ef6d4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-core-font-en",
+      "version": "3.0-16.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:langpacks-core-font-en:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font-en:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font_en:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font_en:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core-font:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core_font:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-core:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_core:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-core-font-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_core_font_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "16.el9" },
+        { "name": "syft:metadata:size", "value": "351" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=7974177c6a4996ee",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "langpacks-en",
+      "version": "3.0-16.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:langpacks-en:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks-en:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_en:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks_en:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:langpacks:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks-en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:langpacks_en:3.0-16.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "16.el9" },
+        { "name": "syft:metadata:size", "value": "400" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "langpacks-3.0-16.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libacl",
+      "version": "2.3.1-3.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libacl:libacl:2.3.1-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libacl:2.3.1-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "41178" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "acl-2.3.1-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&upstream=libarchive-3.5.3-4.el9.src.rpm&distro=rhel-9.2&package-id=6f9da8010675d944",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libarchive",
+      "version": "3.5.3-4.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:libarchive:libarchive:3.5.3-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&upstream=libarchive-3.5.3-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libarchive:3.5.3-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "906150" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libarchive-3.5.3-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&upstream=libassuan-2.5.5-3.el9.src.rpm&distro=rhel-9.2&package-id=f0df71d33cd93a26",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libassuan",
+      "version": "2.5.5-3.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+ and GPLv3+" } }],
+      "cpe": "cpe:2.3:a:libassuan:libassuan:2.5.5-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&upstream=libassuan-2.5.5-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libassuan:2.5.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "171165" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libassuan-2.5.5-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.2&package-id=2fd2059567f2231b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libattr",
+      "version": "2.5.1-3.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libattr:libattr:2.5.1-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libattr:2.5.1-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "29429" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "attr-2.5.1-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libblkid",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libblkid:libblkid:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libblkid:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "229777" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libbrotli@1.0.9-6.el9?arch=x86_64&upstream=brotli-1.0.9-6.el9.src.rpm&distro=rhel-9.2&package-id=177a2891ec722e0b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libbrotli",
+      "version": "1.0.9-6.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libbrotli:libbrotli:1.0.9-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libbrotli@1.0.9-6.el9?arch=x86_64&upstream=brotli-1.0.9-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libbrotli:1.0.9-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "784562" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "brotli-1.0.9-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcap",
+      "version": "2.48-9.el9_2",
+      "licenses": [{ "license": { "name": "BSD or GPLv2" } }],
+      "cpe": "cpe:2.3:a:libcap:libcap:2.48-9.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap:2.48-9.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "9.el9_2" },
+        { "name": "syft:metadata:size", "value": "177471" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcap-2.48-9.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcap-ng",
+      "version": "0.8.2-7.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libcap-ng:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap-ng:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap_ng:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap_ng:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcap:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap-ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcap_ng:0.8.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "75196" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcap-ng-0.8.2-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2&package-id=1ff14ad1a12c7915",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcom_err",
+      "version": "1.46.5-3.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libcom-err:libcom-err:1.46.5-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom-err:libcom_err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom_err:libcom-err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom_err:libcom_err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom:libcom-err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcom:libcom_err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcom-err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcom_err:1.46.5-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "69041" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "e2fsprogs-1.46.5-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/libcomps@0.1.18?package-id=66bfda9bc1300607",
+      "type": "library",
+      "author": "RPM Software Management <rpm-ecosystem@lists.rpm.org>",
+      "name": "libcomps",
+      "version": "0.1.18",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:rpm_software_management_project:python-libcomps:0.1.18:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/libcomps@0.1.18",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_management_project:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_managementproject:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_managementproject:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_management_project:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_management:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_management:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_managementproject:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem_project:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem_project:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystemproject:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystemproject:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_software_management:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-libcomps:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-libcomps:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_libcomps:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_libcomps:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem_project:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-ecosystem:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-ecosystem:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystemproject:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcomps:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcomps:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-libcomps:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_libcomps:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-ecosystem:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_ecosystem:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcomps:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:libcomps:0.1.18:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/PKG-INFO"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib64/python3.9/site-packages/libcomps-0.1.18-py3.9.egg-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=99995d522accc3c7",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcomps",
+      "version": "0.1.18-1.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:libcomps:libcomps:0.1.18-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "215151" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcomps-0.1.18-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=243b0f56bbb981ae",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libcurl-minimal",
+      "version": "7.76.1-23.el9_2.6",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libcurl-minimal:libcurl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl-minimal:libcurl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl_minimal:libcurl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl_minimal:libcurl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl:libcurl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libcurl:libcurl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcurl-minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libcurl_minimal:7.76.1-23.el9_2.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "23.el9_2.6" },
+        { "name": "syft:metadata:size", "value": "518158" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "curl-7.76.1-23.el9_2.6.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64&upstream=libdb-5.3.28-53.el9.src.rpm&distro=rhel-9.2&package-id=09c977c89771d7c1",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libdb",
+      "version": "5.3.28-53.el9",
+      "licenses": [{ "license": { "name": "BSD and LGPLv2 and Sleepycat" } }],
+      "cpe": "cpe:2.3:a:redhat:libdb:5.3.28-53.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64&upstream=libdb-5.3.28-53.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdb:libdb:5.3.28-53.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "53.el9" },
+        { "name": "syft:metadata:size", "value": "1898038" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libdb-5.3.28-53.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=d92cdf960df2c439",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libdnf",
+      "version": "0.69.0-3.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libdnf:libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_2" },
+        { "name": "syft:metadata:size", "value": "2122253" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libdnf-0.69.0-3.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.33.2-1.el9_2?arch=x86_64&upstream=subscription-manager-1.29.33.2-1.el9_2.src.rpm&distro=rhel-9.2&package-id=cd248da7479f7eb4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libdnf-plugin-subscription-manager",
+      "version": "1.29.33.2-1.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2" } }],
+      "cpe": "cpe:2.3:a:libdnf-plugin-subscription-manager:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.33.2-1.el9_2?arch=x86_64&upstream=subscription-manager-1.29.33.2-1.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf-plugin-subscription-manager:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin_subscription_manager:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin_subscription_manager:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf-plugin-subscription:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf-plugin-subscription:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin_subscription:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin_subscription:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf-plugin:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf-plugin:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf_plugin:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libdnf:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libdnf-plugin-subscription-manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libdnf_plugin_subscription_manager:1.29.33.2-1.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9_2" },
+        { "name": "syft:metadata:size", "value": "64962" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "subscription-manager-1.29.33.2-1.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64&upstream=libeconf-0.4.1-3.el9_2.src.rpm&distro=rhel-9.2&package-id=abf889c0a22c1531",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libeconf",
+      "version": "0.4.1-3.el9_2",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libeconf:libeconf:0.4.1-3.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64&upstream=libeconf-0.4.1-3.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libeconf:0.4.1-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_2" },
+        { "name": "syft:metadata:size", "value": "45723" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libeconf-0.4.1-3.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-6.el9?arch=x86_64&upstream=libevent-2.1.12-6.el9.src.rpm&distro=rhel-9.2&package-id=61d83bbd48df5fd1",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libevent",
+      "version": "2.1.12-6.el9",
+      "licenses": [{ "license": { "name": "BSD and ISC" } }],
+      "cpe": "cpe:2.3:a:libevent:libevent:2.1.12-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-6.el9?arch=x86_64&upstream=libevent-2.1.12-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libevent:2.1.12-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "932210" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libevent-2.1.12-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d32517146bdc430b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libfdisk",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libfdisk:libfdisk:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libfdisk@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libfdisk:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "367771" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libffi",
+      "version": "3.4.2-7.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libffi:libffi:3.4.2-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libffi:3.4.2-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "66385" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libffi-3.4.2-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgcc",
+      "version": "11.3.1-4.3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libgcc:libgcc:11.3.1-4.3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgcc:11.3.1-4.3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.3.el9" },
+        { "name": "syft:metadata:size", "value": "198764" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gcc-11.3.1-4.3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2&package-id=ed04899fcadf0517",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgcrypt",
+      "version": "1.10.0-10.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libgcrypt:libgcrypt:1.10.0-10.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgcrypt:1.10.0-10.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "10.el9_2" },
+        { "name": "syft:metadata:size", "value": "1382050" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libgcrypt-1.10.0-10.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgomp@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=01b95332dae49aeb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgomp",
+      "version": "11.3.1-4.3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libgomp:libgomp:11.3.1-4.3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgomp@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgomp:11.3.1-4.3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.3.el9" },
+        { "name": "syft:metadata:size", "value": "420940" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gcc-11.3.1-4.3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libgpg-error",
+      "version": "1.42-5.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libgpg-error:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg-error:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg_error:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg_error:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libgpg:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgpg-error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libgpg_error:1.42-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9" },
+        { "name": "syft:metadata:size", "value": "837088" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libgpg-error-1.42-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&upstream=libidn2-2.3.0-7.el9.src.rpm&distro=rhel-9.2&package-id=5538fdcbd2d5be39",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libidn2",
+      "version": "2.3.0-7.el9",
+      "licenses": [{ "license": { "name": "(GPLv2+ or LGPLv3+) and GPLv3+" } }],
+      "cpe": "cpe:2.3:a:libidn2:libidn2:2.3.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&upstream=libidn2-2.3.0-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libidn2:2.3.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "253460" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libidn2-2.3.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64&upstream=libksba-1.5.1-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8f27b66dbe5dfaa7",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libksba",
+      "version": "1.5.1-6.el9_1",
+      "licenses": [{ "license": { "name": "(LGPLv3+ or GPLv2+) and GPLv3+" } }],
+      "cpe": "cpe:2.3:a:libksba:libksba:1.5.1-6.el9_1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64&upstream=libksba-1.5.1-6.el9_1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libksba:1.5.1-6.el9_1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9_1" },
+        { "name": "syft:metadata:size", "value": "394486" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libksba-1.5.1-6.el9_1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&upstream=libmodulemd-2.13.0-2.el9.src.rpm&distro=rhel-9.2&package-id=c27d441a1b67e693",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libmodulemd",
+      "version": "2.13.0-2.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libmodulemd:libmodulemd:2.13.0-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&upstream=libmodulemd-2.13.0-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libmodulemd:2.13.0-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "733911" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libmodulemd-2.13.0-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libmount",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libmount:libmount:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libmount:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "310093" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_2.3?arch=x86_64&upstream=nghttp2-1.43.0-5.el9_2.3.src.rpm&distro=rhel-9.2&package-id=2d02863c05340cb8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libnghttp2",
+      "version": "1.43.0-5.el9_2.3",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libnghttp2:libnghttp2:1.43.0-5.el9_2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_2.3?arch=x86_64&upstream=nghttp2-1.43.0-5.el9_2.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libnghttp2:1.43.0-5.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9_2.3" },
+        { "name": "syft:metadata:size", "value": "169780" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nghttp2-1.43.0-5.el9_2.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64&upstream=libpwquality-1.4.4-8.el9.src.rpm&distro=rhel-9.2&package-id=1e6317a9d151dc2f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libpwquality",
+      "version": "1.4.4-8.el9",
+      "licenses": [{ "license": { "name": "BSD or GPLv2+" } }],
+      "cpe": "cpe:2.3:a:libpwquality:libpwquality:1.4.4-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64&upstream=libpwquality-1.4.4-8.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libpwquality:1.4.4-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9" },
+        { "name": "syft:metadata:size", "value": "416376" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libpwquality-1.4.4-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-1.el9?arch=x86_64&upstream=librepo-1.14.5-1.el9.src.rpm&distro=rhel-9.2&package-id=9bd242e89378de6f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "librepo",
+      "version": "1.14.5-1.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:librepo:librepo:1.14.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-1.el9?arch=x86_64&upstream=librepo-1.14.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:librepo:1.14.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "220388" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "librepo-1.14.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&upstream=libreport-2.15.2-6.el9.src.rpm&distro=rhel-9.2&package-id=76ca11928aa4c888",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libreport-filesystem",
+      "version": "2.15.2-6.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:libreport-filesystem:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&upstream=libreport-2.15.2-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport-filesystem:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport_filesystem:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport_filesystem:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libreport:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libreport-filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libreport_filesystem:2.15.2-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "0" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libreport-2.15.2-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_2.1?arch=x86_64&upstream=librhsm-0.0.3-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=f23c4c779ba8c868",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "librhsm",
+      "version": "0.0.3-7.el9_2.1",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:librhsm:librhsm:0.0.3-7.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_2.1?arch=x86_64&upstream=librhsm-0.0.3-7.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:librhsm:0.0.3-7.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "79466" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "librhsm-0.0.3-7.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64&upstream=libseccomp-2.5.2-2.el9.src.rpm&distro=rhel-9.2&package-id=81895d3b4f482c4d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libseccomp",
+      "version": "2.5.2-2.el9",
+      "licenses": [{ "license": { "name": "LGPLv2" } }],
+      "cpe": "cpe:2.3:a:libseccomp:libseccomp:2.5.2-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64&upstream=libseccomp-2.5.2-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libseccomp:2.5.2-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "175293" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libseccomp-2.5.2-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libselinux",
+      "version": "3.5-1.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:libselinux:libselinux:3.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "176653" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libselinux-3.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libselinux-utils@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=e9cfd28f3867e3df",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libselinux-utils",
+      "version": "3.5-1.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:libselinux-utils:libselinux-utils:3.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libselinux-utils@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libselinux-utils:libselinux_utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libselinux_utils:libselinux-utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libselinux_utils:libselinux_utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libselinux:libselinux-utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:libselinux:libselinux_utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libselinux-utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libselinux_utils:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "399692" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libselinux-3.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=93156165b4634897",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsepol",
+      "version": "3.5-1.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libsepol:libsepol:3.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsepol:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "787907" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsepol-3.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&upstream=libsigsegv-2.13-4.el9.src.rpm&distro=rhel-9.2&package-id=55d832f38e00eddb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsigsegv",
+      "version": "2.13-4.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:libsigsegv:libsigsegv:2.13-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&upstream=libsigsegv-2.13-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsigsegv:2.13-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "50338" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsigsegv-2.13-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsmartcols",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libsmartcols:libsmartcols:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsmartcols:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "134795" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.22-4.el9?arch=x86_64&upstream=libsolv-0.7.22-4.el9.src.rpm&distro=rhel-9.2&package-id=2252faccfd162833",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libsolv",
+      "version": "0.7.22-4.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:libsolv:libsolv:0.7.22-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.22-4.el9?arch=x86_64&upstream=libsolv-0.7.22-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libsolv:0.7.22-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "883730" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libsolv-0.7.22-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libstdc++",
+      "version": "11.3.1-4.3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:libstdc\\+\\+:libstdc\\+\\+:11.3.1-4.3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libstdc\\+\\+:11.3.1-4.3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.3.el9" },
+        { "name": "syft:metadata:size", "value": "2524385" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gcc-11.3.1-4.3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64&upstream=libtasn1-4.16.0-8.el9_1.src.rpm&distro=rhel-9.2&package-id=ad76cf127fb16e5d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libtasn1",
+      "version": "4.16.0-8.el9_1",
+      "licenses": [{ "license": { "name": "GPLv3+ and LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libtasn1:libtasn1:4.16.0-8.el9_1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64&upstream=libtasn1-4.16.0-8.el9_1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libtasn1:4.16.0-8.el9_1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9_1" },
+        { "name": "syft:metadata:size", "value": "183348" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libtasn1-4.16.0-8.el9_1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&upstream=libunistring-0.9.10-15.el9.src.rpm&distro=rhel-9.2&package-id=fe0e5f68a52de6f9",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libunistring",
+      "version": "0.9.10-15.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ or LGPLv3+" } }],
+      "cpe": "cpe:2.3:a:libunistring:libunistring:0.9.10-15.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&upstream=libunistring-0.9.10-15.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libunistring:0.9.10-15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "15.el9" },
+        { "name": "syft:metadata:size", "value": "1643051" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libunistring-0.9.10-15.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64&upstream=libutempter-1.2.1-6.el9.src.rpm&distro=rhel-9.2&package-id=3270a0bcb4c23861",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libutempter",
+      "version": "1.2.1-6.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:libutempter:libutempter:1.2.1-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64&upstream=libutempter-1.2.1-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libutempter:1.2.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "59409" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libutempter-1.2.1-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libuuid",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:libuuid:libuuid:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libuuid:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "33909" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&upstream=libverto-0.3.2-3.el9.src.rpm&distro=rhel-9.2&package-id=33d489156bb86e75",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libverto",
+      "version": "0.3.2-3.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libverto:libverto:0.3.2-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&upstream=libverto-0.3.2-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libverto:0.3.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "30365" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libverto-0.3.2-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libxcrypt",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        { "license": { "name": "LGPLv2+ and BSD and Public Domain" } }
+      ],
+      "cpe": "cpe:2.3:a:libxcrypt:libxcrypt:4.4.18-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libxcrypt:4.4.18-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "270692" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libxcrypt-4.4.18-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libxml2",
+      "version": "2.9.13-3.el9_2.3",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libxml2:libxml2:2.9.13-3.el9_2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libxml2:2.9.13-3.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_2.3" },
+        { "name": "syft:metadata:size", "value": "1955292" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libxml2-2.9.13-3.el9_2.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&upstream=libyaml-0.2.5-7.el9.src.rpm&distro=rhel-9.2&package-id=25b9b440948266fc",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libyaml",
+      "version": "0.2.5-7.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:libyaml:libyaml:0.2.5-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&upstream=libyaml-0.2.5-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libyaml:0.2.5-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "138283" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libyaml-0.2.5-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "libzstd",
+      "version": "1.5.1-2.el9",
+      "licenses": [{ "license": { "name": "BSD and GPLv2" } }],
+      "cpe": "cpe:2.3:a:libzstd:libzstd:1.5.1-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:libzstd:1.5.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "902051" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "zstd-1.5.1-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2&package-id=4f09d2c77d830d9a",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lua-libs",
+      "version": "5.4.4-3.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:lua-libs:lua-libs:5.4.4-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua-libs:lua_libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_libs:lua-libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua_libs:lua_libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua-libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lua_libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua-libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lua:lua_libs:5.4.4-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "549518" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lua-5.4.4-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2&package-id=dd051804a3459d67",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "lz4-libs",
+      "version": "1.9.3-5.el9",
+      "licenses": [{ "license": { "name": "GPLv2+ and BSD" } }],
+      "cpe": "cpe:2.3:a:lz4-libs:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4-libs:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4_libs:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4_libs:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4:lz4-libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:lz4:lz4_libs:1.9.3-5.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9" },
+        { "name": "syft:metadata:size", "value": "145483" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "lz4-1.9.3-5.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&upstream=mpfr-4.1.0-7.el9.src.rpm&distro=rhel-9.2&package-id=26dc53ca059b363f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "mpfr",
+      "version": "4.1.0-7.el9",
+      "licenses": [{ "license": { "name": "LGPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:mpfr:4.1.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&upstream=mpfr-4.1.0-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mpfr:mpfr:4.1.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "802539" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "mpfr-4.1.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/nanoid@3.3.7?package-id=3786adac4ef91058",
+      "type": "library",
+      "author": "Andrey Sitnik <andrey@sitnik.ru>",
+      "name": "nanoid",
+      "version": "3.3.7",
+      "description": "A tiny (116 bytes), secure URL-friendly unique string ID generator",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:nanoid_project:nanoid:3.3.7:*:*:*:*:node.js:*:*",
+      "purl": "pkg:npm/nanoid@3.3.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/nanoid/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-8.20210508.el9_2.1?arch=noarch&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=b36d437382f5105d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ncurses-base",
+      "version": "6.2-8.20210508.el9_2.1",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:ncurses-base:ncurses-base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-8.20210508.el9_2.1?arch=noarch&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses-base:ncurses_base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_base:ncurses-base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_base:ncurses_base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses-base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses_base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses-base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses_base:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.20210508.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "307293" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ncurses-6.2-8.20210508.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "ncurses-libs",
+      "version": "6.2-8.20210508.el9_2.1",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:ncurses-libs:ncurses-libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses-libs:ncurses_libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_libs:ncurses-libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses_libs:ncurses_libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses-libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:ncurses:ncurses_libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses-libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:ncurses_libs:6.2-8.20210508.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.20210508.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "990407" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "ncurses-6.2-8.20210508.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nettle@3.8-3.el9_0?arch=x86_64&upstream=nettle-3.8-3.el9_0.src.rpm&distro=rhel-9.2&package-id=ecb0776f85b54e0c",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nettle",
+      "version": "3.8-3.el9_0",
+      "licenses": [{ "license": { "name": "LGPLv3+ or GPLv2+" } }],
+      "cpe": "cpe:2.3:a:nettle:nettle:3.8-3.el9_0:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nettle@3.8-3.el9_0?arch=x86_64&upstream=nettle-3.8-3.el9_0.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nettle:3.8-3.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_0" },
+        { "name": "syft:metadata:size", "value": "1134302" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nettle-3.8-3.el9_0.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/next@14.2.3?package-id=7e40530709202583",
+      "type": "library",
+      "name": "next",
+      "version": "14.2.3",
+      "description": "The React Framework",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:next:next:14.2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/next@14.2.3",
+      "externalReferences": [
+        { "url": "https://nextjs.org", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/nodejs@18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652?arch=x86_64&epoch=1&upstream=nodejs-18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652.src.rpm&distro=rhel-9.2&package-id=ff5fbbdc32e7a1e8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "nodejs",
+      "version": "1:18.20.2-2.module+el9.2.0+21812+f1e61652",
+      "licenses": [
+        { "license": { "name": "MIT and ASL 2.0 and ISC and BSD" } }
+      ],
+      "cpe": "cpe:2.3:a:nodejs:nodejs:1\\:18.20.2-2.module\\+el9.2.0\\+21812\\+f1e61652:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/nodejs@18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652?arch=x86_64&epoch=1&upstream=nodejs-18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:nodejs:1\\:18.20.2-2.module\\+el9.2.0\\+21812\\+f1e61652:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        {
+          "name": "syft:metadata:release",
+          "value": "2.module+el9.2.0+21812+f1e61652"
+        },
+        { "name": "syft:metadata:size", "value": "49209184" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "nodejs-18.20.2-2.module+el9.2.0+21812+f1e61652.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&upstream=npth-1.6-8.el9.src.rpm&distro=rhel-9.2&package-id=46359f7db0dbddc2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "npth",
+      "version": "1.6-8.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:npth:1.6-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&upstream=npth-1.6-8.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:npth:npth:1.6-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9" },
+        { "name": "syft:metadata:size", "value": "50619" },
+        { "name": "syft:metadata:sourceRpm", "value": "npth-1.6-8.el9.src.rpm" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=ad9157938b3d14aa",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openldap",
+      "version": "2.6.2-3.el9",
+      "licenses": [{ "license": { "name": "OpenLDAP" } }],
+      "cpe": "cpe:2.3:a:openldap:openldap:2.6.2-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openldap@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openldap:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "1078953" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openldap-2.6.2-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openldap-compat@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=1898caf1d50db008",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openldap-compat",
+      "version": "2.6.2-3.el9",
+      "licenses": [{ "license": { "name": "OpenLDAP" } }],
+      "cpe": "cpe:2.3:a:openldap-compat:openldap-compat:2.6.2-3.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openldap-compat@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openldap-compat:openldap_compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openldap_compat:openldap-compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openldap_compat:openldap_compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openldap:openldap-compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openldap:openldap_compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openldap-compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openldap_compat:2.6.2-3.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9" },
+        { "name": "syft:metadata:size", "value": "60638" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openldap-2.6.2-3.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=262062d1052d7ee2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openssl",
+      "version": "1:3.0.7-18.el9_2",
+      "licenses": [{ "license": { "name": "ASL 2.0" } }],
+      "cpe": "cpe:2.3:a:openssl:openssl:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "18.el9_2" },
+        { "name": "syft:metadata:size", "value": "1894928" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openssl-3.0.7-18.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "openssl-libs",
+      "version": "1:3.0.7-18.el9_2",
+      "licenses": [{ "license": { "name": "ASL 2.0" } }],
+      "cpe": "cpe:2.3:a:openssl-libs:openssl-libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl-libs:openssl_libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_libs:openssl-libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl_libs:openssl_libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl-libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:openssl:openssl_libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl-libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:openssl_libs:1\\:3.0.7-18.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "1" },
+        { "name": "syft:metadata:release", "value": "18.el9_2" },
+        { "name": "syft:metadata:size", "value": "6770852" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "openssl-3.0.7-18.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "p11-kit",
+      "version": "0.24.1-2.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:p11-kit:p11-kit:0.24.1-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11_kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11-kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11_kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11-kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11_kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11-kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11_kit:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "1664534" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "p11-kit-0.24.1-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3ffd26011612a996",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "p11-kit-trust",
+      "version": "0.24.1-2.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:p11-kit-trust:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit-trust:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit_trust:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit_trust:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11-kit:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11_kit:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11-kit-trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:p11:p11_kit_trust:0.24.1-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "450935" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "p11-kit-0.24.1-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pam",
+      "version": "1.5.1-15.el9_2",
+      "licenses": [{ "license": { "name": "BSD and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:pam:1.5.1-15.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pam:pam:1.5.1-15.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "15.el9_2" },
+        { "name": "syft:metadata:size", "value": "1894224" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pam-1.5.1-15.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64&upstream=pcre-8.44-3.el9.3.src.rpm&distro=rhel-9.2&package-id=ac753aaf3bdfda91",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre",
+      "version": "8.44-3.el9.3",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:redhat:pcre:8.44-3.el9.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64&upstream=pcre-8.44-3.el9.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre:pcre:8.44-3.el9.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9.3" },
+        { "name": "syft:metadata:size", "value": "539272" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre-8.44-3.el9.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=fc9e00d771d383c9",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre2",
+      "version": "10.40-2.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:redhat:pcre2:10.40-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "653842" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre2-10.40-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-2.el9?arch=noarch&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=8bcc42a0539615f4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "pcre2-syntax",
+      "version": "10.40-2.el9",
+      "licenses": [{ "license": { "name": "BSD" } }],
+      "cpe": "cpe:2.3:a:pcre2-syntax:pcre2-syntax:10.40-2.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-2.el9?arch=noarch&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2-syntax:pcre2_syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2_syntax:pcre2-syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2_syntax:pcre2_syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:pcre2-syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:pcre2_syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2-syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pcre2:pcre2_syntax:10.40-2.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "2.el9" },
+        { "name": "syft:metadata:size", "value": "234324" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "pcre2-10.40-2.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/picocolors@1.0.0?package-id=3a537ce8cdf75f8a",
+      "type": "library",
+      "author": "Alexey Raspopov",
+      "name": "picocolors",
+      "version": "1.0.0",
+      "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
+      "licenses": [{ "license": { "id": "ISC" } }],
+      "cpe": "cpe:2.3:a:picocolors:picocolors:1.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/picocolors@1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/picocolors/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "popt",
+      "version": "1.18-8.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:redhat:popt:1.18-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:popt:popt:1.18-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9" },
+        { "name": "syft:metadata:size", "value": "130360" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "popt-1.18-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/postcss@8.4.31?package-id=1f48fcfb4be9a483",
+      "type": "library",
+      "author": "Andrey Sitnik <andrey@sitnik.ru>",
+      "name": "postcss",
+      "version": "8.4.31",
+      "description": "Tool for transforming styles with JS plugins",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:postcss:postcss:8.4.31:*:*:*:*:node.js:*:*",
+      "purl": "pkg:npm/postcss@8.4.31",
+      "externalReferences": [
+        { "url": "https://postcss.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/node_modules/postcss/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/pyinotify@0.9.6?package-id=fe389aa84e7fdf5d",
+      "type": "library",
+      "author": "Sebastien Martini <seb@dbzteam.org>",
+      "name": "pyinotify",
+      "version": "0.9.6",
+      "licenses": [{ "license": { "name": "MIT License" } }],
+      "cpe": "cpe:2.3:a:sebastien_martini_project:python-pyinotify:0.9.6:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/pyinotify@0.9.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martini_project:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martiniproject:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martiniproject:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martini_project:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martini:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martini:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martiniproject:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-pyinotify:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-pyinotify:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_pyinotify:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_pyinotify:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb_project:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb_project:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebastien_martini:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebproject:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebproject:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pyinotify:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pyinotify:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-pyinotify:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_pyinotify:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb_project:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb:python-pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb:python_pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sebproject:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pyinotify:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:seb:pyinotify:0.9.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/PKG-INFO"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib/python3.9/site-packages/pyinotify-0.9.6-py3.9.egg-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3",
+      "version": "3.9.16-1.el9_2.3",
+      "licenses": [{ "license": { "name": "Python" } }],
+      "cpe": "cpe:2.3:a:python3:python3:3.9.16-1.el9_2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9_2.3" },
+        { "name": "syft:metadata:size", "value": "32632" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python3.9-3.9.16-1.el9_2.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-audit@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=51c7234dc19b4615",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-audit",
+      "version": "3.0.7-103.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-audit:python3-audit:3.0.7-103.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-audit@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-audit:python3_audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_audit:python3-audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_audit:python3_audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_audit:3.0.7-103.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "103.el9" },
+        { "name": "syft:metadata:size", "value": "344725" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "audit-3.0.7-103.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-distro@1.5.0-7.el9?arch=noarch&upstream=python-distro-1.5.0-7.el9.src.rpm&distro=rhel-9.2&package-id=230e64ce4424957b",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-distro",
+      "version": "1.5.0-7.el9",
+      "licenses": [{ "license": { "name": "ASL 2.0" } }],
+      "cpe": "cpe:2.3:a:python3-distro:python3-distro:1.5.0-7.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-distro@1.5.0-7.el9?arch=noarch&upstream=python-distro-1.5.0-7.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-distro:python3_distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_distro:python3-distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_distro:python3_distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_distro:1.5.0-7.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "7.el9" },
+        { "name": "syft:metadata:size", "value": "156738" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-distro-1.5.0-7.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=2d27b078a00a28f4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-dnf",
+      "version": "4.14.0-5.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-dnf:python3-dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-dnf:python3_dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_dnf:python3-dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_dnf:python3_dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_dnf:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9_2" },
+        { "name": "syft:metadata:size", "value": "1922537" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dnf-4.14.0-5.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=442e446f7c8d512a",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-gpg",
+      "version": "1.15.1-6.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+ and GPLv3+" } }],
+      "cpe": "cpe:2.3:a:python3-gpg:python3-gpg:1.15.1-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-gpg:python3_gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_gpg:python3-gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_gpg:python3_gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_gpg:1.15.1-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "1404173" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "gpgme-1.15.1-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=753df2de3f0b9bdb",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-hawkey",
+      "version": "0.69.0-3.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-hawkey:python3-hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-hawkey:python3_hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_hawkey:python3-hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_hawkey:python3_hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_hawkey:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_2" },
+        { "name": "syft:metadata:size", "value": "308083" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libdnf-0.69.0-3.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch&upstream=python-inotify-0.9.6-25.el9.src.rpm&distro=rhel-9.2&package-id=a73e89e6df312ce8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-inotify",
+      "version": "0.9.6-25.el9",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:python3-inotify:python3-inotify:0.9.6-25.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch&upstream=python-inotify-0.9.6-25.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-inotify:python3_inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_inotify:python3-inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_inotify:python3_inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_inotify:0.9.6-25.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "25.el9" },
+        { "name": "syft:metadata:size", "value": "249451" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-inotify-0.9.6-25.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=34b7e3176802afa5",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-libcomps",
+      "version": "0.1.18-1.el9",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-libcomps:python3-libcomps:0.1.18-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-libcomps:python3_libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libcomps:python3-libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libcomps:python3_libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_libcomps:0.1.18-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "147138" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libcomps-0.1.18-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=de87145675f48e67",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-libdnf",
+      "version": "0.69.0-3.el9_2",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-libdnf:python3-libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-libdnf:python3_libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libdnf:python3-libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libdnf:python3_libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_libdnf:0.69.0-3.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "3.el9_2" },
+        { "name": "syft:metadata:size", "value": "3788871" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libdnf-0.69.0-3.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-libs",
+      "version": "3.9.16-1.el9_2.3",
+      "licenses": [{ "license": { "name": "Python" } }],
+      "cpe": "cpe:2.3:a:python3-libs:python3-libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-libs:python3_libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libs:python3-libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libs:python3_libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_libs:3.9.16-1.el9_2.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9_2.3" },
+        { "name": "syft:metadata:size", "value": "32460104" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python3.9-3.9.16-1.el9_2.3.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=552e776ab65d5746",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-libselinux",
+      "version": "3.5-1.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:python3-libselinux:python3-libselinux:3.5-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-libselinux:python3_libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libselinux:python3-libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_libselinux:python3_libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_libselinux:3.5-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "622519" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "libselinux-3.5-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-6.el9?arch=noarch&upstream=python-pip-21.2.3-6.el9.src.rpm&distro=rhel-9.2&package-id=e75577a1cdd414c2",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-pip-wheel",
+      "version": "21.2.3-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:python3-pip-wheel:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-6.el9?arch=noarch&upstream=python-pip-21.2.3-6.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip-wheel:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip_wheel:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip_wheel:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-pip:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_pip:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-pip-wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_pip_wheel:21.2.3-6.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9" },
+        { "name": "syft:metadata:size", "value": "1220550" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-pip-21.2.3-6.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8569ddc5cb2af7df",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-rpm",
+      "version": "4.16.1.3-24.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-rpm:python3-rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-rpm:python3_rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_rpm:python3-rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_rpm:python3_rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "24.el9_2" },
+        { "name": "syft:metadata:size", "value": "197638" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-24.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-setools@4.4.1-1.el9?arch=x86_64&upstream=setools-4.4.1-1.el9.src.rpm&distro=rhel-9.2&package-id=9bbd0e27c191ada5",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-setools",
+      "version": "4.4.1-1.el9",
+      "licenses": [{ "license": { "id": "LGPL-2.1-only" } }],
+      "cpe": "cpe:2.3:a:python3-setools:python3-setools:4.4.1-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-setools@4.4.1-1.el9?arch=x86_64&upstream=setools-4.4.1-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setools:python3_setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setools:python3-setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setools:python3_setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_setools:4.4.1-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "2339126" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "setools-4.4.1-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=b60cb9497a3cbba0",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-setuptools",
+      "version": "53.0.0-12.el9",
+      "licenses": [{ "license": { "name": "MIT and (BSD or ASL 2.0)" } }],
+      "cpe": "cpe:2.3:a:python3-setuptools:python3-setuptools:53.0.0-12.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools:python3_setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3-setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3_setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_setuptools:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "12.el9" },
+        { "name": "syft:metadata:size", "value": "4351727" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-setuptools-53.0.0-12.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=87b77f53b373f85f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-setuptools-wheel",
+      "version": "53.0.0-12.el9",
+      "licenses": [{ "license": { "name": "MIT and (BSD or ASL 2.0)" } }],
+      "cpe": "cpe:2.3:a:python3-setuptools-wheel:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools-wheel:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools_wheel:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools_wheel:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-setuptools:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_setuptools:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-setuptools-wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_setuptools_wheel:53.0.0-12.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "12.el9" },
+        { "name": "syft:metadata:size", "value": "562584" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-setuptools-53.0.0-12.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64&upstream=python-systemd-234-18.el9.src.rpm&distro=rhel-9.2&package-id=2e5eda42fc92a458",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "python3-systemd",
+      "version": "234-18.el9",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:python3-systemd:python3-systemd:234-18.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64&upstream=python-systemd-234-18.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3-systemd:python3_systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_systemd:python3-systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3_systemd:python3_systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3-systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python3:python3_systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3-systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:python3_systemd:234-18.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "18.el9" },
+        { "name": "syft:metadata:size", "value": "285236" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "python-systemd-234-18.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/react@18.3.1?package-id=6d97bd24683e368a",
+      "type": "library",
+      "name": "react",
+      "version": "18.3.1",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:facebook:react:18.3.1:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/react@18.3.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react.git",
+          "type": "distribution"
+        },
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/react/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/react-dom@18.3.1?package-id=ff5b487ce2833e92",
+      "type": "library",
+      "name": "react-dom",
+      "version": "18.3.1",
+      "description": "React package for working with the DOM.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:react-dom:react-dom:18.3.1:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/react-dom@18.3.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react.git",
+          "type": "distribution"
+        },
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react-dom:react_dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_dom:react-dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_dom:react_dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:react-dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:react_dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react-dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react_dom:18.3.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/react-dom/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/react-is@18.2.0?package-id=e3fe6ff8d3a98105",
+      "type": "library",
+      "name": "react-is",
+      "version": "18.2.0",
+      "description": "Brand checking of React Elements.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:facebook:react-is:18.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/react-is@18.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react.git",
+          "type": "distribution"
+        },
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:react_is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react-is:react-is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react-is:react_is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_is:react-is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_is:react_is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react-is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react_is:18.2.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/react-is/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/react-refresh@0.12.0?package-id=3ca040061f8940a9",
+      "type": "library",
+      "name": "react-refresh",
+      "version": "0.12.0",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:react-refresh:react-refresh:0.12.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/react-refresh@0.12.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react.git",
+          "type": "distribution"
+        },
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react-refresh:react_refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_refresh:react-refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react_refresh:react_refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:react-refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:react_refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react-refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:react:react_refresh:0.12.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/react-refresh/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "readline",
+      "version": "8.1-4.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:readline:readline:8.1-4.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:readline:8.1-4.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "4.el9" },
+        { "name": "syft:metadata:size", "value": "492844" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "readline-8.1-4.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.2-0.15.el9?arch=x86_64&upstream=redhat-release-9.2-0.15.el9.src.rpm&distro=rhel-9.2&package-id=7839d03e837b6f0f",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "redhat-release",
+      "version": "9.2-0.15.el9",
+      "licenses": [{ "license": { "name": "GPLv2" } }],
+      "cpe": "cpe:2.3:a:redhat-release:redhat-release:9.2-0.15.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/redhat-release@9.2-0.15.el9?arch=x86_64&upstream=redhat-release-9.2-0.15.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat-release:redhat_release:9.2-0.15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat_release:redhat-release:9.2-0.15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat_release:redhat_release:9.2-0.15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:redhat-release:9.2-0.15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:redhat_release:9.2-0.15.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "0.15.el9" },
+        { "name": "syft:metadata:size", "value": "57665" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "redhat-release-9.2-0.15.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/regenerator-runtime@0.13.4?package-id=bbe477767f99d7b1",
+      "type": "library",
+      "author": "Ben Newman <bn@cs.stanford.edu>",
+      "name": "regenerator-runtime",
+      "version": "0.13.4",
+      "description": "Runtime for Regenerator-compiled generator and async functions.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:regenerator-runtime:regenerator-runtime:0.13.4:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/regenerator-runtime@0.13.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime",
+          "type": "distribution"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:regenerator-runtime:regenerator_runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:regenerator_runtime:regenerator-runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:regenerator_runtime:regenerator_runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:regenerator:regenerator-runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:regenerator:regenerator_runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:regenerator-runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:regenerator_runtime:0.13.4:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/next/dist/compiled/regenerator-runtime/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch&upstream=rootfiles-8.1-31.el9.src.rpm&distro=rhel-9.2&package-id=0f360e57277273e5",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rootfiles",
+      "version": "8.1-31.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:rootfiles:rootfiles:8.1-31.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch&upstream=rootfiles-8.1-31.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rootfiles:8.1-31.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "31.el9" },
+        { "name": "syft:metadata:size", "value": "817" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rootfiles-8.1-31.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/rpm@4.16.1.3?package-id=6d03a3d2bb1d4be9",
+      "type": "library",
+      "author": "UNKNOWN <rpm-maint@lists.rpm.org>",
+      "name": "rpm",
+      "version": "4.16.1.3",
+      "licenses": [{ "license": { "name": "GNU General Public License v2" } }],
+      "cpe": "cpe:2.3:a:rpm_maint_project:python-rpm:4.16.1.3:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/rpm@4.16.1.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maint_project:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maintproject:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maintproject:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown_project:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown_project:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknownproject:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknownproject:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-rpm:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-rpm:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_rpm:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_rpm:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maint_project:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-maint:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-maint:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maint:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maint:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maintproject:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown_project:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknownproject:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-rpm:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_rpm:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:python-rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:python_rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-maint:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_maint:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:unknown:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm:4.16.1.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/rpm-4.16.1.3-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=256fa88c206e8d6d",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm",
+      "version": "4.16.1.3-24.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "24.el9_2" },
+        { "name": "syft:metadata:size", "value": "2749462" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-24.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=a9c68daac2f51021",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm-build-libs",
+      "version": "4.16.1.3-24.el9_2",
+      "licenses": [
+        { "license": { "name": "GPLv2+ and LGPLv2+ with exceptions" } }
+      ],
+      "cpe": "cpe:2.3:a:rpm-build-libs:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-build-libs:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_build_libs:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_build_libs:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-build:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-build:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_build:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_build:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm-build-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm_build_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "24.el9_2" },
+        { "name": "syft:metadata:size", "value": "198430" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-24.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm-libs",
+      "version": "4.16.1.3-24.el9_2",
+      "licenses": [
+        { "license": { "name": "GPLv2+ and LGPLv2+ with exceptions" } }
+      ],
+      "cpe": "cpe:2.3:a:rpm-libs:rpm-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-libs:rpm_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_libs:rpm-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_libs:rpm_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "24.el9_2" },
+        { "name": "syft:metadata:size", "value": "768980" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-24.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8b8a9ee924a0d178",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "rpm-sign-libs",
+      "version": "4.16.1.3-24.el9_2",
+      "licenses": [
+        { "license": { "name": "GPLv2+ and LGPLv2+ with exceptions" } }
+      ],
+      "cpe": "cpe:2.3:a:rpm-sign-libs:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-sign-libs:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_sign_libs:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_sign_libs:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-sign:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm-sign:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_sign:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm_sign:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm-sign-libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:rpm:rpm_sign_libs:4.16.1.3-24.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "24.el9_2" },
+        { "name": "syft:metadata:size", "value": "27636" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "rpm-4.16.1.3-24.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/scheduler@0.23.2?package-id=0493bbc631c075c5",
+      "type": "library",
+      "name": "scheduler",
+      "version": "0.23.2",
+      "description": "Cooperative scheduler for the browser environment.",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:scheduler:scheduler:0.23.2:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/scheduler@0.23.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react.git",
+          "type": "distribution"
+        },
+        { "url": "https://reactjs.org/", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:facebook:scheduler:0.23.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/scheduler/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "sed",
+      "version": "4.8-9.el9",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:sed:4.8-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sed:sed:4.8-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "9.el9" },
+        { "name": "syft:metadata:size", "value": "813599" },
+        { "name": "syft:metadata:sourceRpm", "value": "sed-4.8-9.el9.src.rpm" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/selinux@3.5?package-id=723df39f73443bfc",
+      "type": "library",
+      "author": "SELinux Project <selinux@vger.kernel.org>",
+      "name": "selinux",
+      "version": "3.5",
+      "licenses": [{ "license": { "name": "UNKNOWN" } }],
+      "cpe": "cpe:2.3:a:selinux_project:python-selinux:3.5:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/selinux@3.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinux_project:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-selinux:python-selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-selinux:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_selinux:python-selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_selinux:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinuxproject:python-selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinuxproject:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinux_project:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-selinux:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_selinux:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinux:python-selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinux:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinuxproject:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:selinux:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:selinux:3.5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/selinux-3.5-py3.9.egg-info/PKG-INFO"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib64/python3.9/site-packages/selinux-3.5-py3.9.egg-info/installed-files.txt"
+        },
+        {
+          "name": "syft:location:2:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:2:path",
+          "value": "/usr/lib64/python3.9/site-packages/selinux-3.5-py3.9.egg-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/setools@4.4.1?package-id=e1d38db33c6df42c",
+      "type": "library",
+      "author": "Chris PeBenito <pebenito@ieee.org>",
+      "name": "setools",
+      "version": "4.4.1",
+      "licenses": [{ "license": { "name": "GPLv2+, LGPLv2.1+" } }],
+      "cpe": "cpe:2.3:a:chris_pebenito_project:python-setools:4.4.1:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/setools@4.4.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenito_project:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenitoproject:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenitoproject:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito_project:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito_project:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenito_project:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenitoproject:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenitoproject:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenito:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenito:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenitoproject:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-setools:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-setools:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_setools:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_setools:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito_project:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenitoproject:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:chris_pebenito:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-setools:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_setools:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:setools:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:setools:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pebenito:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:setools:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:setools:4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/setools-4.4.1-py3.9.egg-info/PKG-INFO"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib64/python3.9/site-packages/setools-4.4.1-py3.9.egg-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-9.el9?arch=noarch&upstream=setup-2.13.7-9.el9.src.rpm&distro=rhel-9.2&package-id=2a2692846495e979",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "setup",
+      "version": "2.13.7-9.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:redhat:setup:2.13.7-9.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-9.el9?arch=noarch&upstream=setup-2.13.7-9.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:setup:setup:2.13.7-9.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "9.el9" },
+        { "name": "syft:metadata:size", "value": "725907" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "setup-2.13.7-9.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/setuptools@53.0.0?package-id=29bcbd7f4150a5f0",
+      "type": "library",
+      "author": "Python Packaging Authority <distutils-sig@python.org>",
+      "name": "setuptools",
+      "version": "53.0.0",
+      "licenses": [{ "license": { "name": "UNKNOWN" } }],
+      "cpe": "cpe:2.3:a:python:setuptools:53.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/setuptools@53.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/METADATA"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/RECORD"
+        },
+        {
+          "name": "syft:location:2:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:2:path",
+          "value": "/usr/lib/python3.9/site-packages/setuptools-53.0.0.dist-info/top_level.txt"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/source-map-js@1.0.2?package-id=189f2c627563cfeb",
+      "type": "library",
+      "author": "Valentin 7rulnik Semirulnik <v7rulnik@gmail.com>",
+      "name": "source-map-js",
+      "version": "1.0.2",
+      "description": "Generates and consumes source maps",
+      "licenses": [{ "license": { "id": "BSD-3-Clause" } }],
+      "cpe": "cpe:2.3:a:source-map-js:source-map-js:1.0.2:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/source-map-js@1.0.2",
+      "externalReferences": [
+        { "url": "https://github.com/7rulnik/source-map-js", "type": "website" }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source-map-js:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source_map_js:source-map-js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source_map_js:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source-map:source-map-js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source-map:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source_map:source-map-js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source_map:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:7rulnik:source-map-js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:7rulnik:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source:source-map-js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:source:source_map_js:1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/source-map-js/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "sqlite-libs",
+      "version": "3.34.1-6.el9_2.1",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:sqlite-libs:sqlite-libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite-libs:sqlite_libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite_libs:sqlite-libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite_libs:sqlite_libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:sqlite-libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:sqlite_libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite:sqlite-libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:sqlite:sqlite_libs:3.34.1-6.el9_2.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "6.el9_2.1" },
+        { "name": "syft:metadata:size", "value": "1310912" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "sqlite-3.34.1-6.el9_2.1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/streamsearch@1.1.0?package-id=6a32f7e0280dab43",
+      "type": "library",
+      "author": "Brian White <mscdex@mscdex.net>",
+      "name": "streamsearch",
+      "version": "1.1.0",
+      "description": "Streaming Boyer-Moore-Horspool searching for node.js",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:streamsearch:streamsearch:1.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/streamsearch@1.1.0",
+      "externalReferences": [
+        {
+          "url": "http://github.com/mscdex/streamsearch.git",
+          "type": "distribution"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mscdex:streamsearch:1.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/streamsearch/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/strimzi-ui@0.1.0?package-id=ccba5598499b537f",
+      "type": "library",
+      "name": "strimzi-ui",
+      "version": "0.1.0",
+      "cpe": "cpe:2.3:a:strimzi-ui:strimzi-ui:0.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/strimzi-ui@0.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:strimzi-ui:strimzi_ui:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:strimzi_ui:strimzi-ui:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:strimzi_ui:strimzi_ui:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:strimzi:strimzi-ui:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:strimzi:strimzi_ui:0.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        { "name": "syft:location:0:path", "value": "/app/package.json" }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/styled-jsx@5.1.1?package-id=71ef73d0e3710365",
+      "type": "library",
+      "name": "styled-jsx",
+      "version": "5.1.1",
+      "description": "Full CSS support for JSX without compromises",
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "cpe": "cpe:2.3:a:styled-jsx:styled-jsx:5.1.1:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/styled-jsx@5.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "javascript" },
+        { "name": "syft:package:type", "value": "npm" },
+        {
+          "name": "syft:package:metadataType",
+          "value": "javascript-npm-package"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:styled-jsx:styled_jsx:5.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:styled_jsx:styled-jsx:5.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:styled_jsx:styled_jsx:5.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:styled:styled-jsx:5.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:styled:styled_jsx:5.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/app/node_modules/styled-jsx/package.json"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=3b3637036cc97dde",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "systemd",
+      "version": "252-14.el9_2.7",
+      "licenses": [{ "license": { "name": "LGPLv2+ and MIT and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:systemd:systemd:252-14.el9_2.7:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "14.el9_2.7" },
+        { "name": "syft:metadata:size", "value": "12625812" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "systemd-252-14.el9_2.7.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "systemd-libs",
+      "version": "252-14.el9_2.7",
+      "licenses": [{ "license": { "name": "LGPLv2+ and MIT" } }],
+      "cpe": "cpe:2.3:a:systemd-libs:systemd-libs:252-14.el9_2.7:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-libs:systemd_libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_libs:systemd-libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_libs:systemd_libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd-libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd_libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd-libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd_libs:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "14.el9_2.7" },
+        { "name": "syft:metadata:size", "value": "1806488" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "systemd-252-14.el9_2.7.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=c417bdbd8387f2c3",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "systemd-pam",
+      "version": "252-14.el9_2.7",
+      "licenses": [{ "license": { "name": "LGPLv2+ and MIT and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:systemd-pam:systemd-pam:252-14.el9_2.7:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/systemd-pam@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-pam:systemd_pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_pam:systemd-pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_pam:systemd_pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd-pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd_pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd-pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd_pam:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "14.el9_2.7" },
+        { "name": "syft:metadata:size", "value": "518347" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "systemd-252-14.el9_2.7.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:pypi/systemd-python@234?package-id=3654b03cd443a6e1",
+      "type": "library",
+      "author": "systemd developers <systemd-devel@lists.freedesktop.org>",
+      "name": "systemd-python",
+      "version": "234",
+      "licenses": [{ "license": { "name": "LGPLv2+" } }],
+      "cpe": "cpe:2.3:a:systemd_developers_project:python-systemd-python:234:*:*:*:*:*:*:*",
+      "purl": "pkg:pypi/systemd-python@234",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-installed-package-cataloger"
+        },
+        { "name": "syft:package:language", "value": "python" },
+        { "name": "syft:package:type", "value": "python" },
+        { "name": "syft:package:metadataType", "value": "python-package" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers_project:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developersproject:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developersproject:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd-python:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd-python:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd_python:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd_python:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel_project:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel_project:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_develproject:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_develproject:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers_project:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers_project:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developersproject:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developersproject:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd-python:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd-python:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd_python:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd_python:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-python:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-python:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel_project:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel_project:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_python:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_python:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-devel:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-devel:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_develproject:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_develproject:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_developers:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python-systemd:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python_systemd:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-python:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-python:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_python:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_python:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python-systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:python_systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-devel:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-devel:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_devel:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:systemd-python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:python:systemd_python:234:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:794f33d520fbb3c26be4dee50088641eb58cff1a8b4f5e67d45000e94bcfb571"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/lib64/python3.9/site-packages/systemd_python-234-py3.9.egg-info"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/systemd-rpm-macros@252-14.el9_2.7?arch=noarch&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=7b6d9c9616e1e034",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "systemd-rpm-macros",
+      "version": "252-14.el9_2.7",
+      "licenses": [{ "license": { "name": "LGPLv2+ and MIT and GPLv2+" } }],
+      "cpe": "cpe:2.3:a:systemd-rpm-macros:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/systemd-rpm-macros@252-14.el9_2.7?arch=noarch&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-rpm-macros:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_rpm_macros:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_rpm_macros:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-rpm:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd-rpm:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_rpm:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd_rpm:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:systemd:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd-rpm-macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:systemd_rpm_macros:252-14.el9_2.7:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "14.el9_2.7" },
+        { "name": "syft:metadata:size", "value": "9516" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "systemd-252-14.el9_2.7.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tar@1.34-6.el9_1?arch=x86_64&epoch=2&upstream=tar-1.34-6.el9_1.src.rpm&distro=rhel-9.2&package-id=08d613c9a541ecf8",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tar",
+      "version": "2:1.34-6.el9_1",
+      "licenses": [{ "license": { "name": "GPLv3+" } }],
+      "cpe": "cpe:2.3:a:redhat:tar:2\\:1.34-6.el9_1:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tar@1.34-6.el9_1?arch=x86_64&epoch=2&upstream=tar-1.34-6.el9_1.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tar:tar:2\\:1.34-6.el9_1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:epoch", "value": "2" },
+        { "name": "syft:metadata:release", "value": "6.el9_1" },
+        { "name": "syft:metadata:size", "value": "3155243" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tar-1.34-6.el9_1.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@3.0.3-8.el9?arch=x86_64&upstream=tpm2-tss-3.0.3-8.el9.src.rpm&distro=rhel-9.2&package-id=68aa97edcbee79cc",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tpm2-tss",
+      "version": "3.0.3-8.el9",
+      "licenses": [{ "license": { "name": "BSD and TCGL" } }],
+      "cpe": "cpe:2.3:a:tpm2-tss:tpm2-tss:3.0.3-8.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tpm2-tss@3.0.3-8.el9?arch=x86_64&upstream=tpm2-tss-3.0.3-8.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tpm2-tss:tpm2_tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tpm2_tss:tpm2-tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tpm2_tss:tpm2_tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:tpm2-tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:tpm2_tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tpm2:tpm2-tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tpm2:tpm2_tss:3.0.3-8.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9" },
+        { "name": "syft:metadata:size", "value": "2132541" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tpm2-tss-3.0.3-8.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.2&package-id=b79c939fefdd4936",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "tzdata",
+      "version": "2024a-1.el9",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:redhat:tzdata:2024a-1.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:tzdata:tzdata:2024a-1.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "1.el9" },
+        { "name": "syft:metadata:size", "value": "1707934" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "tzdata-2024a-1.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=4291cd238eba0959",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "util-linux",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:util-linux:util-linux:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/util-linux@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util-linux:util_linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux:util-linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux:util_linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:util-linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:util_linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util:util-linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util:util_linux:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "11138527" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/util-linux-core@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=e023b19d22c8f074",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "util-linux-core",
+      "version": "2.37.4-11.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:util-linux-core:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/util-linux-core@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util-linux-core:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux_core:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux_core:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util-linux:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util-linux:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util_linux:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util:util-linux-core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:util:util_linux_core:2.37.4-11.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "11.el9_2" },
+        { "name": "syft:metadata:size", "value": "1262775" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "util-linux-2.37.4-11.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "xz-libs",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [{ "license": { "name": "Public Domain" } }],
+      "cpe": "cpe:2.3:a:xz-libs:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz-libs:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz_libs:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz_libs:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:redhat:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz:xz-libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:xz:xz_libs:5.2.5-8.el9_0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "8.el9_0" },
+        { "name": "syft:metadata:size", "value": "181573" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "xz-5.2.5-8.el9_0.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/yum@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=588893d87823c394",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "yum",
+      "version": "4.14.0-5.el9_2",
+      "licenses": [{ "license": { "name": "GPLv2+" } }],
+      "cpe": "cpe:2.3:a:redhat:yum:4.14.0-5.el9_2:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/yum@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum:yum:4.14.0-5.el9_2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "5.el9_2" },
+        { "name": "syft:metadata:size", "value": "77898" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "dnf-4.14.0-5.el9_2.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904",
+      "type": "library",
+      "publisher": "Red Hat, Inc.",
+      "name": "zlib",
+      "version": "1.2.11-39.el9",
+      "licenses": [{ "license": { "name": "zlib and Boost" } }],
+      "cpe": "cpe:2.3:a:redhat:zlib:1.2.11-39.el9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2",
+      "properties": [
+        { "name": "syft:package:foundBy", "value": "rpm-db-cataloger" },
+        { "name": "syft:package:type", "value": "rpm" },
+        { "name": "syft:package:metadataType", "value": "rpm-db-entry" },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:zlib:zlib:1.2.11-39.el9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:a43c117701dd6d012bb9da8974d2d332f70a688944ed19280a020d5357f8b22e"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        },
+        { "name": "syft:metadata:release", "value": "39.el9" },
+        { "name": "syft:metadata:size", "value": "202921" },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "zlib-1.2.11-39.el9.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "os:rhel@9.2",
+      "type": "operating-system",
+      "name": "rhel",
+      "version": "9.2",
+      "description": "Red Hat Enterprise Linux 9.2 (Plow)",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:9:*:baseos:*:*:*:*:*",
+      "swid": { "tagId": "rhel", "name": "rhel", "version": "9.2" },
+      "externalReferences": [
+        { "url": "https://issues.redhat.com/", "type": "issue-tracker" },
+        { "url": "https://www.redhat.com/", "type": "website" }
+      ],
+      "properties": [
+        { "name": "syft:distro:id", "value": "rhel" },
+        { "name": "syft:distro:idLike:0", "value": "fedora" },
+        {
+          "name": "syft:distro:prettyName",
+          "value": "Red Hat Enterprise Linux 9.2 (Plow)"
+        },
+        { "name": "syft:distro:versionID", "value": "9.2" }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.20-2.el9?arch=x86_64&upstream=chkconfig-1.20-2.el9.src.rpm&distro=rhel-9.2&package-id=9981079612400e1b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.2&package-id=506fd4db392edafc",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2&package-id=35a7e322b4354dc8",
+        "pkg:rpm/redhat/setup@2.13.7-9.el9?arch=noarch&upstream=setup-2.13.7-9.el9.src.rpm&distro=rhel-9.2&package-id=2a2692846495e979"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2&package-id=35a7e322b4354dc8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2&package-id=2839d56c3630d08c",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+        "pkg:rpm/redhat/p11-kit-trust@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3ffd26011612a996",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/checkpolicy@3.5-1.el9?arch=x86_64&upstream=checkpolicy-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=d23d45a6fad2694f",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.2&package-id=2fd2059567f2231b",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=9d045aaf1b7a68e2",
+      "dependsOn": [
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=20ce8cc4474b8475"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=20ce8cc4474b8475",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&upstream=gzip-1.12-1.el9.src.rpm&distro=rhel-9.2&package-id=a93b2dc3947152c6",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=9d0c2200e8dd58c7",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=243b0f56bbb981ae"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm&distro=rhel-9.2&package-id=bdaaa55e55ff53d0",
+      "dependsOn": [
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1&upstream=gdbm-1.19-4.el9.src.rpm&distro=rhel-9.2&package-id=761b354e4a426906",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/krb5-libs@1.20.1-9.el9_2?arch=x86_64&upstream=krb5-1.20.1-9.el9_2.src.rpm&distro=rhel-9.2&package-id=398c0cd24306adb7",
+        "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2&package-id=1ff14ad1a12c7915",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64&upstream=dbus-broker-28-7.el9.src.rpm&distro=rhel-9.2&package-id=9d5ceb40acd1a308",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/dbus-common@1.12.20-7.el9_2.1?arch=noarch&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=33187b42a382a679",
+        "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2&package-id=76aa586e0d991726",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3",
+        "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=3b3637036cc97dde"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.20-7.el9_2.1?arch=noarch&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=33187b42a382a679",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=3b3637036cc97dde"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=f7be1f9847973ac6",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=55a4fbd380f817ef",
+      "dependsOn": [
+        "pkg:rpm/redhat/dbus-broker@28-7.el9?arch=x86_64&upstream=dbus-broker-28-7.el9.src.rpm&distro=rhel-9.2&package-id=9d5ceb40acd1a308"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&upstream=dejavu-fonts-2.37-18.el9.src.rpm&distro=rhel-9.2&package-id=b7168bc61a4fdefc",
+      "dependsOn": [
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1&upstream=fonts-rpm-macros-2.0.5-7.el9.1.src.rpm&distro=rhel-9.2&package-id=6cc72f92d4966749"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/diffutils@3.7-12.el9?arch=x86_64&upstream=diffutils-3.7-12.el9.src.rpm&distro=rhel-9.2&package-id=174e9478576d794b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=f88cd17b6d8b189c",
+      "dependsOn": [
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch&upstream=libreport-2.15.2-6.el9.src.rpm&distro=rhel-9.2&package-id=76ca11928aa4c888"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=5bcc52fe6dc4603d",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/python3-dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=2d27b078a00a28f4"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.188-3.el9?arch=noarch&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=f5df68fdd9282c61",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=c92de458b11b567b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=e5d44aae1a49bed2",
+      "dependsOn": [
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.188-3.el9?arch=noarch&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=f5df68fdd9282c61",
+        "pkg:rpm/redhat/elfutils-libelf@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=c92de458b11b567b",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2&package-id=76aa586e0d991726",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-12.1.el9_2?arch=x86_64&upstream=file-5.39-12.1.el9_2.src.rpm&distro=rhel-9.2&package-id=0dfb75c17a8b9423",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2&package-id=35a7e322b4354dc8",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/setup@2.13.7-9.el9?arch=noarch&upstream=setup-2.13.7-9.el9.src.rpm&distro=rhel-9.2&package-id=2a2692846495e979"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.8.0-5.el9?arch=x86_64&epoch=1&upstream=findutils-4.8.0-5.el9.src.rpm&distro=rhel-9.2&package-id=701b5ca77859ef74",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&upstream=gawk-5.1.0-6.el9.src.rpm&distro=rhel-9.2&package-id=158cf9fdab4d74de",
+      "dependsOn": [
+        "pkg:rpm/redhat/filesystem@3.16-2.el9?arch=x86_64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.2&package-id=35a7e322b4354dc8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gmp@6.2.0-10.el9?arch=x86_64&epoch=1&upstream=gmp-6.2.0-10.el9.src.rpm&distro=rhel-9.2&package-id=2bb3b9c7adaedb4e",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&upstream=libsigsegv-2.13-4.el9.src.rpm&distro=rhel-9.2&package-id=55d832f38e00eddb",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&upstream=mpfr-4.1.0-7.el9.src.rpm&distro=rhel-9.2&package-id=26dc53ca059b363f",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1&upstream=gdbm-1.19-4.el9.src.rpm&distro=rhel-9.2&package-id=761b354e4a426906",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64&upstream=gnutls-3.7.6-21.el9_2.3.src.rpm&distro=rhel-9.2&package-id=7456ad8810579504",
+        "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9",
+        "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64&upstream=pcre-8.44-3.el9.3.src.rpm&distro=rhel-9.2&package-id=ac753aaf3bdfda91",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.2&package-id=b79c939fefdd4936"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=60576fe64fdd7d93",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+      "dependsOn": [
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.2&package-id=506fd4db392edafc",
+        "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=60576fe64fdd7d93",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-10.el9?arch=x86_64&epoch=1&upstream=gmp-6.2.0-10.el9.src.rpm&distro=rhel-9.2&package-id=2bb3b9c7adaedb4e",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-2.el9_0?arch=x86_64&upstream=gnupg2-2.3.3-2.el9_0.src.rpm&distro=rhel-9.2&package-id=c7a5ba8dd5b92d5b",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64&upstream=gnutls-3.7.6-21.el9_2.3.src.rpm&distro=rhel-9.2&package-id=7456ad8810579504",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&upstream=libassuan-2.5.5-3.el9.src.rpm&distro=rhel-9.2&package-id=f0df71d33cd93a26",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2&package-id=ed04899fcadf0517",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa",
+        "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64&upstream=libksba-1.5.1-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8f27b66dbe5dfaa7",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&upstream=npth-1.6-8.el9.src.rpm&distro=rhel-9.2&package-id=46359f7db0dbddc2",
+        "pkg:rpm/redhat/openldap-compat@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=1898caf1d50db008",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64&upstream=gnutls-3.7.6-21.el9_2.3.src.rpm&distro=rhel-9.2&package-id=7456ad8810579504",
+      "dependsOn": [
+        "pkg:rpm/redhat/crypto-policies@20221215-1.git9a18988.el9_2.2?arch=noarch&upstream=crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm&distro=rhel-9.2&package-id=c68b022d888d3ed0",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&upstream=libidn2-2.3.0-7.el9.src.rpm&distro=rhel-9.2&package-id=5538fdcbd2d5be39",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64&upstream=libtasn1-4.16.0-8.el9_1.src.rpm&distro=rhel-9.2&package-id=ad76cf127fb16e5d",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&upstream=libunistring-0.9.10-15.el9.src.rpm&distro=rhel-9.2&package-id=fe0e5f68a52de6f9",
+        "pkg:rpm/redhat/nettle@3.8-3.el9_0?arch=x86_64&upstream=nettle-3.8-3.el9_0.src.rpm&distro=rhel-9.2&package-id=ecb0776f85b54e0c",
+        "pkg:rpm/redhat/p11-kit-trust@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3ffd26011612a996",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64&upstream=gobject-introspection-1.68.0-11.el9.src.rpm&distro=rhel-9.2&package-id=d6335e1922cdb5fb",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=d155d9e484ba0ca5",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gnupg2@2.3.3-2.el9_0?arch=x86_64&upstream=gnupg2-2.3.3-2.el9_0.src.rpm&distro=rhel-9.2&package-id=c7a5ba8dd5b92d5b",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&upstream=libassuan-2.5.5-3.el9.src.rpm&distro=rhel-9.2&package-id=f0df71d33cd93a26",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&upstream=libsigsegv-2.13-4.el9.src.rpm&distro=rhel-9.2&package-id=55d832f38e00eddb",
+        "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64&upstream=pcre-8.44-3.el9.3.src.rpm&distro=rhel-9.2&package-id=ac753aaf3bdfda91"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&upstream=gzip-1.12-1.el9.src.rpm&distro=rhel-9.2&package-id=a93b2dc3947152c6",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64&upstream=ima-evm-utils-1.4-4.el9.src.rpm&distro=rhel-9.2&package-id=204a975cb2bc3ba7",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&upstream=keyutils-1.6.3-1.el9.src.rpm&distro=rhel-9.2&package-id=55d5e42253b50ced",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/tpm2-tss@3.0.3-8.el9?arch=x86_64&upstream=tpm2-tss-3.0.3-8.el9.src.rpm&distro=rhel-9.2&package-id=68aa97edcbee79cc"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2&package-id=81e63cdc65a50d3b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&upstream=json-glib-1.6.6-1.el9.src.rpm&distro=rhel-9.2&package-id=d6f65de78a805960",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&upstream=keyutils-1.6.3-1.el9.src.rpm&distro=rhel-9.2&package-id=55d5e42253b50ced",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@28-7.el9?arch=x86_64&upstream=kmod-28-7.el9.src.rpm&distro=rhel-9.2&package-id=1f7352a741116df2",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.20.1-9.el9_2?arch=x86_64&upstream=krb5-1.20.1-9.el9_2.src.rpm&distro=rhel-9.2&package-id=398c0cd24306adb7",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/crypto-policies@20221215-1.git9a18988.el9_2.2?arch=noarch&upstream=crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm&distro=rhel-9.2&package-id=c68b022d888d3ed0",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64&upstream=gawk-5.1.0-6.el9.src.rpm&distro=rhel-9.2&package-id=158cf9fdab4d74de",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64&upstream=keyutils-1.6.3-1.el9.src.rpm&distro=rhel-9.2&package-id=55d5e42253b50ced",
+        "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2&package-id=1ff14ad1a12c7915",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&upstream=libverto-0.3.2-3.el9.src.rpm&distro=rhel-9.2&package-id=33d489156bb86e75",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=96b4e155ff62096d",
+      "dependsOn": [
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=75c54bdb853ef6d4"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=75c54bdb853ef6d4",
+      "dependsOn": [
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch&upstream=dejavu-fonts-2.37-18.el9.src.rpm&distro=rhel-9.2&package-id=b7168bc61a4fdefc"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=7974177c6a4996ee",
+      "dependsOn": [
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch&upstream=langpacks-3.0-16.el9.src.rpm&distro=rhel-9.2&package-id=96b4e155ff62096d"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.2&package-id=2fd2059567f2231b"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&upstream=libarchive-3.5.3-4.el9.src.rpm&distro=rhel-9.2&package-id=6f9da8010675d944",
+      "dependsOn": [
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2&package-id=dd051804a3459d67",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64&upstream=libassuan-2.5.5-3.el9.src.rpm&distro=rhel-9.2&package-id=f0df71d33cd93a26",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.2&package-id=2fd2059567f2231b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libbrotli@1.0.9-6.el9?arch=x86_64&upstream=brotli-1.0.9-6.el9.src.rpm&distro=rhel-9.2&package-id=177a2891ec722e0b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2&package-id=1ff14ad1a12c7915",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=99995d522accc3c7",
+      "dependsOn": [
+        "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2&package-id=76aa586e0d991726",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=243b0f56bbb981ae",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/krb5-libs@1.20.1-9.el9_2?arch=x86_64&upstream=krb5-1.20.1-9.el9_2.src.rpm&distro=rhel-9.2&package-id=398c0cd24306adb7",
+        "pkg:rpm/redhat/libcom_err@1.46.5-3.el9?arch=x86_64&upstream=e2fsprogs-1.46.5-3.el9.src.rpm&distro=rhel-9.2&package-id=1ff14ad1a12c7915",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_2.3?arch=x86_64&upstream=nghttp2-1.43.0-5.el9_2.3.src.rpm&distro=rhel-9.2&package-id=2d02863c05340cb8",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64&upstream=libdb-5.3.28-53.el9.src.rpm&distro=rhel-9.2&package-id=09c977c89771d7c1",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf-plugin-subscription-manager@1.29.33.2-1.el9_2?arch=x86_64&upstream=subscription-manager-1.29.33.2-1.el9_2.src.rpm&distro=rhel-9.2&package-id=cd248da7479f7eb4",
+      "dependsOn": [
+        "pkg:rpm/redhat/dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=5bcc52fe6dc4603d",
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2&package-id=81e63cdc65a50d3b",
+        "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=d92cdf960df2c439",
+        "pkg:rpm/redhat/librepo@1.14.5-1.el9?arch=x86_64&upstream=librepo-1.14.5-1.el9.src.rpm&distro=rhel-9.2&package-id=9bd242e89378de6f",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=d92cdf960df2c439",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=d155d9e484ba0ca5",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2&package-id=81e63cdc65a50d3b",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&upstream=libmodulemd-2.13.0-2.el9.src.rpm&distro=rhel-9.2&package-id=c27d441a1b67e693",
+        "pkg:rpm/redhat/librepo@1.14.5-1.el9?arch=x86_64&upstream=librepo-1.14.5-1.el9.src.rpm&distro=rhel-9.2&package-id=9bd242e89378de6f",
+        "pkg:rpm/redhat/librhsm@0.0.3-7.el9_2.1?arch=x86_64&upstream=librhsm-0.0.3-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=f23c4c779ba8c868",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+        "pkg:rpm/redhat/libsolv@0.7.22-4.el9?arch=x86_64&upstream=libsolv-0.7.22-4.el9.src.rpm&distro=rhel-9.2&package-id=2252faccfd162833",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64&upstream=libeconf-0.4.1-3.el9_2.src.rpm&distro=rhel-9.2&package-id=abf889c0a22c1531",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-6.el9?arch=x86_64&upstream=libevent-2.1.12-6.el9.src.rpm&distro=rhel-9.2&package-id=61d83bbd48df5fd1",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d32517146bdc430b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2&package-id=ed04899fcadf0517",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=01b95332dae49aeb",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64&upstream=libidn2-2.3.0-7.el9.src.rpm&distro=rhel-9.2&package-id=5538fdcbd2d5be39",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&upstream=libunistring-0.9.10-15.el9.src.rpm&distro=rhel-9.2&package-id=fe0e5f68a52de6f9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-6.el9_1?arch=x86_64&upstream=libksba-1.5.1-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8f27b66dbe5dfaa7",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64&upstream=libgpg-error-1.42-5.el9.src.rpm&distro=rhel-9.2&package-id=1dbf898c898509fa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&upstream=libmodulemd-2.13.0-2.el9.src.rpm&distro=rhel-9.2&package-id=c27d441a1b67e693",
+      "dependsOn": [
+        "pkg:rpm/redhat/file-libs@5.39-12.1.el9_2?arch=x86_64&upstream=file-5.39-12.1.el9_2.src.rpm&distro=rhel-9.2&package-id=0dfb75c17a8b9423",
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&upstream=libyaml-0.2.5-7.el9.src.rpm&distro=rhel-9.2&package-id=25b9b440948266fc",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-5.el9_2.3?arch=x86_64&upstream=nghttp2-1.43.0-5.el9_2.3.src.rpm&distro=rhel-9.2&package-id=2d02863c05340cb8",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64&upstream=libpwquality-1.4.4-8.el9.src.rpm&distro=rhel-9.2&package-id=1e6317a9d151dc2f",
+      "dependsOn": [
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=9d045aaf1b7a68e2",
+        "pkg:rpm/redhat/cracklib@2.9.6-27.el9?arch=x86_64&upstream=cracklib-2.9.6-27.el9.src.rpm&distro=rhel-9.2&package-id=20ce8cc4474b8475",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-1.el9?arch=x86_64&upstream=librepo-1.14.5-1.el9.src.rpm&distro=rhel-9.2&package-id=9bd242e89378de6f",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=d155d9e484ba0ca5",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=243b0f56bbb981ae",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-7.el9_2.1?arch=x86_64&upstream=librhsm-0.0.3-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=f23c4c779ba8c868",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64&upstream=json-glib-1.6.6-1.el9.src.rpm&distro=rhel-9.2&package-id=d6f65de78a805960",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64&upstream=libseccomp-2.5.2-2.el9.src.rpm&distro=rhel-9.2&package-id=81895d3b4f482c4d",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux-utils@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=e9cfd28f3867e3df",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=93156165b4634897",
+        "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=fc9e00d771d383c9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=93156165b4634897",
+        "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=fc9e00d771d383c9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=93156165b4634897",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64&upstream=libsigsegv-2.13-4.el9.src.rpm&distro=rhel-9.2&package-id=55d832f38e00eddb",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.22-4.el9?arch=x86_64&upstream=libsolv-0.7.22-4.el9.src.rpm&distro=rhel-9.2&package-id=2252faccfd162833",
+      "dependsOn": [
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64&upstream=libtasn1-4.16.0-8.el9_1.src.rpm&distro=rhel-9.2&package-id=ad76cf127fb16e5d",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64&upstream=libunistring-0.9.10-15.el9.src.rpm&distro=rhel-9.2&package-id=fe0e5f68a52de6f9",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64&upstream=libutempter-1.2.1-6.el9.src.rpm&distro=rhel-9.2&package-id=3270a0bcb4c23861",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64&upstream=libverto-0.3.2-3.el9.src.rpm&distro=rhel-9.2&package-id=33d489156bb86e75",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-3.el9_2.3?arch=x86_64&upstream=libxml2-2.9.13-3.el9_2.3.src.rpm&distro=rhel-9.2&package-id=12a4552096aaa1fa",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64&upstream=libyaml-0.2.5-7.el9.src.rpm&distro=rhel-9.2&package-id=25b9b440948266fc",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2&package-id=4f09d2c77d830d9a",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2&package-id=dd051804a3459d67",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64&upstream=mpfr-4.1.0-7.el9.src.rpm&distro=rhel-9.2&package-id=26dc53ca059b363f",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gmp@6.2.0-10.el9?arch=x86_64&epoch=1&upstream=gmp-6.2.0-10.el9.src.rpm&distro=rhel-9.2&package-id=2bb3b9c7adaedb4e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/ncurses-base@6.2-8.20210508.el9_2.1?arch=noarch&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=b36d437382f5105d"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.8-3.el9_0?arch=x86_64&upstream=nettle-3.8-3.el9_0.src.rpm&distro=rhel-9.2&package-id=ecb0776f85b54e0c",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/nodejs@18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652?arch=x86_64&epoch=1&upstream=nodejs-18.20.2-2.module%2Bel9.2.0%2B21812%2Bf1e61652.src.rpm&distro=rhel-9.2&package-id=ff5fbbdc32e7a1e8",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2&package-id=2839d56c3630d08c",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libbrotli@1.0.9-6.el9?arch=x86_64&upstream=brotli-1.0.9-6.el9.src.rpm&distro=rhel-9.2&package-id=177a2891ec722e0b",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=262062d1052d7ee2",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64&upstream=npth-1.6-8.el9.src.rpm&distro=rhel-9.2&package-id=46359f7db0dbddc2",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap-compat@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=1898caf1d50db008",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/openldap@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=ad9157938b3d14aa"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.2-3.el9?arch=x86_64&upstream=openldap-2.6.2-3.el9.src.rpm&distro=rhel-9.2&package-id=ad9157938b3d14aa",
+      "dependsOn": [
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64&upstream=cyrus-sasl-2.1.27-21.el9.src.rpm&distro=rhel-9.2&package-id=bdaaa55e55ff53d0",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libevent@2.1.12-6.el9?arch=x86_64&upstream=libevent-2.1.12-6.el9.src.rpm&distro=rhel-9.2&package-id=61d83bbd48df5fd1",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+      "dependsOn": [
+        "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2&package-id=2839d56c3630d08c",
+        "pkg:rpm/redhat/crypto-policies@20221215-1.git9a18988.el9_2.2?arch=noarch&upstream=crypto-policies-20221215-1.git9a18988.el9_2.2.src.rpm&distro=rhel-9.2&package-id=c68b022d888d3ed0",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=262062d1052d7ee2",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3ffd26011612a996",
+      "dependsOn": [
+        "pkg:rpm/redhat/alternatives@1.20-2.el9?arch=x86_64&upstream=chkconfig-1.20-2.el9.src.rpm&distro=rhel-9.2&package-id=9981079612400e1b",
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64&upstream=libtasn1-4.16.0-8.el9_1.src.rpm&distro=rhel-9.2&package-id=ad76cf127fb16e5d",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libdb@5.3.28-53.el9?arch=x86_64&upstream=libdb-5.3.28-53.el9.src.rpm&distro=rhel-9.2&package-id=09c977c89771d7c1",
+        "pkg:rpm/redhat/libeconf@0.4.1-3.el9_2?arch=x86_64&upstream=libeconf-0.4.1-3.el9_2.src.rpm&distro=rhel-9.2&package-id=abf889c0a22c1531",
+        "pkg:rpm/redhat/libpwquality@1.4.4-8.el9?arch=x86_64&upstream=libpwquality-1.4.4-8.el9.src.rpm&distro=rhel-9.2&package-id=1e6317a9d151dc2f",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=262062d1052d7ee2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=fc9e00d771d383c9",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-2.el9?arch=noarch&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=8bcc42a0539615f4"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-3.el9.3?arch=x86_64&upstream=pcre-8.44-3.el9.3.src.rpm&distro=rhel-9.2&package-id=ac753aaf3bdfda91",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-audit@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=51c7234dc19b4615",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-distro@1.5.0-7.el9?arch=noarch&upstream=python-distro-1.5.0-7.el9.src.rpm&distro=rhel-9.2&package-id=230e64ce4424957b",
+      "dependsOn": [
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=b60cb9497a3cbba0",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=2d27b078a00a28f4",
+      "dependsOn": [
+        "pkg:rpm/redhat/dnf-data@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=f88cd17b6d8b189c",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64&upstream=libmodulemd-2.13.0-2.el9.src.rpm&distro=rhel-9.2&package-id=c27d441a1b67e693",
+        "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=442e446f7c8d512a",
+        "pkg:rpm/redhat/python3-hawkey@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=753df2de3f0b9bdb",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=34b7e3176802afa5",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=de87145675f48e67",
+        "pkg:rpm/redhat/python3-rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8569ddc5cb2af7df",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=442e446f7c8d512a",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64&upstream=gpgme-1.15.1-6.el9.src.rpm&distro=rhel-9.2&package-id=d155d9e484ba0ca5",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=753df2de3f0b9bdb",
+      "dependsOn": [
+        "pkg:rpm/redhat/glib2@2.68.4-6.el9?arch=x86_64&upstream=glib2-2.68.4-6.el9.src.rpm&distro=rhel-9.2&package-id=ae0e701781b299aa",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=d92cdf960df2c439",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libsolv@0.7.22-4.el9?arch=x86_64&upstream=libsolv-0.7.22-4.el9.src.rpm&distro=rhel-9.2&package-id=2252faccfd162833",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+        "pkg:rpm/redhat/python3-libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=de87145675f48e67",
+        "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-25.el9?arch=noarch&upstream=python-inotify-0.9.6-25.el9.src.rpm&distro=rhel-9.2&package-id=a73e89e6df312ce8",
+      "dependsOn": [
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=b60cb9497a3cbba0",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=34b7e3176802afa5",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el9?arch=x86_64&upstream=libcomps-0.1.18-1.el9.src.rpm&distro=rhel-9.2&package-id=99995d522accc3c7",
+        "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=de87145675f48e67",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libdnf@0.69.0-3.el9_2?arch=x86_64&upstream=libdnf-0.69.0-3.el9_2.src.rpm&distro=rhel-9.2&package-id=d92cdf960df2c439",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=c161eb30a501957b",
+        "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/expat@2.5.0-1.el9_2.1?arch=x86_64&upstream=expat-2.5.0-1.el9_2.1.src.rpm&distro=rhel-9.2&package-id=76aa586e0d991726",
+        "pkg:rpm/redhat/gdbm-libs@1.19-4.el9?arch=x86_64&epoch=1&upstream=gdbm-1.19-4.el9.src.rpm&distro=rhel-9.2&package-id=761b354e4a426906",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libffi@3.4.2-7.el9?arch=x86_64&upstream=libffi-3.4.2-7.el9.src.rpm&distro=rhel-9.2&package-id=f02d9ed92f5474c9",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/python3-pip-wheel@21.2.3-6.el9?arch=noarch&upstream=python-pip-21.2.3-6.el9.src.rpm&distro=rhel-9.2&package-id=e75577a1cdd414c2",
+        "pkg:rpm/redhat/python3-setuptools-wheel@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=87b77f53b373f85f",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+        "pkg:rpm/redhat/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.2&package-id=b79c939fefdd4936",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=552e776ab65d5746",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@21.2.3-6.el9?arch=noarch&upstream=python-pip-21.2.3-6.el9.src.rpm&distro=rhel-9.2&package-id=e75577a1cdd414c2",
+      "dependsOn": [
+        "pkg:rpm/redhat/ca-certificates@2023.2.60_v7.0.306-90.1.el9_2?arch=noarch&upstream=ca-certificates-2023.2.60_v7.0.306-90.1.el9_2.src.rpm&distro=rhel-9.2&package-id=2839d56c3630d08c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8569ddc5cb2af7df",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c",
+        "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=a9c68daac2f51021",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+        "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8b8a9ee924a0d178"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setools@4.4.1-1.el9?arch=x86_64&upstream=setools-4.4.1-1.el9.src.rpm&distro=rhel-9.2&package-id=9bbd0e27c191ada5",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libsepol@3.5-1.el9?arch=x86_64&upstream=libsepol-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=93156165b4634897",
+        "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=b60cb9497a3cbba0",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools@53.0.0-12.el9?arch=noarch&upstream=python-setuptools-53.0.0-12.el9.src.rpm&distro=rhel-9.2&package-id=b60cb9497a3cbba0",
+      "dependsOn": [
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-18.el9?arch=x86_64&upstream=python-systemd-234-18.el9.src.rpm&distro=rhel-9.2&package-id=2e5eda42fc92a458",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=f4f3c553d312f74c",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/python3-libs@3.9.16-1.el9_2.3?arch=x86_64&upstream=python3.9-3.9.16-1.el9_2.3.src.rpm&distro=rhel-9.2&package-id=edfe20b65dc0add4"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch&upstream=rootfiles-8.1-31.el9.src.rpm&distro=rhel-9.2&package-id=0f360e57277273e5",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=a9c68daac2f51021",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/elfutils-libelf@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=c92de458b11b567b",
+        "pkg:rpm/redhat/elfutils-libs@0.188-3.el9?arch=x86_64&upstream=elfutils-0.188-3.el9.src.rpm&distro=rhel-9.2&package-id=e5d44aae1a49bed2",
+        "pkg:rpm/redhat/file-libs@5.39-12.1.el9_2?arch=x86_64&upstream=file-5.39-12.1.el9_2.src.rpm&distro=rhel-9.2&package-id=0dfb75c17a8b9423",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libgomp@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=01b95332dae49aeb",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2&package-id=4f09d2c77d830d9a",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2&package-id=4f09d2c77d830d9a",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+        "pkg:rpm/redhat/rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=256fa88c206e8d6d",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-sign-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=8b8a9ee924a0d178",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/gnupg2@2.3.3-2.el9_0?arch=x86_64&upstream=gnupg2-2.3.3-2.el9_0.src.rpm&distro=rhel-9.2&package-id=c7a5ba8dd5b92d5b",
+        "pkg:rpm/redhat/ima-evm-utils@1.4-4.el9?arch=x86_64&upstream=ima-evm-utils-1.4-4.el9.src.rpm&distro=rhel-9.2&package-id=204a975cb2bc3ba7",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lua-libs@5.4.4-3.el9?arch=x86_64&upstream=lua-5.4.4-3.el9.src.rpm&distro=rhel-9.2&package-id=4f09d2c77d830d9a",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=256fa88c206e8d6d",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=9d0c2200e8dd58c7",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64&upstream=libarchive-3.5.3-4.el9.src.rpm&distro=rhel-9.2&package-id=6f9da8010675d944",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64&upstream=popt-1.18-8.el9.src.rpm&distro=rhel-9.2&package-id=e52ebe7b919befcb",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-24.el9_2?arch=x86_64&upstream=rpm-4.16.1.3-24.el9_2.src.rpm&distro=rhel-9.2&package-id=d45088b206838e25"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-9.el9?arch=noarch&upstream=setup-2.13.7-9.el9.src.rpm&distro=rhel-9.2&package-id=2a2692846495e979",
+      "dependsOn": [
+        "pkg:rpm/redhat/redhat-release@9.2-0.15.el9?arch=x86_64&upstream=redhat-release-9.2-0.15.el9.src.rpm&distro=rhel-9.2&package-id=7839d03e837b6f0f"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-6.el9_2.1?arch=x86_64&upstream=sqlite-3.34.1-6.el9_2.1.src.rpm&distro=rhel-9.2&package-id=12e2aa06209d716e",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2&package-id=ed04899fcadf0517",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2&package-id=dd051804a3459d67",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=c417bdbd8387f2c3",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+        "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70",
+        "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=3b3637036cc97dde"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-rpm-macros@252-14.el9_2.7?arch=noarch&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=7b6d9c9616e1e034",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=3b3637036cc97dde",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2&package-id=b2b140771748e045",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2&package-id=55a4fbd380f817ef",
+        "pkg:rpm/redhat/glibc-common@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=47e7140eff866f4c",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64&upstream=grep-3.6-5.el9.src.rpm&distro=rhel-9.2&package-id=782f644b1abd074f",
+        "pkg:rpm/redhat/kmod-libs@28-7.el9?arch=x86_64&upstream=kmod-28-7.el9.src.rpm&distro=rhel-9.2&package-id=1f7352a741116df2",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.2&package-id=d7283cba2a069507",
+        "pkg:rpm/redhat/libfdisk@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d32517146bdc430b",
+        "pkg:rpm/redhat/libgcc@11.3.1-4.3.el9?arch=x86_64&upstream=gcc-11.3.1-4.3.el9.src.rpm&distro=rhel-9.2&package-id=03c4aa92a0368ac2",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-10.el9_2?arch=x86_64&upstream=libgcrypt-1.10.0-10.el9_2.src.rpm&distro=rhel-9.2&package-id=ed04899fcadf0517",
+        "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+        "pkg:rpm/redhat/libseccomp@2.5.2-2.el9?arch=x86_64&upstream=libseccomp-2.5.2-2.el9.src.rpm&distro=rhel-9.2&package-id=81895d3b4f482c4d",
+        "pkg:rpm/redhat/libselinux-utils@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=e9cfd28f3867e3df",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64&upstream=zstd-1.5.1-2.el9.src.rpm&distro=rhel-9.2&package-id=3fc40e5b393fdae4",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64&upstream=lz4-1.9.3-5.el9.src.rpm&distro=rhel-9.2&package-id=dd051804a3459d67",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd",
+        "pkg:rpm/redhat/p11-kit@0.24.1-2.el9?arch=x86_64&upstream=p11-kit-0.24.1-2.el9.src.rpm&distro=rhel-9.2&package-id=1b07d12e1f141bf5",
+        "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70",
+        "pkg:rpm/redhat/pcre2@10.40-2.el9?arch=x86_64&upstream=pcre2-10.40-2.el9.src.rpm&distro=rhel-9.2&package-id=fc9e00d771d383c9",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64&upstream=sed-4.8-9.el9.src.rpm&distro=rhel-9.2&package-id=9b70b04aba638e6e",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3",
+        "pkg:rpm/redhat/systemd-pam@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=c417bdbd8387f2c3",
+        "pkg:rpm/redhat/systemd-rpm-macros@252-14.el9_2.7?arch=noarch&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=7b6d9c9616e1e034",
+        "pkg:rpm/redhat/util-linux@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=4291cd238eba0959",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.34-6.el9_1?arch=x86_64&epoch=2&upstream=tar-1.34-6.el9_1.src.rpm&distro=rhel-9.2&package-id=08d613c9a541ecf8",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libacl@2.3.1-3.el9?arch=x86_64&upstream=acl-2.3.1-3.el9.src.rpm&distro=rhel-9.2&package-id=fd4fcebabf6c0912",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@3.0.3-8.el9?arch=x86_64&upstream=tpm2-tss-3.0.3-8.el9.src.rpm&distro=rhel-9.2&package-id=68aa97edcbee79cc",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64&upstream=json-c-0.14-11.el9.src.rpm&distro=rhel-9.2&package-id=81e63cdc65a50d3b",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-23.el9_2.6?arch=x86_64&upstream=curl-7.76.1-23.el9_2.6.src.rpm&distro=rhel-9.2&package-id=243b0f56bbb981ae",
+        "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&epoch=1&upstream=openssl-3.0.7-18.el9_2.src.rpm&distro=rhel-9.2&package-id=9bcaee2bc3a3e8cd"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux-core@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=e023b19d22c8f074",
+      "dependsOn": [
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+        "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef",
+        "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=4291cd238eba0959",
+      "dependsOn": [
+        "pkg:rpm/redhat/audit-libs@3.0.7-103.el9?arch=x86_64&upstream=audit-3.0.7-103.el9.src.rpm&distro=rhel-9.2&package-id=270ce0ba26562e57",
+        "pkg:rpm/redhat/bash@5.1.8-6.el9_1?arch=x86_64&upstream=bash-5.1.8-6.el9_1.src.rpm&distro=rhel-9.2&package-id=8514ab5735ba2af8",
+        "pkg:rpm/redhat/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.2&package-id=e7f4240c7d5b6a70",
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb",
+        "pkg:rpm/redhat/libblkid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d44ec65034ddba93",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64&upstream=libcap-ng-0.8.2-7.el9.src.rpm&distro=rhel-9.2&package-id=b68ce4b948a34511",
+        "pkg:rpm/redhat/libfdisk@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=d32517146bdc430b",
+        "pkg:rpm/redhat/libmount@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=9f417e558843e963",
+        "pkg:rpm/redhat/libselinux@3.5-1.el9?arch=x86_64&upstream=libselinux-3.5-1.el9.src.rpm&distro=rhel-9.2&package-id=917efcb5251b16d2",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=28e3ce0c840ef85b",
+        "pkg:rpm/redhat/libutempter@1.2.1-6.el9?arch=x86_64&upstream=libutempter-1.2.1-6.el9.src.rpm&distro=rhel-9.2&package-id=3270a0bcb4c23861",
+        "pkg:rpm/redhat/libuuid@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=7725a1c135b36eef",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64&upstream=libxcrypt-4.4.18-3.el9.src.rpm&distro=rhel-9.2&package-id=2ae8b1ca1a5efe08",
+        "pkg:rpm/redhat/ncurses-libs@6.2-8.20210508.el9_2.1?arch=x86_64&upstream=ncurses-6.2-8.20210508.el9_2.1.src.rpm&distro=rhel-9.2&package-id=4809a1f593fc7e01",
+        "pkg:rpm/redhat/pam@1.5.1-15.el9_2?arch=x86_64&upstream=pam-1.5.1-15.el9_2.src.rpm&distro=rhel-9.2&package-id=982f63600ebe0e70",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64&upstream=readline-8.1-4.el9.src.rpm&distro=rhel-9.2&package-id=046bade3b9d88f22",
+        "pkg:rpm/redhat/systemd-libs@252-14.el9_2.7?arch=x86_64&upstream=systemd-252-14.el9_2.7.src.rpm&distro=rhel-9.2&package-id=0269597af34202c3",
+        "pkg:rpm/redhat/util-linux-core@2.37.4-11.el9_2?arch=x86_64&upstream=util-linux-2.37.4-11.el9_2.src.rpm&distro=rhel-9.2&package-id=e023b19d22c8f074",
+        "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64&upstream=xz-5.2.5-8.el9_0.src.rpm&distro=rhel-9.2&package-id=2b8f618a9d835569",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=588893d87823c394",
+      "dependsOn": [
+        "pkg:rpm/redhat/dnf@4.14.0-5.el9_2?arch=noarch&upstream=dnf-4.14.0-5.el9_2.src.rpm&distro=rhel-9.2&package-id=5bcc52fe6dc4603d"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-39.el9?arch=x86_64&upstream=zlib-1.2.11-39.el9.src.rpm&distro=rhel-9.2&package-id=3442a5bb30435904",
+      "dependsOn": [
+        "pkg:rpm/redhat/glibc@2.34-60.el9_2.14?arch=x86_64&upstream=glibc-2.34-60.el9_2.14.src.rpm&distro=rhel-9.2&package-id=555f55157e3d46eb"
+      ]
+    }
+  ]
+}

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/SyftImageConfig.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/SyftImageConfig.java
@@ -48,6 +48,12 @@ public class SyftImageConfig extends Config {
     @Builder.Default
     List<String> paths = new ArrayList<>();
 
+    /**
+     * Flag to indicate whether RPMs should be added to manifest.
+     */
+    @Builder.Default
+    boolean rpms = false;
+
     @JsonIgnore
     @Override
     public boolean isEmpty() {

--- a/core/src/main/resources/schemas/syft-image-config.json
+++ b/core/src/main/resources/schemas/syft-image-config.json
@@ -13,6 +13,10 @@
       "description": "Configuration type",
       "enum": ["syft-image"]
     },
+    "rpms": {
+      "description": "Flag to indicate whether RPMs should be added to manifest",
+      "type": "boolean"
+    },
     "paths": {
       "description": "All files located in the container image filesystem under given paths will be added to the resulting manifest. If this option is skipped, all found artifacts will be added.",
       "type": "array",

--- a/docs/modules/user-guide/pages/configurations/syft-image.adoc
+++ b/docs/modules/user-guide/pages/configurations/syft-image.adoc
@@ -11,6 +11,11 @@ List of paths within the container image that should be used to filter component
 If the path to component (for example a JAR file) is located on one of the paths provided in the configuration file
 it will be retained. Every component located outsude of given paths will be removed from the manifest.
 
+=== `rpms`
+
+A flag whether RPM packages should be added to generated manifest. By default this flag is set to `false` which means
+that no RPM packagaes will be added to manifest.
+
 == Example
 
 [source,yaml]
@@ -23,3 +28,14 @@ paths:
 
 If we have two components: `/opt/product/content/first.jar` and `/var/lib/product/content/second.jar` detected in the image
 we will only add `/opt/product/content/first.jar` to the manifest and the `/var/lib/product/content/second.jar` will be skipped.
+
+[source,yaml]
+----
+apiVersion: sbomer.jboss.org/v1alpha1
+type: syft-image
+rpms: true
+paths:
+    - "/opt"
+----
+
+This example is similar to the above one with one difference: all RPM packages will be added to the manifest.


### PR DESCRIPTION
Adds support for adding RPM components to the manifest. If the rpms flag is set to true, RPMs will be preserved in the manifest. Otherwise (the default option) RPM components will be removed.

https://issues.redhat.com/browse/SBOMER-91