### PR TITLE
fix(SBOMER-166): do not set product coordinates to not send UMB message

### DIFF
--- a/e2e/src/test/resources/requests/A3LCEFCLLVYAA.json
+++ b/e2e/src/test/resources/requests/A3LCEFCLLVYAA.json
@@ -1,21 +1,11 @@
 {
-  "apiVersion": "sbomer.jboss.org/v1alpha1",
-  "buildId": "A3LCEFCLLVYAA",
-  "products": [
-    {
-      "processors": [
+    "apiVersion": "sbomer.jboss.org/v1alpha1",
+    "buildId": "A3LCEFCLLVYAA",
+    "products": [
         {
-          "type": "redhat-product",
-          "errata": {
-            "productName": "RHTESTPRODUCT",
-            "productVersion": "RHEL-8-RHTESTPRODUCT-1.1",
-            "productVariant": "8Base-RHTESTPRODUCT-1.1"
-          }
+            "generator": {
+                "type": "gradle-cyclonedx"
+            }
         }
-      ],
-      "generator": {
-        "type": "gradle-cyclonedx"
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
The problem is that the main component (metadata/component) does not have the build information attached, because the artifact cannot be found in PNC and thus the information about the build system wasn't added to external references in the main component.

This comimt stops setting the product coordinates for this specific e2e, but this is just a workaround. The proper fix will be implemented later.

Related: https://issues.redhat.com/browse/SBOMER-26
Fixes: https://issues.redhat.com/browse/SBOMER-166