### PR TITLE
feat(SBOMER-126): handle case where distribution does not provide hash

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
@@ -159,7 +159,7 @@ public class CycloneDxGenerateOperationCommand extends AbstractGenerateOperation
         String fileName = extractFilenameFromURL(deliverableUrl);
         Optional<String> distributionSha256 = artifactsToManifest.stream()
                 .filter(
-                        a -> a.getDistribution() != null
+                        a -> a.getDistribution() != null && a.getDistribution().getSha256() != null
                                 && deliverableUrl.equals(a.getDistribution().getDistributionUrl()))
                 .map(a -> a.getDistribution().getSha256())
                 .findFirst();

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
@@ -370,7 +370,6 @@ public class OperationController extends AbstractController {
         if (failedTaskRuns.isEmpty()) {
 
             List<Sbom> sboms = storeOperationSboms(generationRequest);
-            notificationService.notifyCompleted(sboms);
 
             return updateRequest(
                     generationRequest,
@@ -572,8 +571,6 @@ public class OperationController extends AbstractController {
             // And store it in the database
             sboms.add(sbomRepository.saveSbom(sbom));
         }
-
-        s3LogHandler.storeFiles(generationRequest);
 
         return sboms;
     }


### PR DESCRIPTION
This is a workaround for https://issues.redhat.com/browse/SBOMER-126.