### PR TITLE
feat(SBOMER-341): add select and search bar for manifests page

### DIFF
--- a/ui/src/app/api/DefaultSbomerApi.ts
+++ b/ui/src/app/api/DefaultSbomerApi.ts
@@ -17,7 +17,7 @@
 ///
 
 import axios, { Axios, AxiosError } from 'axios';
-import { SbomerApi, SbomerGeneration, SbomerManifest, SbomerStats, SbomerRequest, SbomerRequestManifest } from '../types';
+import { SbomerApi, SbomerGeneration, SbomerManifest, SbomerRequest, SbomerRequestManifest, SbomerStats } from '../types';
 
 type Options = {
   baseUrl: string;
@@ -67,9 +67,20 @@ export class DefaultSbomerApi implements SbomerApi {
     );
   }
 
-  async getManifests(pagination: { pageSize: number; pageIndex: number }): Promise<{ data: SbomerManifest[]; total: number }> {
+  async getManifests(pagination: { pageSize: number; pageIndex: number ;},  queryOption: string, query: string): Promise<{ data: SbomerManifest[]; total: number }> {
+    let queryPrefix = ''
+    switch(queryOption){
+      case 'Purl':
+        queryPrefix = 'rootPurl'
+        break;
+      default:
+        queryPrefix = ''
+    }
+
+    const queryFullString = queryPrefix == '' ? '' : `${queryPrefix}=eq='${query}'`
+
     const response = await fetch(
-      `${this.baseUrl}/api/v1beta1/manifests?pageSize=${pagination.pageSize}&pageIndex=${pagination.pageIndex}`,
+      `${this.baseUrl}/api/v1beta1/manifests?query=${encodeURIComponent(queryFullString)}&pageSize=${pagination.pageSize}&pageIndex=${pagination.pageIndex}`,
     );
 
     if (response.status != 200) {

--- a/ui/src/app/components/ManifestsTableTable/useSboms.ts
+++ b/ui/src/app/components/ManifestsTableTable/useSboms.ts
@@ -25,16 +25,18 @@ export function useManifests(initialPage: number, intialPageSize: number) {
   const [total, setTotal] = useState(0);
   const [pageIndex, setPageIndex] = useState(initialPage || 0);
   const [pageSize, setPageSize] = useState(intialPageSize || 10);
+  const [queryType, setQueryType] = useState('');
+  const [query, setQuery] = useState('')
 
   const getManifests = useCallback(
-    async ({ pageSize, pageIndex }: { pageSize: number; pageIndex: number }) => {
+    async ({ pageSize, pageIndex, queryType: queryType, query }: { pageSize: number; pageIndex: number, queryType: string, query: string }) => {
       try {
-        return await sbomerApi.getManifests({ pageSize, pageIndex });
+        return await sbomerApi.getManifests({ pageSize, pageIndex}, queryType, query);
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [pageIndex, pageSize],
+    [pageIndex, pageSize, queryType, query],
   );
 
   const { loading, value, error, retry } = useAsyncRetry(
@@ -42,11 +44,13 @@ export function useManifests(initialPage: number, intialPageSize: number) {
       getManifests({
         pageSize: pageSize,
         pageIndex: pageIndex,
+        queryType: queryType,
+        query: query
       }).then((data) => {
         setTotal(data.total);
         return data.data;
       }),
-    [pageIndex, pageSize],
+    [pageIndex, pageSize, queryType, query],
   );
 
   return [
@@ -61,6 +65,8 @@ export function useManifests(initialPage: number, intialPageSize: number) {
     {
       setPageIndex,
       setPageSize,
+      setQueryType,
+      setQuery,
       retry,
     },
   ] as const;

--- a/ui/src/app/types.ts
+++ b/ui/src/app/types.ts
@@ -120,7 +120,6 @@ export class SbomerRequest {
     // Parse `request_config` if it exists
     if (payload.requestConfig) {
       try {
-        
         this.requestConfig = JSON.stringify(payload.requestConfig);
         var rConfig = JSON.parse(this.requestConfig); // Convert to JSON object
         this.requestConfigTypeName = rConfig.type;
@@ -161,7 +160,6 @@ export class SbomerRequest {
 }
 
 export class SbomerRequestManifest {
-
   public reqId: string;
   public reqReceivalTime: Date;
   public reqEventType: string;
@@ -184,7 +182,6 @@ export class SbomerRequestManifest {
     // Parse `request_config` if it exists
     if (payload.requestConfig) {
       try {
-
         this.reqConfig = JSON.stringify(payload.requestConfig);
         var rConfig = JSON.parse(this.reqConfig); // Convert to JSON object
         this.reqConfigTypeName = rConfig.type;
@@ -243,7 +240,11 @@ export type SbomerApi = {
     pageIndex: number;
   }): Promise<{ data: SbomerGeneration[]; total: number }>;
 
-  getManifests(pagination: { pageSize: number; pageIndex: number }): Promise<{ data: SbomerManifest[]; total: number }>;
+  getManifests(
+    pagination: { pageSize: number; pageIndex: number },
+    queryType: string,
+    query: string,
+  ): Promise<{ data: SbomerManifest[]; total: number }>;
   getManifestsForGeneration(generationId: string): Promise<{ data: SbomerManifest[]; total: number }>;
 
   getGeneration(id: string): Promise<SbomerGeneration>;
@@ -258,5 +259,4 @@ export type SbomerApi = {
   getRequestEvent(id: string): Promise<SbomerRequestManifest>;
 
   getRequestEventGenerations(id: string): Promise<{ data: SbomerGeneration[]; total: number }>;
-
 };


### PR DESCRIPTION
I am adding menu and search feature to Manifests page.

This planned to be implemented in the Requests page, but with more filters (there is just one additional in Manifests page).


Notes:

- The options of the select (aka 'No filter' and 'Purl') are represented by string, but probably could be represented by enum/type, which could enable us to add more options easily
- Currently, when no filter is applied, the request string contains `query=` with following value of ` ` (nothing), but this the same effect as not having the `query=` at all.