### PR TITLE
test: Correct assertion and fix logging output

### DIFF
--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/ContainerImageGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/ContainerImageGenerationRequestIT.java
@@ -18,6 +18,7 @@
 package org.jboss.sbomer.test.e2e.rw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -114,12 +115,11 @@ class ContainerImageGenerationRequestIT extends E2EStageBase {
                 "{} container image - Generation Request created: {}",
                 requestBody.getValue("/image").toString(),
                 generationId);
+
         waitForGeneration(generationId);
 
         final Response response = getManifestsForGeneration(generationId);
-
-        assertEquals(3, response.body().jsonPath().getInt("totalHits"));
-
-        log.info("{} container image passed", requestBody.getValue("image"));
+        assertTrue((response.body().jsonPath().getInt("totalHits") > 0));
+        log.info("{} container image passed", requestBody.getValue("/image"));
     }
 }


### PR DESCRIPTION
Fixes previous skinnyManifest E2E tests

* Rather than verifiy each generates N manifests, check that there is more than zero
* Fix json path for logging