### PR TITLE
fix: improve generation of S3 ID

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/s3/S3ClientFacade.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/s3/S3ClientFacade.java
@@ -174,12 +174,12 @@ public class S3ClientFacade {
         }
     }
 
-    public void upload(String path, String key) {
+    public void upload(Path path, String key) {
         log.debug("Uploading '{}' file as '{}'...", path, key);
 
         try {
             PutObjectRequest request = PutObjectRequest.builder().key(key).bucket(bucketName()).build();
-            client.putObject(request, Path.of(path));
+            client.putObject(request, path);
         } catch (SdkException e) {
             throw new ApplicationException("An error occurred when uploading '{}' file to S3", path, e);
         }

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureTest.java
@@ -123,19 +123,19 @@ class S3FeatureTest {
         Path logFile = logsDir.resolve("init.log");
         Files.write(logFile, "Some log".getBytes());
 
-        // doNothing().when(clientFacade).upload(file.toFile().getAbsolutePath(),
+        // doNothing().when(clientFacade).upload(file.toAbsolutePath(),
         // "bucket-name/bucket-name/bom.json");
         when(clientFacade.doesObjectExists("AABBCC/bom.json")).thenReturn(false);
         when(clientFacade.doesObjectExists("AABBCC/logs/init.log")).thenReturn(true);
-        doNothing().when(clientFacade).upload(file.toFile().getAbsolutePath(), "AABBCC/bom.json");
-        doNothing().when(clientFacade).upload(logFile.toFile().getAbsolutePath(), "AABBCC/logs/init.log");
+        doNothing().when(clientFacade).upload(file.toAbsolutePath(), "AABBCC/bom.json");
+        doNothing().when(clientFacade).upload(logFile.toAbsolutePath(), "AABBCC/logs/init.log");
 
         storageHandler.storeFiles(generationRequest);
 
         verify(clientFacade, times(1)).doesObjectExists("AABBCC/bom.json");
-        verify(clientFacade, times(1)).upload(file.toFile().getAbsolutePath(), "AABBCC/bom.json");
+        verify(clientFacade, times(1)).upload(file.toAbsolutePath(), "AABBCC/bom.json");
         verify(clientFacade, times(1)).doesObjectExists("AABBCC/logs/init.log");
-        verify(clientFacade, times(0)).upload(logFile.toFile().getAbsolutePath(), "AABBCC/logs/init.log");
+        verify(clientFacade, times(0)).upload(logFile.toAbsolutePath(), "AABBCC/logs/init.log");
     }
 
     @Test


### PR DESCRIPTION
Avoid converting `Path` to/from `String` and `Path` to `File` by using `Path` everywhere. Avoid using regex replacement to create the ID by using the path name directly.