### PR TITLE
fix: remove the transactional annotations from consumer

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/AmqpMessageConsumer.java
@@ -68,7 +68,6 @@ import lombok.extern.slf4j.Slf4j;
 @ApplicationScoped
 @Unremovable
 @Slf4j
-@Transactional // Quarkus should initialize the database connection pool before processing @Transactional beans
 public class AmqpMessageConsumer {
 
     @Inject
@@ -94,7 +93,6 @@ public class AmqpMessageConsumer {
 
     @Incoming("errata")
     @Blocking(ordered = false, value = "errata-processor-pool")
-    @Transactional
     public CompletionStage<Void> processErrata(Message<byte[]> message) {
         log.debug("Received new Errata tool status change notification via the AMQP consumer");
 
@@ -147,7 +145,6 @@ public class AmqpMessageConsumer {
 
     @Incoming("builds")
     @Blocking(ordered = false, value = "build-processor-pool")
-    @Transactional
     public CompletionStage<Void> process(Message<String> message) {
         log.debug("Received new PNC build status notification via the AMQP consumer");
         log.debug("Message content: {}", message.getPayload());


### PR DESCRIPTION
@goldmann  The Transactional annotation was introduced to force the initialization of the AmqpMessageConsumer after the DB connection initialization. However, this has introduced as a side effect a timeout constraint of 60 seconds on the "processErrata" and "process" methods. For big advisories, more time will be definitely needed to complete the bootstrapping of all the generations. I would remove the annotations from the class altogether. Since we have now a readiness probe for the DB pool initialization, we should be ok. 