### PR TITLE
fix(SBOMER-171):  bugfixing operation handling

### DIFF
--- a/core/src/main/java/org/jboss/sbomer/core/config/SbomerConfigProvider.java
+++ b/core/src/main/java/org/jboss/sbomer/core/config/SbomerConfigProvider.java
@@ -88,6 +88,11 @@ public class SbomerConfigProvider {
     public void adjust(OperationConfig config) {
         log.debug("Adjusting operation configuration...");
 
+        // If we have not specified any products (for example when provided an empty config)
+        if (config.getProduct() == null) {
+            config.setProduct(ProductConfig.builder().build());
+        }
+
         GeneratorConfig generatorConfig = config.getProduct().getGenerator();
 
         // Generator configuration was not provided, will use defaults

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/Config.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/config/Config.java
@@ -37,7 +37,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 @SuperBuilder(setterPrefix = "with")
 @AllArgsConstructor
@@ -113,6 +115,15 @@ public abstract class Config {
 
             return param;
         }).collect(Collectors.joining(" "));
+    }
+
+    public static <T extends Config> T newInstance(Class<T> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (Exception e) {
+            log.warn("Unable to create a new default config of class '{}'", clazz, e);
+            return null;
+        }
     }
 
     public String toJson() {

--- a/core/src/main/resources/schemas/operation_config.json
+++ b/core/src/main/resources/schemas/operation_config.json
@@ -5,6 +5,15 @@
   "description": "User-provided configuration file to instruct SBOM generation",
   "type": "object",
   "$defs": {
+    "processor-default": {
+      "$id": "/schemas/processors/default",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "default"
+        }
+      }
+    },
     "processor-redhat-product": {
       "$id": "/schemas/processors/redhat-product",
       "type": "object",
@@ -82,8 +91,11 @@
           "type": "array",
           "uniqueItems": true,
           "minItems": 0,
-          "maxItems": 1,
+          "maxItems": 2,
           "prefixItems": [
+            {
+              "$ref": "#/$defs/processor-default"
+            },
             {
               "$ref": "#/$defs/processor-redhat-product"
             }

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/ConfigTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/ConfigTest.java
@@ -1,7 +1,9 @@
 package org.jboss.sbomer.core.test.unit.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -54,7 +56,59 @@ public class ConfigTest {
     }
 
     @Nested
+    class DeliverableAnalysisConfigTest {
+
+        @Test
+        void shouldReturnDefault() {
+            DeliverableAnalysisConfig config = Config.newInstance(DeliverableAnalysisConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertNull(config.getDeliverableUrls());
+            assertNull(config.getErrata());
+            assertNull(config.getMilestoneId());
+        }
+    }
+
+    @Nested
+    class OperationConfigTest {
+
+        @Test
+        void shouldReturnDefault() {
+            OperationConfig config = Config.newInstance(OperationConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertNull(config.getDeliverableUrls());
+            assertNull(config.getOperationId());
+            assertNull(config.getProduct());
+        }
+    }
+
+    @Nested
+    class PncBuildConfigTest {
+
+        @Test
+        void shouldReturnDefault() {
+            PncBuildConfig config = Config.newInstance(PncBuildConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertNull(config.getBuildId());
+            assertNull(config.getEnvironment());
+            assertTrue(config.getProducts().isEmpty());
+        }
+    }
+
+    @Nested
     class SyftImageConfigTest {
+
+        @Test
+        void shouldReturnNewInstance() {
+            SyftImageConfig config = Config.newInstance(SyftImageConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertTrue(config.getPaths().isEmpty());
+            assertFalse(config.isIncludeRpms());
+
+        }
 
         @Test
         void shouldAddDefaultProcessor() {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -136,9 +136,20 @@ public class GenerationRequest extends ConfigMap {
     }
 
     @JsonIgnore
+    @Deprecated
     public <T extends Config> T getConfig(Class<T> clazz) {
+        return getConfig(clazz, false);
+    }
+
+    @JsonIgnore
+    public <T extends Config> T getConfig(Class<T> clazz, boolean def) {
         String configData = getData().get(KEY_CONFIG);
-        return Config.fromString(configData, clazz);
+        T config = Config.fromString(configData, clazz);
+
+        if (config == null && def) {
+            return Config.newInstance(clazz);
+        }
+        return config;
     }
 
     @JsonIgnore

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationInitDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationInitDependentResource.java
@@ -83,7 +83,7 @@ public class TaskRunOperationInitDependentResource
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.OPERATIONINIT.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
 
-        OperationConfig config = generationRequest.getConfig(OperationConfig.class);
+        OperationConfig config = generationRequest.getConfig(OperationConfig.class, true);
 
         return new TaskRunBuilder().withNewMetadata()
                 .withNamespace(generationRequest.getMetadata().getNamespace())


### PR DESCRIPTION
This PR fixes some inconsistencies in operation handling. Operation schema was updated, because it was wrong according to what we generate internally. Now it is allowed to not provide product config. Handling of empty config was fixed as well.