### PR TITLE
feat(SBOMER-121): additional metadata for container images

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/KojiService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/KojiService.java
@@ -28,9 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
 import org.apache.commons.collections4.MultiValuedMap;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.pnc.build.finder.core.BuildConfig;
@@ -48,7 +45,11 @@ import org.jboss.pnc.dto.Artifact;
 import org.jboss.sbomer.cli.feature.sbom.utils.buildfinder.FinderStatus;
 
 import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiIdOrName;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -198,6 +199,30 @@ public class KojiService {
         } catch (Throwable e) {
             log.error("Lookup in Brew failed due to {}", e.getMessage() == null ? e.toString() : e.getMessage(), e);
         }
+        return null;
+    }
+
+    public KojiBuildInfo findBuild(String nvr) throws KojiClientException {
+        if (nvr == null) {
+            return null;
+        }
+
+        log.debug("Finding Brew build for NVR '{}'...", nvr);
+
+        List<KojiBuildInfo> builds = kojiSession.getBuild(List.of(KojiIdOrName.getFor(nvr)));
+
+        if (builds.size() == 0) {
+            log.debug("No results found");
+            return null;
+        }
+
+        if (builds.size() == 1) {
+            log.debug("Found a build for NVR '{}'...", nvr);
+            return builds.get(0);
+        }
+
+        log.warn("Found more than one build for NVR '{}', this is unexpected, returning nothing!", nvr);
+
         return null;
     }
 }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/processor/DefaultProcessorIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.net.MalformedURLException;
 import java.util.List;
 
 import org.cyclonedx.model.Bom;
@@ -37,7 +38,7 @@ class DefaultProcessorIT {
     PncService pncService;
 
     @BeforeEach
-    void init() {
+    void init() throws MalformedURLException {
         this.defaultProcessor = new DefaultProcessor(pncService, Mockito.mock(KojiService.class));
     }
 
@@ -50,6 +51,7 @@ class DefaultProcessorIT {
         component.setPurl("pkg:maven/org.ow2.asm/asm@9.1.0.redhat-00002?type=jar");
         component.setVersion("9.1.0.redhat-00002");
         component.setHashes(List.of(new Hash(Algorithm.SHA1, "2cdf6b457191ed82ef3a9d2e579f6d0aa495a533")));
+        component.setType(Component.Type.LIBRARY);
 
         Metadata metadata = new Metadata();
         metadata.setComponent(component);

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/DefaultProcessorTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/DefaultProcessorTest.java
@@ -1,10 +1,18 @@
 package org.jboss.sbomer.cli.test.unit.feature.sbom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URL;
 
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Commit;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.ExternalReference.Type;
+import org.jboss.pnc.build.finder.core.BuildConfig;
 import org.jboss.sbomer.cli.feature.sbom.processor.DefaultProcessor;
 import org.jboss.sbomer.cli.feature.sbom.service.KojiService;
 import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
@@ -12,6 +20,9 @@ import org.jboss.sbomer.core.pnc.PncService;
 import org.jboss.sbomer.core.test.TestResources;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 
 public class DefaultProcessorTest {
 
@@ -26,5 +37,47 @@ public class DefaultProcessorTest {
         Bom processed = defaultProcessor.process(bom);
 
         assertEquals(143, processed.getComponents().size());
+    }
+
+    @Test
+    void testAddBrewInfo() throws IOException, KojiClientException {
+        PncService pncServiceMock = Mockito.mock(PncService.class);
+        KojiService kojiServiceMock = Mockito.mock(KojiService.class);
+
+        KojiBuildInfo kojiBuildInfo = new KojiBuildInfo();
+        kojiBuildInfo.setId(12345);
+        kojiBuildInfo.setSource("https://git.com/repo#hash");
+
+        BuildConfig buildConfig = new BuildConfig();
+        buildConfig.setKojiWebURL(new URL("https://koji.web"));
+
+        when(kojiServiceMock.getConfig()).thenReturn(buildConfig);
+        when(kojiServiceMock.findBuild(eq("jboss-webserver-58-openjdk17-rhel8-openshift-container-5.8.0-5")))
+                .thenReturn(kojiBuildInfo);
+
+        DefaultProcessor defaultProcessor = new DefaultProcessor(pncServiceMock, kojiServiceMock);
+
+        Bom bom = SbomUtils.fromString(TestResources.asString("boms/image-after-adjustments.json"));
+        Bom processed = defaultProcessor.process(bom);
+
+        assertEquals(143, processed.getComponents().size());
+
+        Component component = processed.getMetadata().getComponent();
+
+        assertEquals("Red Hat", component.getSupplier().getName());
+        assertEquals("Red Hat", component.getPublisher());
+
+        ExternalReference buildSystem = SbomUtils.getExternalReferences(component, Type.BUILD_SYSTEM).get(0);
+
+        assertEquals("https://koji.web/buildinfo?buildID=12345", buildSystem.getUrl());
+        assertEquals("brew-build-id", buildSystem.getComment());
+
+        assertEquals("https://git.com/repo#hash", SbomUtils.getExternalReferences(component, Type.VCS).get(0).getUrl());
+
+        Commit commit = component.getPedigree().getCommits().get(0);
+
+        assertEquals("hash", commit.getUid());
+        assertEquals("https://git.com/repo#hash", commit.getUrl());
+
     }
 }

--- a/core/src/main/java/org/jboss/sbomer/core/pnc/PncService.java
+++ b/core/src/main/java/org/jboss/sbomer/core/pnc/PncService.java
@@ -340,7 +340,9 @@ public class PncService {
             GroupConfiguration groupConfig = getGroupConfig(groupConfigRef.getId());
 
             if (groupConfig == null) {
-                log.warn("GroupConfiguration '{}' could not be found, this is unexpected, but ignoring", groupConfigRef.getId());
+                log.warn(
+                        "GroupConfiguration '{}' could not be found, this is unexpected, but ignoring",
+                        groupConfigRef.getId());
                 return;
             }
 


### PR DESCRIPTION
In case the main component is a container image we will try to add more information. First we will try to see whether it was built in Brew. If it was, we will query Brew and populate following fields:

* supplier
* publisher
* build system external resource
* vcs external resource
* and finally a pedigree commit.

https://issues.redhat.com/browse/SBOMER-121