### PR TITLE
Fix some JUnit API issues

### DIFF
--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/ConfigReaderIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/ConfigReaderIT.java
@@ -18,6 +18,7 @@
 package org.jboss.sbomer.cli.test.integ.feature.sbom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -168,7 +169,7 @@ class ConfigReaderIT {
             assertNotNull(config);
             assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
 
-            assertTrue(config instanceof PncBuildConfig);
+            assertInstanceOf(PncBuildConfig.class, config);
 
             ProductConfig productConfig = ((PncBuildConfig) config).getProducts().get(0);
             assertEquals(0, productConfig.getProcessors().size());
@@ -279,7 +280,7 @@ class ConfigReaderIT {
             Config config = configReader.getConfig(build);
 
             assertNotNull(config);
-            assertTrue(config instanceof PncBuildConfig);
+            assertInstanceOf(PncBuildConfig.class, config);
             assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
 
             ProductConfig productConfig = ((PncBuildConfig) config).getProducts().get(0);
@@ -345,7 +346,7 @@ class ConfigReaderIT {
             Config config = configReader.getConfig(build);
 
             assertNotNull(config);
-            assertTrue(config instanceof PncBuildConfig);
+            assertInstanceOf(PncBuildConfig.class, config);
             assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
 
             ProductConfig productConfig = ((PncBuildConfig) config).getProducts().get(0);

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/SbomerConfigProviderTest.java
@@ -1,6 +1,7 @@
 package org.jboss.sbomer.core.test.unit.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -107,8 +108,8 @@ class SbomerConfigProviderTest {
             ProductConfig product = config.getProducts().get(0);
 
             assertEquals(2, product.getProcessors().size());
-            assertTrue(product.getProcessors().get(0) instanceof DefaultProcessorConfig);
-            assertTrue(product.getProcessors().get(1) instanceof RedHatProductProcessorConfig);
+            assertInstanceOf(DefaultProcessorConfig.class, product.getProcessors().get(0));
+            assertInstanceOf(RedHatProductProcessorConfig.class, product.getProcessors().get(1));
             assertEquals(GeneratorType.MAVEN_CYCLONEDX, product.getGenerator().getType());
             assertEquals("--batch-mode", product.getGenerator().getArgs());
             assertEquals("2.7.9", product.getGenerator().getVersion());
@@ -124,8 +125,8 @@ class SbomerConfigProviderTest {
             ProductConfig product = config.getProducts().get(0);
 
             assertEquals(2, product.getProcessors().size());
-            assertTrue(product.getProcessors().get(0) instanceof DefaultProcessorConfig);
-            assertTrue(product.getProcessors().get(1) instanceof RedHatProductProcessorConfig);
+            assertInstanceOf(DefaultProcessorConfig.class, product.getProcessors().get(0));
+            assertInstanceOf(RedHatProductProcessorConfig.class, product.getProcessors().get(1));
             assertEquals(GeneratorType.MAVEN_CYCLONEDX, product.getGenerator().getType());
             assertEquals("--batch-mode", product.getGenerator().getArgs());
             assertEquals("1.1.1", product.getGenerator().getVersion());
@@ -141,8 +142,8 @@ class SbomerConfigProviderTest {
             ProductConfig product = config.getProducts().get(0);
 
             assertEquals(2, product.getProcessors().size());
-            assertTrue(product.getProcessors().get(0) instanceof DefaultProcessorConfig);
-            assertTrue(product.getProcessors().get(1) instanceof RedHatProductProcessorConfig);
+            assertInstanceOf(DefaultProcessorConfig.class, product.getProcessors().get(0));
+            assertInstanceOf(RedHatProductProcessorConfig.class, product.getProcessors().get(1));
             assertEquals(GeneratorType.MAVEN_CYCLONEDX, product.getGenerator().getType());
             assertEquals("--custom-args", product.getGenerator().getArgs());
             assertEquals("2.7.9", product.getGenerator().getVersion());
@@ -158,8 +159,8 @@ class SbomerConfigProviderTest {
             ProductConfig product = config.getProducts().get(0);
 
             assertEquals(2, product.getProcessors().size());
-            assertTrue(product.getProcessors().get(0) instanceof DefaultProcessorConfig);
-            assertTrue(product.getProcessors().get(1) instanceof RedHatProductProcessorConfig);
+            assertInstanceOf(DefaultProcessorConfig.class, product.getProcessors().get(0));
+            assertInstanceOf(RedHatProductProcessorConfig.class, product.getProcessors().get(1));
         }
 
         @Test

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureIT.java
@@ -39,7 +39,7 @@ import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.service.test.integ.feature.s3.S3FeatureIT.S3ClientConfig;
 import org.jboss.sbomer.service.test.integ.feature.sbom.messaging.AmqpTestResourceLifecycleManager;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -59,7 +59,7 @@ import io.restassured.http.ContentType;
 @QuarkusTest
 @TestProfile(S3ClientConfig.class)
 @WithTestResource(AmqpTestResourceLifecycleManager.class)
-public class S3FeatureIT {
+class S3FeatureIT {
 
     @InjectSpy
     S3StorageHandler storageHandler;
@@ -88,8 +88,8 @@ public class S3FeatureIT {
         }
     }
 
-    @BeforeClass
-    static void init() {
+    @BeforeAll
+    public static void init() {
         RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
 
     }

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/SbomRepositoryIT.java
@@ -17,11 +17,11 @@
  */
 package org.jboss.sbomer.service.test.integ.feature.sbom;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.sbomer.service.test.integ.feature.sbom.messaging;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/BuildControllerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/BuildControllerTest.java
@@ -1,8 +1,8 @@
 package org.jboss.sbomer.service.test.unit.feature.sbom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TaskRunSyftImageGenerateDependentResourceTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TaskRunSyftImageGenerateDependentResourceTest.java
@@ -1,6 +1,6 @@
 package org.jboss.sbomer.service.test.unit.feature.sbom.syftimage;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.ParseException;
 import java.util.Collections;


### PR DESCRIPTION
* Replace mix of junit4/junit5 classes with junit5
* Simplify `assertTrue`/`instanceOf` calls by using `assertInstanceOf`