### PR TITLE
feat(SBOMER-128): pass rpms parameter to the task run

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
@@ -104,7 +104,7 @@ public class SyftImageAdjuster implements Adjuster {
             // Handle RPMs
             if (purl.getType().equals("rpm")) {
                 // Remove all components that are RPMs if the includeRpms is not set to true
-                log.debug("Component is of type RPM, to be removed: {} (includeRpms: {})", purl, !includeRpms);
+                log.debug("Component is of type RPM, to be removed: {} (includeRpms: {})", purl, includeRpms);
                 return !includeRpms;
             } else {
                 // Handle everything else

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/adjust/SyftImageAdjustCommand.java
@@ -25,6 +25,7 @@ import org.cyclonedx.model.Bom;
 import org.jboss.sbomer.cli.feature.sbom.adjuster.SyftImageAdjuster;
 import org.jboss.sbomer.core.features.sbom.enums.GeneratorType;
 
+import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -32,6 +33,7 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true,
         name = "syft-image",
         description = "Adjust the Syft manifest output for a container image")
+@Slf4j
 public class SyftImageAdjustCommand extends AbstractAdjustCommand {
 
     @Option(names = "--path-filter")
@@ -47,6 +49,9 @@ public class SyftImageAdjustCommand extends AbstractAdjustCommand {
 
     @Override
     protected Bom doAdjust(Bom bom, Path workDir) {
+        log.debug("Paths: {}", paths);
+        log.debug("RPMs: {}", rpms);
+
         SyftImageAdjuster adjuster = new SyftImageAdjuster(paths, rpms);
 
         return adjuster.adjust(bom, workDir);

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/SyftImageConfig.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/SyftImageConfig.java
@@ -25,6 +25,7 @@ import org.jboss.sbomer.core.features.sbom.config.runtime.ProcessorConfig;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.AllArgsConstructor;
@@ -55,7 +56,8 @@ public class SyftImageConfig extends Config {
      * Flag to indicate whether RPMs should be added to manifest.
      */
     @Builder.Default
-    boolean rpms = false;
+    @JsonProperty("rpms")
+    boolean includeRpms = false;
 
     /**
      * Processors configuration.

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/TaskRunSyftImageGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/image/syft/controller/TaskRunSyftImageGenerateDependentResource.java
@@ -54,6 +54,7 @@ public class TaskRunSyftImageGenerateDependentResource
 
     public static final String PARAM_COMMAND_CONTAINER_IMAGE = "image";
     public static final String PARAM_PATHS = "paths";
+    public static final String PARAM_RPMS = "rpms";
     public static final String PARAM_PROCESSORS = "processors";
     public static final String TASK_SUFFIX = "-generate-image-syft";
     public static final String SA_SUFFIX = "-sa";
@@ -92,6 +93,10 @@ public class TaskRunSyftImageGenerateDependentResource
             throw new ApplicationException("Cannot set timeout", e);
         }
 
+        String rpmsParam = Objects
+                .requireNonNullElse(generationRequest.getConfig(SyftImageConfig.class).isIncludeRpms(), false) ? "true"
+                        : "false";
+
         return new TaskRunBuilder().withNewMetadata()
                 .withNamespace(generationRequest.getMetadata().getNamespace())
                 .withLabels(labels)
@@ -119,7 +124,8 @@ public class TaskRunSyftImageGenerateDependentResource
                                                 Objects.requireNonNullElse(
                                                         generationRequest.getConfig(SyftImageConfig.class).getPaths(),
                                                         Collections.emptyList())))
-                                .build())
+                                .build(),
+                        new ParamBuilder().withName(PARAM_RPMS).withValue(new ParamValue(rpmsParam)).build())
                 .withTaskRef(new TaskRefBuilder().withName(release + TASK_SUFFIX).build())
 
                 .withWorkspaces(


### PR DESCRIPTION
The `rpms` parameter from configuration was not passed and thus ignored. The default value of `false` was used meaning that RPMs were not added to the manifest.

Fixes: https://issues.redhat.com/browse/SBOMER-128