### PR TITLE
feat: remove transactional annotations from UMB consumer

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/ErrataNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/ErrataNotificationHandler.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,8 +80,9 @@ public class ErrataNotificationHandler {
         return status == QE || status == SHIPPED_LIVE;
     }
 
-    @Transactional
+    @Transactional(value = TxType.REQUIRES_NEW)
     protected RequestEvent addErrataAdvisoryRequestConfig(RequestEvent requestEvent, String errataId) {
+        requestEvent = RequestEvent.findById(requestEvent.getId());
         requestEvent.setRequestConfig(ErrataAdvisoryRequestConfig.builder().withAdvisoryId(errataId).build());
         return requestEvent.save();
     }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -61,6 +61,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -88,6 +89,7 @@ public class PncNotificationHandler {
     @RestClient
     PncClient pncClient;
 
+    @Transactional
     public void handle(RequestEvent requestEvent) throws JsonProcessingException {
 
         JsonNode msgNode = requestEvent.getEvent().get(EVENT_KEY_UMB_MSG);
@@ -243,14 +245,16 @@ public class PncNotificationHandler {
 
     }
 
-    @Transactional
+    @Transactional(value = TxType.REQUIRES_NEW)
     protected RequestEvent addPncBuildRequestConfig(RequestEvent requestEvent, String buildId) {
+        requestEvent = RequestEvent.findById(requestEvent.getId());
         requestEvent.setRequestConfig(PncBuildRequestConfig.builder().withBuildId(buildId).build());
         return requestEvent.save();
     }
 
-    @Transactional
+    @Transactional(value = TxType.REQUIRES_NEW)
     protected RequestEvent addPncOperationRequestConfig(RequestEvent requestEvent, String operationId) {
+        requestEvent = RequestEvent.findById(requestEvent.getId());
         requestEvent.setRequestConfig(PncOperationRequestConfig.builder().withOperationId(operationId).build());
         return requestEvent.save();
     }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -20,6 +20,7 @@ package org.jboss.sbomer.service.feature.sbom.model;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.DynamicUpdate;
@@ -148,7 +149,8 @@ public class SbomGenerationRequest extends PanacheEntityBase {
 
         // If the request is null (e.g. sync called from the controllers) do not override it
         if (request != null) {
-            sbomGenerationRequest.setRequest(request);
+            RequestEvent dbRequestEvent = RequestEvent.findById(request.getId());
+            sbomGenerationRequest.setRequest(Optional.ofNullable(dbRequestEvent).orElse(request));
         }
 
         // Store it in the database

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
@@ -55,6 +55,7 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -166,7 +167,8 @@ public class AdvisoryService {
         }
     }
 
-    private Collection<SbomGenerationRequest> processDockerBuilds(
+    @Transactional
+    protected Collection<SbomGenerationRequest> processDockerBuilds(
             RequestEvent requestEvent,
             Map<ProductVersionEntry, List<BuildItem>> buildDetails) {
 
@@ -198,7 +200,8 @@ public class AdvisoryService {
         return sbomRequests;
     }
 
-    private Collection<SbomGenerationRequest> processRPMBuilds(
+    @Transactional
+    protected Collection<SbomGenerationRequest> processRPMBuilds(
             RequestEvent requestEvent,
             Details details,
             ErrataProduct product,
@@ -258,7 +261,7 @@ public class AdvisoryService {
         return sbomRequests;
     }
 
-    public Long findErrataProductVersionIdByName(ErrataProduct product, String pVersionName) {
+    private Long findErrataProductVersionIdByName(ErrataProduct product, String pVersionName) {
         if (product != null && product.getData() != null && product.getData().getRelationships() != null) {
             return product.getData()
                     .getRelationships()

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildIT.java
@@ -129,6 +129,8 @@ class PncBuildIT {
         RequestEvent requestEvent = requestEvents.get(0);
         assertEquals(RequestEventType.UMB, requestEvent.getEventType());
 
+        // Refresh the request event because it was updated in its own transaction
+        requestEvent = RequestEvent.findById(requestEvent.getId());
         // Verify request config
         RequestConfig requestConfig = requestEvent.getRequestConfig();
         assertTrue(requestConfig instanceof PncBuildRequestConfig);
@@ -182,6 +184,8 @@ class PncBuildIT {
         assertEquals(1, requestEvents.size());
         RequestEvent requestEvent = requestEvents.get(0);
         assertEquals(RequestEventType.UMB, requestEvent.getEventType());
+        // Refresh the request event because it was updated in its own transaction
+        requestEvent = RequestEvent.findById(requestEvent.getId());
 
         // Verify request config
         RequestConfig requestConfig = requestEvent.getRequestConfig();


### PR DESCRIPTION
This replaces https://github.com/project-ncl/sbomer/pull/905

@goldmann The Transactional annotation was introduced to force the initialization of the AmqpMessageConsumer after the DB connection initialization. However, this has introduced as a side effect a timeout constraint of 60 seconds on the "processErrata" and "process" methods. For big advisories, more time will be definitely needed to complete the bootstrapping of all the generations. I would remove the annotations from the class altogether. Since we have now a readiness probe for the DB pool initialization, we should be ok.
I have used TxType.REQUIRES_NEW so to make sure that the RequestEvents are updated all the times, even if an outre transaction fails. This is to ensure we keep the audit of events on track.
