### PR TITLE
test: Additional E2E tests for skinny image manifest type

### DIFF
--- a/e2e/src/test/resources/requests/skinny-manifest-images.json
+++ b/e2e/src/test/resources/requests/skinny-manifest-images.json
@@ -1,0 +1,12 @@
+[
+{
+    "apiVersion": "sbomer.jboss.org/v1alpha1",
+    "type": "image",
+    "image": "registry.redhat.io/openshift4/ose-egress-http-proxy@sha256:ce1e5acecb4dfa89d2b3a4ed97faa84dfbeecc115083c8f0017b4fb89fc6e400"
+},
+{
+    "apiVersion": "sbomer.jboss.org/v1alpha1",
+    "type": "image",
+    "image": "registry.redhat.io/openshift4/oc-mirror-plugin-rhel8@sha256:80acc20087bec702fcb2624345f3dda071cd78092e5d3c972d75615b837549de"
+}
+]


### PR DESCRIPTION
This PR adds an additional two images to check with E2E tests, the test input json is now an array as opposed to multiple payloads in separate files.

This test would of originally failing due to alternative image manifest types (non-fat manifest) not being handled by the tekton inspect tasks, this simply tests for regression.

What I'm not sure on 

- If we actually need two additional image? 
  - These where the original generations in the bug 
  - There is also additional images that where used during testing but removed (internal url references), these fail later for a different reason
- If we only have one image to test is it worth keeping the `@ParameterizedTest`? The only advantage I can think of is if we find something similar in future and a list of images is easier