### PR TITLE
Upgrade domino to 0.0.117 that generates CycloneDX SBOMs using the 1.6 schema by default

### DIFF
--- a/core/src/main/resources/META-INF/sbomer-config.yaml
+++ b/core/src/main/resources/META-INF/sbomer-config.yaml
@@ -22,7 +22,7 @@ sbomer:
     default-generator: maven-cyclonedx
     generators:
       maven-domino:
-        default-version: "0.0.107"
+        default-version: "0.0.117"
         default-args: "--warn-on-missing-scm --legacy-scm-locator"
       maven-cyclonedx:
         default-version: "2.7.9"

--- a/docs/modules/user-guide/pages/generation/configuration/pnc-build.adoc
+++ b/docs/modules/user-guide/pages/generation/configuration/pnc-build.adoc
@@ -112,7 +112,7 @@ buildId: A7IGVJ7N2DYAA
 //     generator:
 //       type: maven-domino
 //       args: "--config-file .domino/cccddd.json --warn-on-missing-scm"
-//       version: "0.0.107"
+//       version: "0.0.117"
 
 //   - processors:
 //       - type: redhat-product

--- a/docs/modules/user-guide/pages/generation/generators/maven-domino.adoc
+++ b/docs/modules/user-guide/pages/generation/generators/maven-domino.adoc
@@ -28,7 +28,7 @@ Run the `java -jar domino.jar report --help` command to get a list of all possib
 
 === `version`
 
-Default version: `0.0.107`.
+Default version: `0.0.117`.
 
 == Execution
 
@@ -39,5 +39,13 @@ Below you can find the command that will be running the generator:
 $ java -jar domino.jar report --project-dir=[DIR] --output-file=[OUTPUT_DIR]/bom.json --manifest -s [PATH_TO_SETTINGS_XML_FILE] [ARGS]
 ----
 
+== CycloneDX Schema Version
 
+The default CycloneDX schema version for the generated SBOMs is 1.6. A different schema version can be requested by adding argument `--cdx-schema-version` with the desired value. For example
 
+[source,console]
+----
+java -jar domino.jar report --config-file quarkus-bom-config.json --manifest --legacy-scm-locator --output-file quarkus-bom-sbom.json --cdx-schema-version 1.4
+----
+
+will generate a CycloneDX SBOM using the schema version 1.4.

--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
@@ -130,7 +130,7 @@ public class GenerationsV1Beta1 {
                             @ExampleObject(
                                     name = "PNC build with one product defined and a custom generator",
                                     description = "Requests manifest generation for a PNC build with identifier: ARYT3LBXDVYAC with custom generator parameters",
-                                    value = "{\"type\": \"pnc-build\", \"buildId\": \"ARYT3LBXDVYAC\", \"products\":[{\"generator\":{\"type\":\"maven-domino\",\"args\":\"--warn-on-missing-scm --legacy-scm-locator\",\"version\":\"0.0.107\"}}]}"),
+                                    value = "{\"type\": \"pnc-build\", \"buildId\": \"ARYT3LBXDVYAC\", \"products\":[{\"generator\":{\"type\":\"maven-domino\",\"args\":\"--warn-on-missing-scm --legacy-scm-locator\",\"version\":\"0.0.117\"}}]}"),
                             @ExampleObject(
                                     name = "PNC operation",
                                     description = "Requests manifest generation for a PNC operation with identifier: A5WL3DFZ3AIAA",


### PR DESCRIPTION
This version generates SBOMs using the CycloneDX schema version 1.6 by default. But also introduces the `--cdx-schema-version` argument to request a different schema version.