### PR TITLE
fix(SBOMER-142): Really add the NPM dependencies in Operation generation

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/WorkaroundMissingNpmDependencies.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/WorkaroundMissingNpmDependencies.java
@@ -1,0 +1,203 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.feature.sbom.processor;
+
+import com.github.packageurl.PackageURL;
+import lombok.extern.slf4j.Slf4j;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.BomReference;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Dependency;
+import org.cyclonedx.model.ExternalReference;
+import org.jboss.pnc.dto.Artifact;
+import org.jboss.pnc.dto.Build;
+import org.jboss.pnc.enums.BuildType;
+import org.jboss.sbomer.core.pnc.PncService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.jboss.sbomer.core.features.sbom.Constants.SBOM_RED_HAT_PNC_BUILD_ID;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createComponent;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createDependency;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getExternalReferences;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setArtifactMetadata;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPncBuildMetadata;
+
+/**
+ * Class for working around problem with missing NPM dependencies in manifest. For every component that was produced by
+ * a non-NPM PNC build, this class will look up that build's build time NPM dependencies. It will check if these
+ * dependencies are already present in the manifest and if not, it will add them as new components.
+ */
+@Slf4j
+public class WorkaroundMissingNpmDependencies {
+
+    private final PncService pncService;
+
+    // Map Build ID -> list of NPM dependencies of the build
+    // We will add these dependencies as new components
+    private final Map<String, List<Artifact>> buildsWithNpmDependencies = new HashMap<>();
+    // Map Build ID -> components that were built by the build
+    // These components will get new dependency components added to them
+    private final Map<String, List<Component>> componentsToAddNpmDependencies = new HashMap<>();
+    // Map PNC artifact -> the artifact transformed as a new manifest component
+    private final Map<Artifact, Component> newComponents = new HashMap<>();
+
+    public WorkaroundMissingNpmDependencies(PncService pncService) {
+        this.pncService = pncService;
+    }
+
+    public void analyzeBuild(Component component, Build build) {
+        if (build.getBuildConfigRevision().getBuildType() == BuildType.NPM) {
+            // Not processing pure NPM builds, cyclonedx-nodejs plugin handles them correctly
+            return;
+        }
+        String buildId = build.getId();
+        List<Artifact> npmDependencies = buildsWithNpmDependencies.get(buildId);
+        if (npmDependencies == null) {
+            npmDependencies = new ArrayList<>(pncService.getNPMDependencies(buildId));
+            buildsWithNpmDependencies.put(buildId, npmDependencies);
+        }
+        if (npmDependencies.isEmpty()) {
+            // No NPM dependencies to add
+            return;
+        }
+        List<Component> components = componentsToAddNpmDependencies.computeIfAbsent(buildId, k -> new ArrayList<>());
+        components.add(component);
+    }
+
+    public void analyzeComponentsBuild(Component component) {
+        List<ExternalReference> externalReferences = getExternalReferences(
+                component,
+                ExternalReference.Type.BUILD_SYSTEM,
+                SBOM_RED_HAT_PNC_BUILD_ID);
+        if (externalReferences.isEmpty()) {
+            // Not a PNC build
+            return;
+        }
+        if (externalReferences.size() > 1) {
+            log.warn(
+                    "Component {} has more than one {}/{} external reference",
+                    component.getPurl(),
+                    ExternalReference.Type.BUILD_SYSTEM,
+                    SBOM_RED_HAT_PNC_BUILD_ID);
+            return;
+        }
+        String buildID = parseBuildIdFromURL(externalReferences.get(0).getUrl());
+        if (buildID == null) {
+            log.warn("Could not parse PNC build ID from url {}", externalReferences.get(0).getUrl());
+            return;
+        }
+        Build build = pncService.getBuild(buildID);
+        if (build == null) {
+            log.warn("Could not obtain PNC build for build id {}", buildID);
+            return;
+        }
+        analyzeBuild(component, build);
+    }
+
+    public void addMissingDependencies(Bom bom) {
+        filterOutAlreadyPresentDependencies(bom);
+        generateNewComponents(bom);
+        addDependencies(bom);
+    }
+
+    private void filterOutAlreadyPresentDependencies(Bom bom) {
+        if (bom.getComponents() == null) {
+            return;
+        }
+        Set<String> listedPurls = bom.getComponents()
+                .stream()
+                .map(DefaultProcessor::getPackageURL)
+                .map(PackageURL::getCoordinates)
+                .collect(Collectors.toSet());
+
+        Iterator<Map.Entry<String, List<Artifact>>> it = buildsWithNpmDependencies.entrySet().iterator();
+
+        while (it.hasNext()) {
+            Map.Entry<String, List<Artifact>> entry = it.next();
+            List<Artifact> missingArtifacts = entry.getValue();
+            missingArtifacts.removeIf(a -> listedPurls.contains(a.getPurl()));
+            if (missingArtifacts.isEmpty()) {
+                it.remove();
+                componentsToAddNpmDependencies.remove(entry.getKey());
+            }
+        }
+    }
+
+    private void generateNewComponents(Bom bom) {
+        Set<Artifact> artifacts = new HashSet<>();
+        buildsWithNpmDependencies.values().forEach(artifacts::addAll);
+
+        for (Artifact artifact : artifacts) {
+            Component newComponent = createComponent(artifact, Component.Scope.REQUIRED, Component.Type.LIBRARY);
+            setArtifactMetadata(newComponent, artifact, pncService.getApiUrl());
+            setPncBuildMetadata(newComponent, artifact.getBuild(), pncService.getApiUrl());
+            bom.addComponent(newComponent);
+            newComponents.put(artifact, newComponent);
+            log.debug("Created new component {} from NPM dependency.", newComponent.getPurl());
+        }
+    }
+
+    private void addDependencies(Bom bom) {
+        Map<String, Dependency> bomDependencies;
+        if (bom.getDependencies() == null) {
+            bomDependencies = new HashMap<>();
+        } else {
+            bomDependencies = bom.getDependencies().stream().collect(Collectors.toMap(BomReference::getRef, c -> c));
+        }
+
+        for (Map.Entry<String, List<Artifact>> e : buildsWithNpmDependencies.entrySet()) {
+            String buildId = e.getKey();
+            List<Artifact> npmDependencies = e.getValue();
+
+            for (Component dependant : componentsToAddNpmDependencies.get(buildId)) {
+                Dependency bomDependant = bomDependencies
+                        .computeIfAbsent(dependant.getBomRef(), ref -> addNewDependency(bom, ref));
+
+                for (Artifact npmDependency : npmDependencies) {
+                    String bomRef = newComponents.get(npmDependency).getBomRef();
+                    Dependency bomDependency = bomDependencies
+                            .computeIfAbsent(bomRef, ref -> addNewDependency(bom, ref));
+                    bomDependant.addDependency(bomDependency);
+                }
+            }
+        }
+    }
+
+    public static Dependency addNewDependency(Bom bom, String bomRef) {
+        Dependency dependency = createDependency(bomRef);
+        bom.addDependency(dependency);
+        return dependency;
+    }
+
+    private static String parseBuildIdFromURL(String buildURL) {
+        int lastSlashIndex = buildURL.lastIndexOf('/');
+        if (lastSlashIndex != -1) {
+            return buildURL.substring(lastSlashIndex + 1);
+        } else {
+            return null;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/KojiService.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/service/KojiService.java
@@ -242,6 +242,19 @@ public class KojiService {
         return buildInfo;
     }
 
+    public KojiBuildInfo findBuild(int id) throws KojiClientException {
+        log.debug("Retrieving Brew build with id '{}'...", id);
+
+        KojiBuildInfo build = kojiSession.getBuild(id);
+
+        if (build == null) {
+            log.warn("Build with id {} not found", id);
+            return null;
+        }
+
+        return build;
+    }
+
     public KojiBuildInfo findBuild(String nvr) throws KojiClientException {
         if (nvr == null) {
             return null;

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/DefaultProcessorTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/DefaultProcessorTest.java
@@ -164,27 +164,6 @@ public class DefaultProcessorTest {
         verifyAddedNpmDependencies(processed);
     }
 
-    @Test
-    void testAddMissingNpmDependenciesToOperation() throws IOException {
-        DefaultProcessor defaultProcessor = mockForAddMissingNpmDependencies();
-
-        // With
-        Bom bom = SbomUtils.fromString(TestResources.asString("boms/operation.json"));
-        Optional<Component> missingComponent = getComponent(bom, "pkg:npm/once@1.4.0");
-        Optional<Dependency> missingDependency = getDependency("pkg:npm/once@1.4.0", bom.getDependencies());
-
-        assertTrue(missingComponent.isEmpty());
-        assertTrue(missingDependency.isEmpty());
-        assertEquals(3, bom.getComponents().size());
-
-        // When
-        Bom processed = defaultProcessor.process(bom);
-
-        // Then
-        assertEquals(5, processed.getComponents().size());
-        verifyAddedNpmDependencies(processed);
-    }
-
     private static DefaultProcessor mockForAddMissingNpmDependencies() throws IOException {
         PncService pncServiceMock = Mockito.mock(PncService.class);
         KojiService kojiServiceMock = Mockito.mock(KojiService.class);

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/WorkaroundMissingNpmDependenciesTest.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/unit/feature/sbom/WorkaroundMissingNpmDependenciesTest.java
@@ -1,0 +1,263 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.cli.test.unit.feature.sbom;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Dependency;
+import org.jboss.pnc.dto.Artifact;
+import org.jboss.pnc.dto.Build;
+import org.jboss.sbomer.cli.feature.sbom.processor.WorkaroundMissingNpmDependencies;
+import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
+import org.jboss.sbomer.core.features.sbom.utils.SbomUtils;
+import org.jboss.sbomer.core.pnc.PncService;
+import org.jboss.sbomer.core.test.TestResources;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WorkaroundMissingNpmDependenciesTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperProvider.json();
+
+    @Test
+    public void testNpmDependencyAdded() throws IOException {
+        // Mock PNC service
+        PncService pncServiceMock = Mockito.mock(PncService.class);
+        Build pncBuild = OBJECT_MAPPER.readValue(TestResources.asString("pnc/mavenBuild.json"), Build.class);
+        List<Artifact> artifacts = OBJECT_MAPPER
+                .readValue(TestResources.asString("pnc/npmDependencies.json"), new TypeReference<>() {
+                });
+        when(pncServiceMock.getBuild(eq("FOOBAR012345"))).thenReturn(pncBuild);
+        when(pncServiceMock.getNPMDependencies(eq("FOOBAR012345"))).thenReturn(artifacts);
+
+        // Prepare test component
+        Bom bom = Objects.requireNonNull(SbomUtils.createBom());
+        Component component1 = SbomUtils.createComponent(
+                "foo.bar",
+                "baz",
+                "1.0.0.redhat-00001",
+                "Test project",
+                "pkg:maven/foo.bar/baz@1.0.0.redhat-00001?type=jar",
+                Component.Type.LIBRARY);
+        bom.addComponent(component1);
+        bom.addDependency(SbomUtils.createDependency(component1.getBomRef()));
+        SbomUtils.setPncBuildMetadata(component1, pncBuild, "pnc.example.com");
+
+        Component component2 = SbomUtils.createComponent(
+                "foo.bar",
+                "qux",
+                "1.0.0.redhat-00001",
+                "Test project",
+                "pkg:maven/foo.bar/qux@1.0.0.redhat-00001?type=jar",
+                Component.Type.LIBRARY);
+        bom.addComponent(component2);
+        bom.addDependency(SbomUtils.createDependency(component2.getBomRef()));
+        SbomUtils.setPncBuildMetadata(component2, pncBuild, "pnc.example.com");
+
+        // Check assertions before test
+        assertEquals(2, bom.getComponents().size());
+        assertEquals(2, bom.getDependencies().size());
+
+        // Run test
+        WorkaroundMissingNpmDependencies workaround = new WorkaroundMissingNpmDependencies(pncServiceMock);
+        workaround.analyzeComponentsBuild(component1);
+        workaround.analyzeComponentsBuild(component2);
+        workaround.addMissingDependencies(bom);
+
+        // Verify after test
+        assertEquals(4, bom.getComponents().size());
+        assertEquals(4, bom.getDependencies().size());
+
+        Dependency dependency1 = getDependency(component1.getBomRef(), bom.getDependencies()).orElseThrow();
+        Dependency dependency2 = getDependency(component2.getBomRef(), bom.getDependencies()).orElseThrow();
+        assertEquals(2, dependency1.getDependencies().size());
+        assertEquals(2, dependency2.getDependencies().size());
+        assertEquals(dependency1.getDependencies(), dependency2.getDependencies());
+
+        assertTrue(getDependency("pkg:npm/once@1.4.0", bom.getDependencies()).isPresent());
+        assertTrue(getDependency("pkg:npm/once@1.4.0", dependency1.getDependencies()).isPresent());
+        assertTrue(getDependency("pkg:npm/once@1.4.0", dependency2.getDependencies()).isPresent());
+
+        assertTrue(
+                getDependency("pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2", bom.getDependencies())
+                        .isPresent());
+        assertTrue(
+                getDependency(
+                        "pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2",
+                        dependency1.getDependencies()).isPresent());
+        assertTrue(
+                getDependency(
+                        "pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2",
+                        dependency2.getDependencies()).isPresent());
+    }
+
+    @Test
+    public void testSkipExistingComponent() throws IOException {
+        // Mock PNC service
+        PncService pncServiceMock = Mockito.mock(PncService.class);
+        Build pncBuild = OBJECT_MAPPER.readValue(TestResources.asString("pnc/mavenBuild.json"), Build.class);
+        List<Artifact> artifacts = OBJECT_MAPPER
+                .readValue(TestResources.asString("pnc/npmDependencies.json"), new TypeReference<>() {
+                });
+        when(pncServiceMock.getBuild(eq("FOOBAR012345"))).thenReturn(pncBuild);
+        when(pncServiceMock.getNPMDependencies(eq("FOOBAR012345"))).thenReturn(artifacts);
+
+        // Prepare test component
+        Bom bom = Objects.requireNonNull(SbomUtils.createBom());
+        Component component1 = SbomUtils.createComponent(
+                "foo.bar",
+                "baz",
+                "1.0.0.redhat-00001",
+                "Test project",
+                "pkg:maven/foo.bar/baz@1.0.0.redhat-00001?type=jar",
+                Component.Type.LIBRARY);
+        bom.addComponent(component1);
+        bom.addDependency(SbomUtils.createDependency(component1.getBomRef()));
+        SbomUtils.setPncBuildMetadata(component1, pncBuild, "pnc.example.com");
+
+        Component component2 = SbomUtils
+                .createComponent(null, "once", "1.4.0", null, "pkg:npm/once@1.4.0", Component.Type.LIBRARY);
+        bom.addComponent(component2);
+        bom.addDependency(SbomUtils.createDependency(component2.getBomRef()));
+
+        // Check assertions before test
+        assertEquals(2, bom.getComponents().size());
+        assertEquals(2, bom.getDependencies().size());
+
+        // Run test
+        WorkaroundMissingNpmDependencies workaround = new WorkaroundMissingNpmDependencies(pncServiceMock);
+        workaround.analyzeComponentsBuild(component1);
+        workaround.analyzeComponentsBuild(component2);
+        workaround.addMissingDependencies(bom);
+
+        // Verify after test
+        assertEquals(3, bom.getComponents().size());
+        assertEquals(3, bom.getDependencies().size());
+
+        Dependency dependency1 = getDependency(component1.getBomRef(), bom.getDependencies()).orElseThrow();
+        Dependency dependency2 = getDependency(component2.getBomRef(), bom.getDependencies()).orElseThrow();
+        assertEquals(1, dependency1.getDependencies().size());
+        assertNull(dependency2.getDependencies());
+
+        assertTrue(
+                getDependency("pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2", bom.getDependencies())
+                        .isPresent());
+        assertTrue(
+                getDependency(
+                        "pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2",
+                        dependency1.getDependencies()).isPresent());
+
+        verify(pncServiceMock, times(1)).getNPMDependencies(eq("FOOBAR012345"));
+    }
+
+    @Test
+    public void testOverlappingBuilds() throws IOException {
+        // Mock PNC service
+        PncService pncServiceMock = Mockito.mock(PncService.class);
+        Build pncBuild1 = OBJECT_MAPPER.readValue(TestResources.asString("pnc/mavenBuild.json"), Build.class);
+        List<Artifact> artifacts1 = OBJECT_MAPPER
+                .readValue(TestResources.asString("pnc/npmDependencies.json"), new TypeReference<>() {
+                });
+        Build pncBuild2 = OBJECT_MAPPER.readValue(TestResources.asString("pnc/mavenBuild2.json"), Build.class);
+        List<Artifact> artifacts2 = OBJECT_MAPPER
+                .readValue(TestResources.asString("pnc/npmDependencies2.json"), new TypeReference<>() {
+                });
+        when(pncServiceMock.getBuild(eq("FOOBAR012345"))).thenReturn(pncBuild1);
+        when(pncServiceMock.getNPMDependencies(eq("FOOBAR012345"))).thenReturn(artifacts1);
+        when(pncServiceMock.getBuild(eq("FOOBAZ012345"))).thenReturn(pncBuild2);
+        when(pncServiceMock.getNPMDependencies(eq("FOOBAZ012345"))).thenReturn(artifacts2);
+
+        // Prepare test component
+        Bom bom = Objects.requireNonNull(SbomUtils.createBom());
+        Component component1 = SbomUtils.createComponent(
+                "foo.bar",
+                "baz",
+                "1.0.0.redhat-00001",
+                "Test project",
+                "pkg:maven/foo.bar/baz@1.0.0.redhat-00001?type=jar",
+                Component.Type.LIBRARY);
+        bom.addComponent(component1);
+        bom.addDependency(SbomUtils.createDependency(component1.getBomRef()));
+        SbomUtils.setPncBuildMetadata(component1, pncBuild1, "pnc.example.com");
+        Component component2 = SbomUtils.createComponent(
+                "foo.bar",
+                "qux",
+                "1.0.0.redhat-00001",
+                "Test project",
+                "pkg:maven/foo.bar/qux@1.0.0.redhat-00001?type=jar",
+                Component.Type.LIBRARY);
+        bom.addComponent(component2);
+        bom.addDependency(SbomUtils.createDependency(component2.getBomRef()));
+        SbomUtils.setPncBuildMetadata(component2, pncBuild2, "pnc.example.com");
+
+        // Check assertions before test
+        assertEquals(2, bom.getComponents().size());
+        assertEquals(2, bom.getDependencies().size());
+
+        // Run test
+        WorkaroundMissingNpmDependencies workaround = new WorkaroundMissingNpmDependencies(pncServiceMock);
+        workaround.analyzeComponentsBuild(component1);
+        workaround.analyzeComponentsBuild(component2);
+        workaround.addMissingDependencies(bom);
+
+        // Verify after test
+        assertEquals(5, bom.getComponents().size());
+        assertEquals(5, bom.getDependencies().size());
+
+        Dependency dependency1 = getDependency(component1.getBomRef(), bom.getDependencies()).orElseThrow();
+        Dependency dependency2 = getDependency(component2.getBomRef(), bom.getDependencies()).orElseThrow();
+        assertEquals(2, dependency1.getDependencies().size());
+        assertEquals(2, dependency2.getDependencies().size());
+        assertNotEquals(dependency1.getDependencies(), dependency2.getDependencies());
+
+        assertTrue(getDependency("pkg:npm/once@1.4.0", bom.getDependencies()).isPresent());
+        assertTrue(getDependency("pkg:npm/once@1.4.0", dependency1.getDependencies()).isPresent());
+        assertTrue(getDependency("pkg:npm/once@1.4.0", dependency2.getDependencies()).isPresent());
+
+        assertTrue(
+                getDependency("pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2", bom.getDependencies())
+                        .isPresent());
+        assertTrue(
+                getDependency(
+                        "pkg:npm/%40redhat/kogito-tooling-keyboard-shortcuts@0.9.0-2",
+                        dependency1.getDependencies()).isPresent());
+
+        assertTrue(getDependency("pkg:npm/twice@1.4.0", bom.getDependencies()).isPresent());
+        assertTrue(getDependency("pkg:npm/twice@1.4.0", dependency2.getDependencies()).isPresent());
+    }
+
+    private static Optional<Dependency> getDependency(String ref, List<Dependency> dependencies) {
+        return dependencies.stream().filter(d -> d.getRef().equals(ref)).findFirst();
+    }
+}

--- a/cli/src/test/resources/pnc/mavenBuild.json
+++ b/cli/src/test/resources/pnc/mavenBuild.json
@@ -1,0 +1,79 @@
+{
+  "id": "FOOBAR012345",
+  "submitTime": "2021-06-02T13:43:32.482Z",
+  "startTime": "2021-06-02T13:43:32.488Z",
+  "endTime": "2021-06-02T14:29:53.043Z",
+  "progress": "FINISHED",
+  "status": "SUCCESS",
+  "buildContentId": "build-FOOBAR012345",
+  "temporaryBuild": false,
+  "alignmentPreference": null,
+  "scmUrl": "http://git.example.com/gerrit/kiegroup/kogito-tooling.git",
+  "scmRevision": "88c1a77824c7bf0b636f24b4bde2b87c0b38d8a1",
+  "scmTag": "0.9.0",
+  "buildOutputChecksum": "5ac8ad0ab9b907d4280533bc1b9def22",
+  "lastUpdateTime": "2021-06-02T14:29:53.043Z",
+  "scmBuildConfigRevision": null,
+  "scmBuildConfigRevisionInternal": null,
+  "project": {
+    "id": "937",
+    "name": "kiegroup/kogito-tooling",
+    "description": null,
+    "issueTrackerUrl": null,
+    "projectUrl": null,
+    "engineeringTeam": null,
+    "technicalLeader": null
+  },
+  "scmRepository": {
+    "id": "953",
+    "internalUrl": "git@git.example.com:pnc-workspace/kiegroup/kogito-tooling.git",
+    "externalUrl": "https://github.com/kiegroup/kogito-tooling.git",
+    "preBuildSyncEnabled": true
+  },
+  "environment": {
+    "id": "107",
+    "name": "NodeJS 12; NPM 6; Git 2.24.1",
+    "description": "NodeJS 12; NPM 6; Git 2.24.1 [builder-rhel-7-nodejs12-git-2.24.1:1.0.2]",
+    "systemImageRepositoryUrl": "quay.io/rh-newcastle",
+    "systemImageId": "builder-rhel-7-nodejs12-git-2.24.1:1.0.2",
+    "attributes": {
+      "OS": "Linux",
+      "NPM": "6",
+      "Nodejs": "12"
+    },
+    "systemImageType": "DOCKER_IMAGE",
+    "deprecated": false,
+    "hidden": false
+  },
+  "attributes": {
+    "BREW_BUILD_VERSION": "0.0.0",
+    "BREW_BUILD_NAME": "kogito-tooling",
+    "BUILD_ARCHIVED": "true",
+    "BUILD_OUTPUT_OK": "true"
+  },
+  "user": {
+    "id": "189",
+    "username": "emingora"
+  },
+  "buildConfigRevision": {
+    "id": "5405",
+    "rev": 2543874,
+    "name": "org.kie.kogito-tooling-0.9.0-DR1",
+    "buildScript": "npm deploy",
+    "scmRevision": "0.9.0",
+    "creationTime": "2021-04-23T05:34:19.106Z",
+    "modificationTime": "2021-06-02T13:42:22.052Z",
+    "buildType": "MVN",
+    "defaultAlignmentParams": "-DversioningStrategy=HYPHENED -DversionIncrementalSuffix=redhat",
+    "brewPullActive": true
+  },
+  "productMilestone": {
+    "id": "1160",
+    "version": "0.9.0",
+    "endDate": null,
+    "startingDate": "2021-03-31T12:00:00Z",
+    "plannedEndDate": "2021-04-29T12:00:00Z"
+  },
+  "groupBuild": null,
+  "noRebuildCause": null
+}

--- a/cli/src/test/resources/pnc/mavenBuild2.json
+++ b/cli/src/test/resources/pnc/mavenBuild2.json
@@ -1,0 +1,79 @@
+{
+  "id": "FOOBAZ012345",
+  "submitTime": "2021-06-02T13:43:32.482Z",
+  "startTime": "2021-06-02T13:43:32.488Z",
+  "endTime": "2021-06-02T14:29:53.043Z",
+  "progress": "FINISHED",
+  "status": "SUCCESS",
+  "buildContentId": "build-FOOBAZ012345",
+  "temporaryBuild": false,
+  "alignmentPreference": null,
+  "scmUrl": "http://git.example.com/gerrit/kiegroup/kogito-tooling.git",
+  "scmRevision": "88c1a77824c7bf0b636f24b4bde2b87c0b38d8a1",
+  "scmTag": "0.9.0",
+  "buildOutputChecksum": "5ac8ad0ab9b907d4280533bc1b9def22",
+  "lastUpdateTime": "2021-06-02T14:29:53.043Z",
+  "scmBuildConfigRevision": null,
+  "scmBuildConfigRevisionInternal": null,
+  "project": {
+    "id": "937",
+    "name": "kiegroup/kogito-tooling",
+    "description": null,
+    "issueTrackerUrl": null,
+    "projectUrl": null,
+    "engineeringTeam": null,
+    "technicalLeader": null
+  },
+  "scmRepository": {
+    "id": "953",
+    "internalUrl": "git@git.example.com:pnc-workspace/kiegroup/kogito-tooling.git",
+    "externalUrl": "https://github.com/kiegroup/kogito-tooling.git",
+    "preBuildSyncEnabled": true
+  },
+  "environment": {
+    "id": "107",
+    "name": "NodeJS 12; NPM 6; Git 2.24.1",
+    "description": "NodeJS 12; NPM 6; Git 2.24.1 [builder-rhel-7-nodejs12-git-2.24.1:1.0.2]",
+    "systemImageRepositoryUrl": "quay.io/rh-newcastle",
+    "systemImageId": "builder-rhel-7-nodejs12-git-2.24.1:1.0.2",
+    "attributes": {
+      "OS": "Linux",
+      "NPM": "6",
+      "Nodejs": "12"
+    },
+    "systemImageType": "DOCKER_IMAGE",
+    "deprecated": false,
+    "hidden": false
+  },
+  "attributes": {
+    "BREW_BUILD_VERSION": "0.0.0",
+    "BREW_BUILD_NAME": "kogito-tooling",
+    "BUILD_ARCHIVED": "true",
+    "BUILD_OUTPUT_OK": "true"
+  },
+  "user": {
+    "id": "189",
+    "username": "emingora"
+  },
+  "buildConfigRevision": {
+    "id": "5405",
+    "rev": 2543874,
+    "name": "org.kie.kogito-tooling-0.9.0-DR1",
+    "buildScript": "npm deploy",
+    "scmRevision": "0.9.0",
+    "creationTime": "2021-04-23T05:34:19.106Z",
+    "modificationTime": "2021-06-02T13:42:22.052Z",
+    "buildType": "MVN",
+    "defaultAlignmentParams": "-DversioningStrategy=HYPHENED -DversionIncrementalSuffix=redhat",
+    "brewPullActive": true
+  },
+  "productMilestone": {
+    "id": "1160",
+    "version": "0.9.0",
+    "endDate": null,
+    "startingDate": "2021-03-31T12:00:00Z",
+    "plannedEndDate": "2021-04-29T12:00:00Z"
+  },
+  "groupBuild": null,
+  "noRebuildCause": null
+}

--- a/cli/src/test/resources/pnc/npmDependencies2.json
+++ b/cli/src/test/resources/pnc/npmDependencies2.json
@@ -1,0 +1,61 @@
+[
+    {
+        "id": "2160610",
+        "identifier": "once:1.4.0",
+        "purl": "pkg:npm/once@1.4.0",
+        "artifactQuality": "IMPORTED",
+        "buildCategory": "STANDARD",
+        "md5": "fac2afc3cbe5e133d7a5c34ec3f862ac",
+        "sha1": "583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf",
+        "filename": "once-1.4.0.tgz",
+        "deployPath": "/once/-/once-1.4.0.tgz",
+        "importDate": "2019-09-11T06:50:45.947Z",
+        "originUrl": "https://repository.example.com/nexus/repository/registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "size": 1979,
+        "deployUrl": "https://indy-gateway.example.com/api/content/npm/hosted/shared-imports/once/-/once-1.4.0.tgz",
+        "publicUrl": "https://indy.example.com/api/content/npm/hosted/shared-imports/once/-/once-1.4.0.tgz",
+        "creationTime": null,
+        "modificationTime": null,
+        "qualityLevelReason": null,
+        "targetRepository": {
+            "id": "17150",
+            "temporaryRepo": false,
+            "identifier": "indy-npm",
+            "repositoryType": "NPM",
+            "repositoryPath": "/api/content/npm/hosted/shared-imports/"
+        },
+        "build": null,
+        "creationUser": null,
+        "modificationUser": null
+    },{
+        "id": "2160611",
+        "identifier": "twice:1.4.0",
+        "purl": "pkg:npm/twice@1.4.0",
+        "artifactQuality": "IMPORTED",
+        "buildCategory": "STANDARD",
+        "md5": "123456789be5e133d7a5c34ec3f862ac",
+        "sha1": "1234567985961d4b113ac17d9c50baef9dd76bd1",
+        "sha256": "123456789370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf",
+        "filename": "twice-1.4.0.tgz",
+        "deployPath": "/twice/-/twice-1.4.0.tgz",
+        "importDate": "2019-09-11T06:50:45.947Z",
+        "originUrl": "https://repository.example.com/nexus/repository/registry.npmjs.org/twice/-/twice-1.4.0.tgz",
+        "size": 1979,
+        "deployUrl": "https://indy-gateway.example.com/api/content/npm/hosted/shared-imports/twice/-/twice-1.4.0.tgz",
+        "publicUrl": "https://indy.example.com/api/content/npm/hosted/shared-imports/twice/-/twice-1.4.0.tgz",
+        "creationTime": null,
+        "modificationTime": null,
+        "qualityLevelReason": null,
+        "targetRepository": {
+            "id": "17150",
+            "temporaryRepo": false,
+            "identifier": "indy-npm",
+            "repositoryType": "NPM",
+            "repositoryPath": "/api/content/npm/hosted/shared-imports/"
+        },
+        "build": null,
+        "creationUser": null,
+        "modificationUser": null
+    }
+]


### PR DESCRIPTION
The operation generation actually doesn't use the Processor where the
addition was taking place previously. This moves it to
CycloneDxGenerateOperationCommand directly.

Also this implementaion doesn't query PNC multiple times for the same
build. And it will not repeat same dependnecy if it comes from multiple
builds.


+ refactor: simplify and optimize component creation for OperationCommand