### PR TITLE
feat(SBOMER-224): adjust syft image TaskRun compute resources

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/TektonResourceUtils.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/TektonResourceUtils.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.k8s.reconciler;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TektonResourceUtils {
+    public static enum ResourceTarget {
+        CPU, MEMORY
+    }
+
+    public static enum ResourceType {
+        REQUESTS, LIMITS
+    }
+
+    private TektonResourceUtils() {
+        // This is a utility class
+    }
+
+    public static void adjustComputeResources(TaskRun taskRun) {
+        log.debug("Adjusting compute resources for TaskRun '{}'", taskRun.getFullResourceName());
+
+        ResourceRequirements computeResources = taskRun.getSpec().getComputeResources();
+
+        if (computeResources == null) {
+            computeResources = new ResourceRequirements();
+        }
+
+        String labelType = taskRun.getMetadata().getLabels().get(Labels.LABEL_TYPE);
+
+        if (labelType == null) {
+            log.warn(
+                    "Unable to find '{}' label in the '{}' TaskRun, configuring resources will be skipped",
+                    Labels.LABEL_TYPE,
+                    taskRun.getMetadata().getName());
+
+            return;
+        }
+
+        GenerationRequestType requestType = GenerationRequestType.fromName(labelType);
+
+        try {
+            for (ResourceTarget target : ResourceTarget.values()) {
+                computeResources.setLimits(
+                        Map.of(
+                                target.toString().toLowerCase(),
+                                Quantity.parse(getResources(requestType, ResourceType.LIMITS, target))));
+
+                computeResources.setRequests(
+                        Map.of(
+                                target.toString().toLowerCase(),
+                                Quantity.parse(getResources(requestType, ResourceType.REQUESTS, target))));
+
+            }
+
+        } catch (IllegalArgumentException e) {
+            log.warn("Unable to set resources for TaskRun '{}'", taskRun.getFullResourceName(), e);
+            return;
+        }
+
+        log.info(
+                "Updating compute resources of TaskRun '{}' to: {}",
+                taskRun.getFullResourceName(),
+                computeResources.toString());
+
+        taskRun.getSpec().setComputeResources(computeResources);
+    }
+
+    /**
+     * Fetches configured compute resource values for a given generator.
+     * 
+     * @param generatorType
+     * @param type
+     * @param target
+     * @return
+     */
+    private static String getResources(GenerationRequestType generatorType, ResourceType type, ResourceTarget target) {
+        Optional<String> value = ConfigProvider.getConfig()
+                .getOptionalValue(
+                        String.format(
+                                "sbomer.generator.%s.tekton.resources.%s.%s",
+                                generatorType.toName(),
+                                type.toString().toLowerCase(),
+                                target.toString().toLowerCase()),
+                        String.class);
+
+        if (value.isPresent()) {
+            return value.get();
+        }
+
+        return null;
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/generator/image/controller/TaskRunSyftImageGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/generator/image/controller/TaskRunSyftImageGenerateDependentResource.java
@@ -28,6 +28,7 @@ import org.jboss.sbomer.core.features.sbom.config.SyftImageConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.TektonResourceUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.GenerateResourceDiscriminator;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
 
@@ -97,7 +98,7 @@ public class TaskRunSyftImageGenerateDependentResource
                 .requireNonNullElse(generationRequest.getConfig(SyftImageConfig.class).isIncludeRpms(), false) ? "true"
                         : "false";
 
-        return new TaskRunBuilder().withNewMetadata()
+        TaskRun taskRun = new TaskRunBuilder().withNewMetadata()
                 .withNamespace(generationRequest.getMetadata().getNamespace())
                 .withLabels(labels)
                 .withName(generationRequest.dependentResourceName(SbomGenerationPhase.GENERATE))
@@ -137,5 +138,9 @@ public class TaskRunSyftImageGenerateDependentResource
                                 .build())
                 .endSpec()
                 .build();
+
+        TektonResourceUtils.adjustComputeResources(taskRun);
+
+        return taskRun;
     }
 }

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -199,3 +199,15 @@ sbomer:
       # # This includes removing the generation request kubernetes resource as well as any leftovers on the filesystem
       # # located in the sbomer.sbom-dir directory.
       cleanup: false
