### PR TITLE
feat(SBOMER-149): clean up RPM purls in syft iamge adjuster

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/SyftImageAdjuster.java
@@ -186,9 +186,6 @@ public class SyftImageAdjuster implements Adjuster {
                 .append("@")
                 .append(UrlUtils.urlencode(inspectData.getDigest()))
                 .append("?")
-                .append("repository_url=")
-                .append(componentNameParts[0]) // This should be the registry the image was pulled from
-                .append("&")
                 .append("os=")
                 .append(inspectData.getOs())
                 .append("&")
@@ -293,8 +290,6 @@ public class SyftImageAdjuster implements Adjuster {
                             // If we removed any qualifiers, we need to rebuild the purl
                             if (qualifiers.entrySet()
                                     .removeIf(q -> !q.getKey().equals("arch") && !q.getKey().equals("epoch"))) {
-                                System.out.println(qualifiers);
-
                                 String updatedPurl = new PackageURL(
                                         packageURL.getType(),
                                         packageURL.getNamespace(),

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
@@ -36,7 +36,7 @@ public class SyftImageAdjusterTest {
         Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
 
         assertEquals(
-                "pkg:oci/amq-streams-console-ui-rhel9@sha256%3Af63b27a29c032843941b15567ebd1f37f540160e8066ac74c05367134c2ff3aa?repository_url=registry.com&os=linux&arch=amd64&tag=2.7.0-8.1718294415",
+                "pkg:oci/amq-streams-console-ui-rhel9@sha256%3Af63b27a29c032843941b15567ebd1f37f540160e8066ac74c05367134c2ff3aa?os=linux&arch=amd64&tag=2.7.0-8.1718294415",
                 adjusted.getMetadata().getComponent().getPurl());
         assertEquals(32, adjusted.getComponents().size());
     }

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/adjust/SyftImageAdjusterTest.java
@@ -23,14 +23,10 @@ public class SyftImageAdjusterTest {
 
     Bom bom = null;
 
-    SyftImageAdjusterTest() throws IOException {
-        this.bom = SbomUtils.fromString(TestResources.asString("boms/image.json"));
-
-    }
-
     @BeforeEach
     void init() throws IOException {
         Files.writeString(Path.of(tmpDir.getAbsolutePath(), "skopeo.json"), TestResources.asString("skopeo.json"));
+        this.bom = SbomUtils.fromString(TestResources.asString("boms/image.json"));
     }
 
     @Test
@@ -70,6 +66,26 @@ public class SyftImageAdjusterTest {
         Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
 
         assertEquals(182, adjusted.getComponents().size());
+    }
+
+    @Test
+    void shouldLeaveOnlyArchAndEpochQualifiers() throws IOException {
+        SyftImageAdjuster adjuster = new SyftImageAdjuster(null, true);
+
+        assertEquals(
+                "pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64&upstream=bzip2-1.0.8-8.el9.src.rpm&distro=rhel-9.2",
+                bom.getComponents().get(10).getPurl());
+
+        assertEquals(
+                "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1&upstream=dbus-1.12.20-7.el9_2.1.src.rpm&distro=rhel-9.2",
+                bom.getComponents().get(21).getPurl());
+
+        Bom adjusted = adjuster.adjust(bom, tmpDir.toPath());
+
+        assertEquals("pkg:rpm/redhat/bzip2-libs@1.0.8-8.el9?arch=x86_64", adjusted.getComponents().get(10).getPurl());
+        assertEquals(
+                "pkg:rpm/redhat/dbus@1.12.20-7.el9_2.1?arch=x86_64&epoch=1",
+                adjusted.getComponents().get(21).getPurl());
     }
 
 }


### PR DESCRIPTION
All qualifiers besides 'arch' and 'epoch' are removed from purl for RPM components in the syft cntainer image generator.

Fixes: https://issues.redhat.com/browse/SBOMER-149