### PR TITLE
fix(SBOMER-278): Fix typo

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
@@ -142,7 +142,7 @@ public class GenerationsV1Beta1 {
                             @ExampleObject(
                                     name = "Container image",
                                     description = "Requests manifest generation for a container image with iodentifier: registry.access.redhat.com/ubi9/ubi-micro:9.4",
-                                    value = "{\"type\": \"syft-image\", \"image\": \"registry.access.redhat.com/ubi9/ubi-micro:9.4\"}") //
+                                    value = "{\"type\": \"image\", \"image\": \"registry.access.redhat.com/ubi9/ubi-micro:9.4\"}") //
                     }))
     @APIResponse(
             responseCode = "202",


### PR DESCRIPTION
The payload is no longer `"type": "syft-image"`  