+
+  generator:
+    # GenerationRequestType.toName()
+    containerimage:
+      tekton:
+        resources:
+          requests:
+            cpu: "800m"
+            memory: "1200Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1400Mi"

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/reconciler/TektonResourceUtilsTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/reconciler/TektonResourceUtilsTest.java
@@ -1,0 +1,134 @@
+package org.jboss.sbomer.service.test.unit.feature.sbom.reconciler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.service.feature.sbom.k8s.reconciler.TektonResourceUtils;
+import org.jboss.sbomer.service.feature.sbom.k8s.resources.Labels;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
+
+public class TektonResourceUtilsTest {
+
+    @Test
+    void shouldHandleContainerImageResources() {
+        TaskRun taskRun = new TaskRunBuilder().withNewMetadata()
+                .withName("taskrun-name")
+                .withLabels(Map.of(Labels.LABEL_TYPE, GenerationRequestType.CONTAINERIMAGE.toName()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        TektonResourceUtils.adjustComputeResources(taskRun);
+
+        ResourceRequirements computeResources = taskRun.getSpec().getComputeResources();
+
+        // CPU
+        assertEquals(Quantity.parse("800m"), computeResources.getRequests().get("cpu"));
+        assertEquals(Quantity.parse("1000m"), computeResources.getLimits().get("cpu"));
+
+        // Memoery
+        assertEquals(Quantity.parse("1200Mi"), computeResources.getRequests().get("memory"));
+        assertEquals(Quantity.parse("1400Mi"), computeResources.getLimits().get("memory"));
+    }
+
+    @Test
+    void shouldSetMockedResources() {
+        Config mockConfig = mock(Config.class);
+
+        when(mockConfig.getOptionalValue("sbomer.generator.containerimage.tekton.resources.requests.cpu", String.class))
+                .thenReturn(Optional.of("100m"));
+
+        when(mockConfig.getOptionalValue("sbomer.generator.containerimage.tekton.resources.limits.cpu", String.class))
+                .thenReturn(Optional.of("200m"));
+
+        when(
+                mockConfig.getOptionalValue(
+                        "sbomer.generator.containerimage.tekton.resources.requests.memory",
+                        String.class)).thenReturn(Optional.of("100Mi"));
+
+        when(
+                mockConfig.getOptionalValue(
+                        "sbomer.generator.containerimage.tekton.resources.limits.memory",
+                        String.class)).thenReturn(Optional.of("200Mi"));
+
+        TaskRun taskRun = new TaskRunBuilder().withNewMetadata()
+                .withName("taskrun-name")
+                .withLabels(Map.of(Labels.LABEL_TYPE, GenerationRequestType.CONTAINERIMAGE.toName()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        try (MockedStatic<ConfigProvider> utilities = Mockito.mockStatic(ConfigProvider.class)) {
+            utilities.when(ConfigProvider::getConfig).thenReturn(mockConfig);
+
+            TektonResourceUtils.adjustComputeResources(taskRun);
+        }
+
+        ResourceRequirements computeResources = taskRun.getSpec().getComputeResources();
+
+        // CPU
+        assertEquals(Quantity.parse("100m"), computeResources.getRequests().get("cpu"));
+        assertEquals(Quantity.parse("200m"), computeResources.getLimits().get("cpu"));
+
+        // Memoery
+        assertEquals(Quantity.parse("100Mi"), computeResources.getRequests().get("memory"));
+        assertEquals(Quantity.parse("200Mi"), computeResources.getLimits().get("memory"));
+    }
+
+    @Test
+    void shouldNotSetResourcesInCaseOfFailure() {
+        Config mockConfig = mock(Config.class);
+
+        when(mockConfig.getOptionalValue("sbomer.generator.containerimage.tekton.resources.requests.cpu", String.class))
+                .thenReturn(Optional.of("100m"));
+
+        when(mockConfig.getOptionalValue("sbomer.generator.containerimage.tekton.resources.limits.cpu", String.class))
+                .thenReturn(Optional.of("200m"));
+
+        when(
+                mockConfig.getOptionalValue(
+                        "sbomer.generator.containerimage.tekton.resources.requests.memory",
+                        String.class)).thenReturn(Optional.of("100Mi"));
+
+        // This is the failing one
+        when(
+                mockConfig.getOptionalValue(
+                        "sbomer.generator.containerimage.tekton.resources.limits.memory",
+                        String.class)).thenReturn(Optional.of("2garbage00Mi"));
+
+        TaskRun taskRun = new TaskRunBuilder().withNewMetadata()
+                .withName("taskrun-name")
+                .withLabels(Map.of(Labels.LABEL_TYPE, GenerationRequestType.CONTAINERIMAGE.toName()))
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        try (MockedStatic<ConfigProvider> utilities = Mockito.mockStatic(ConfigProvider.class)) {
+            utilities.when(ConfigProvider::getConfig).thenReturn(mockConfig);
+
+            TektonResourceUtils.adjustComputeResources(taskRun);
+        }
+
+        ResourceRequirements computeResources = taskRun.getSpec().getComputeResources();
+
+        assertNull(computeResources);
+    }
+}


### PR DESCRIPTION
It does this based on the configuration and it can be overridden by an env variable.

Currently covering only container image generations, will be extended to other types if it proves to be working properly.