### PR TITLE
fix(SBOMER-167): do not create new requests if we already handle it

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
@@ -38,6 +38,7 @@ import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -79,6 +80,7 @@ public class AmqpMessageConsumer {
 
     @Incoming("builds")
     @Blocking(ordered = false, value = "build-processor-pool")
+    @Transactional
     public CompletionStage<Void> process(Message<String> message) {
         receivedMessages.incrementAndGet();
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -496,6 +496,25 @@ public class SbomService {
 
     }
 
+    public SbomGenerationRequest findRequestByIdentifier(GenerationRequestType type, String identifier) {
+        QueryParameters parameters = QueryParameters.builder()
+                .rsqlQuery("identifier=eq='" + identifier + "' and type=eq=" + type)
+                .sort("creationTime=desc=")
+                .pageSize(10)
+                .pageIndex(0)
+                .build();
+
+        List<SbomGenerationRequest> sboms = sbomRequestRepository.search(parameters);
+
+        log.debug("Found {} results for the '{}' identifier nad '{}' type", sboms.size(), identifier, type);
+
+        if (sboms.isEmpty()) {
+            return null;
+        }
+
+        return sboms.get(0);
+    }
+
     /**
      * Notify the creation of an existing SBOM via UMB.
      *


### PR DESCRIPTION
Because we only ACK the message when we successfully create a `GenerationRequest` CR and sync it with the DB we probably can use this fact to check whether a `SbomGenerationRequest` entity already exists for a given PNC build.

I think it is safe to assume that if it exists, it was created by processing another message. It could help with processing duplicate UMB messages, because we have a single active consumer and we process next message only when we ACK or reject previous message.

https://issues.redhat.com/browse/SBOMER-167

WDYT @vibe13?