### PR TITLE
Use dynamic port for WireMock server

### DIFF
--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/ServiceWireMock.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/ServiceWireMock.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class ServiceWireMock implements QuarkusTestResourceLifecycleManager {
@@ -31,9 +32,9 @@ public class ServiceWireMock implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(12377);
+        wireMockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
         wireMockServer.start();
-        Map<String, String> configs = new HashMap<String, String>();
+        Map<String, String> configs = new HashMap<>();
         configs.put("sbomer.host", wireMockServer.baseUrl());
         configs.put("quarkus.application.version", "test-version-1.0.0");
         return Collections.unmodifiableMap(configs);

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
@@ -1,5 +1,7 @@
 package org.jboss.sbomer.cli.test.integ.feature.sbom.processor;
 
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -61,8 +63,8 @@ class DefaultProcessorIT {
         assertEquals("Red Hat", component.getPublisher());
         assertEquals("Red Hat", component.getPublisher());
 
-        assertEquals(
-                "https://localhost:12388/pnc-rest/v2/builds/APT4PH2ILMAAA",
-                SbomUtils.getExternalReferences(component, Type.BUILD_SYSTEM, "pnc-build-id").get(0).getUrl());
+        assertThat(
+                SbomUtils.getExternalReferences(component, Type.BUILD_SYSTEM, "pnc-build-id").get(0).getUrl(),
+                matchesPattern("^https://localhost:\\d+/pnc-rest/v2/builds/APT4PH2ILMAAA$"));
     }
 }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/utils/PncWireMock.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/utils/PncWireMock.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class PncWireMock implements QuarkusTestResourceLifecycleManager {
@@ -30,7 +31,7 @@ public class PncWireMock implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(12388);
+        wireMockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
         wireMockServer.start();
 
         return Collections.singletonMap("sbomer.pnc.host", wireMockServer.baseUrl().substring(7));

--- a/service/src/test/java/org/jboss/sbomer/service/test/PncWireMock.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/PncWireMock.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class PncWireMock implements QuarkusTestResourceLifecycleManager {
@@ -30,7 +31,7 @@ public class PncWireMock implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(12388);
+        wireMockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
         wireMockServer.start();
 
         return Collections.singletonMap("sbomer.pnc.host", wireMockServer.baseUrl().substring(7));


### PR DESCRIPTION
Do we need fixed ports? I keep getting errors that the port is already in use.