### PR TITLE
fix(SBOMER-244): use different subscription IDs across AZ to handle load in parallel

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ mp:
     incoming:
       errata:
         port: ${UMB_BROKER_PORT}
-        address: ${SBOMER_CONSUMER_ERRATA_TOPIC}
+        address: Consumer.sbomer-${SBOMER_DEPLOYMENT_TYPE}.sbomer-errata-${SBOMER_DEPLOYMENT_TARGET}-${SBOMER_DEPLOYMENT_ZONE}.${SBOMER_CONSUMER_ERRATA_TOPIC_SUFFIX}
         host: "${UMB_BROKER_HOST}"
         connector: smallrye-amqp
         enabled: ${sbomer.features.umb.enabled}
@@ -37,7 +37,7 @@ mp:
         failure-strategy: reject
       builds:
         port: ${UMB_BROKER_PORT}
-        address: ${SBOMER_CONSUMER_PNC_TOPIC}
+        address: Consumer.sbomer-${SBOMER_DEPLOYMENT_TYPE}.sbomer-pnc-${SBOMER_DEPLOYMENT_TARGET}-${SBOMER_DEPLOYMENT_ZONE}.${SBOMER_CONSUMER_PNC_TOPIC_SUFFIX}
         host: "${UMB_BROKER_HOST}"
         connector: smallrye-amqp
         enabled: ${sbomer.features.umb.enabled}


### PR DESCRIPTION
Different subscription IDs should make clients receive messages in parallel.