### PR TITLE
fix: make the JVM settings for generator static

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/GradleCycloneDxGenerateCommand.java
@@ -57,9 +57,9 @@ public class GradleCycloneDxGenerateCommand extends AbstractGradleGenerateComman
         environment.putAll(
                 Map.of(
                         "GRADLE_OPTS",
-                        "-XshowSettings:vm",
+                        "-XshowSettings:vm -XX:+PrintCommandLineFlags",
                         "JAVA_OPTS",
-                        "-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=50.0 -XX:+ExitOnOutOfMemoryError"));
+                        "-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"));
 
         ProcessRunner.run(environment, parent.getWorkdir(), command(buildCmdOptions));
 

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenCycloneDxGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/MavenCycloneDxGenerateCommand.java
@@ -47,9 +47,9 @@ public class MavenCycloneDxGenerateCommand extends AbstractMavenGenerateCommand 
         ProcessRunner.run(
                 Map.of(
                         "MAVEN_OPTS",
-                        "-XshowSettings:vm",
+                        "-XshowSettings:vm -XX:+PrintCommandLineFlags",
                         "JAVA_TOOL_OPTIONS",
-                        "-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=50.0 -XX:+ExitOnOutOfMemoryError"),
+                        "-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"),
                 parent.getWorkdir(),
                 command(buildCmdOptions));
 

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/generate/MavenDominoGenerator.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/generate/MavenDominoGenerator.java
@@ -126,9 +126,10 @@ public class MavenDominoGenerator implements SbomGenerator {
         cmd.addAll(
                 Arrays.asList(
                         dominoJava,
-                        "-XX:InitialRAMPercentage=50.0",
-                        "-XX:MaxRAMPercentage=50.0",
+                        "-XX:InitialRAMPercentage=75.0",
+                        "-XX:MaxRAMPercentage=75.0",
                         "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+PrintCommandLineFlags",
                         "-XshowSettings:vm",
                         // Workaround for Domino trying to parse what it shouldn't parse
                         "-Dquarkus.args=\"\"",

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/generate/MavenDominoGeneratorTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/generate/MavenDominoGeneratorTest.java
@@ -97,9 +97,10 @@ class MavenDominoGeneratorTest {
         assertEquals(
                 Arrays.asList(
                         "java",
-                        "-XX:InitialRAMPercentage=50.0",
-                        "-XX:MaxRAMPercentage=50.0",
+                        "-XX:InitialRAMPercentage=75.0",
+                        "-XX:MaxRAMPercentage=75.0",
                         "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+PrintCommandLineFlags",
                         "-XshowSettings:vm",
                         "-Dquarkus.args=\"\"",
                         "-jar",
@@ -125,9 +126,10 @@ class MavenDominoGeneratorTest {
         assertEquals(
                 Arrays.asList(
                         "java",
-                        "-XX:InitialRAMPercentage=50.0",
-                        "-XX:MaxRAMPercentage=50.0",
+                        "-XX:InitialRAMPercentage=75.0",
+                        "-XX:MaxRAMPercentage=75.0",
                         "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+PrintCommandLineFlags",
                         "-XshowSettings:vm",
                         "-Dquarkus.args=\"\"",
                         "-jar",
@@ -150,9 +152,10 @@ class MavenDominoGeneratorTest {
         assertEquals(
                 Arrays.asList(
                         "java",
-                        "-XX:InitialRAMPercentage=50.0",
-                        "-XX:MaxRAMPercentage=50.0",
+                        "-XX:InitialRAMPercentage=75.0",
+                        "-XX:MaxRAMPercentage=75.0",
                         "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+PrintCommandLineFlags",
                         "-XshowSettings:vm",
                         "-Dquarkus.args=\"\"",
                         "-jar",
@@ -176,9 +179,10 @@ class MavenDominoGeneratorTest {
         assertEquals(
                 Arrays.asList(
                         "java",
-                        "-XX:InitialRAMPercentage=50.0",
-                        "-XX:MaxRAMPercentage=50.0",
+                        "-XX:InitialRAMPercentage=75.0",
+                        "-XX:MaxRAMPercentage=75.0",
                         "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+PrintCommandLineFlags",
                         "-XshowSettings:vm",
                         "-Dquarkus.args=\"\"",
                         "-jar",

--- a/images/sbomer-generator/runtime/run.sh
+++ b/images/sbomer-generator/runtime/run.sh
@@ -113,7 +113,5 @@ source "${HOME}/env.sh"
 # See: https://issues.redhat.com/browse/SBOMER-69
 export DOMINO_JAVA_BIN="${HOME}/.sdkman/candidates/java/17/bin/java"
 
-jvm_params=( $SBOMER_JVM_PARAMS )
-
 echo "Running generation..."
-exec "${HOME}/.sdkman/candidates/java/17/bin/java" "${jvm_params}" -Duser.home=/workdir -jar /workdir/generator/quarkus-run.jar -v sbom auto generate --workdir /tmp/sbomer-workdir --config "${config_path}" --index "${index}"
+exec "${HOME}/.sdkman/candidates/java/17/bin/java" -XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=15.0 -XX:+ExitOnOutOfMemoryError -XX:+PrintCommandLineFlags -XshowSettings:vm -Duser.home=/workdir -jar /workdir/generator/quarkus-run.jar -v sbom auto generate --workdir /tmp/sbomer-workdir --config "${config_path}" --index "${index}"


### PR DESCRIPTION
These settings control only the SBOMer CLI that launches the generator. Generator itself has own set of resource limits.

Bump memory settings for Domino and CycloneDX plugins.