### PR TITLE
Fix path converter

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/PathConverter.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/PathConverter.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.cli.feature.sbom.command;
 
 import java.nio.file.Path;
 
+import io.quarkus.logging.Log;
 import picocli.CommandLine.ITypeConverter;
 
 public class PathConverter implements ITypeConverter<Path> {
@@ -33,6 +34,12 @@ public class PathConverter implements ITypeConverter<Path> {
             return null;
         }
 
-        return Path.of(path.replaceFirst("~", System.getenv("HOME")));
+        String userHome = System.getProperty("user.home");
+
+        if (userHome == null || !path.startsWith("~")) {
+            return Path.of(path);
+        }
+
+        return Path.of(userHome + path.substring(1));
     }
 }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/cli/PathConverterTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/cli/PathConverterTest.java
@@ -1,0 +1,23 @@
+package org.jboss.sbomer.cli.test.unit.cli;
+
+import org.jboss.sbomer.cli.feature.sbom.command.PathConverter;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class PathConverterTest {
+    @Test
+    void testConvert() throws Exception {
+        String userHome = System.getProperty("user.home");
+        assertThat(userHome, notNullValue());
+        assertThat(new PathConverter().convert("~"), is(Path.of(userHome)));
+        assertThat(new PathConverter().convert("~/"), is(Path.of(userHome + "/")));
+        // XXX: This one differs from bash if "x" is a user on the system
+        assertThat(new PathConverter().convert("~x"), is(Path.of(userHome + "x")));
+        assertThat(new PathConverter().convert("/~"), is(Path.of("/~")));
+    }
+}


### PR DESCRIPTION
So, this didn't work as expected. I am not really sure of the use case, but this is what I found:

1. It replaced the _first occurrence_ of `~` which is not necessarily the first character.
2. Using `System.getProperty("user.home")` is cross-platform while `System.getenv("HOME")` isn't, and I guess technically these could return `null`.
3. Removed the use of a regex. Could have tried to replace `~` with `^~`, but the regex does not handle "special" characters in paths.