### PR TITLE
feat(SBOMER-341): add select and search bar for manifests page

### DIFF
--- a/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
+++ b/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
@@ -6,7 +6,18 @@ import {
   Skeleton,
   Timestamp,
   TimestampTooltipVariant,
+  ToolbarItem,
   Tooltip,
+  Toolbar,
+  Select,
+  SearchInput,
+  SelectOption,
+  ToolbarContent,
+  SelectList,
+  MenuToggleElement,
+  MenuToggle,
+  SelectGroup,
+  Button
 } from '@patternfly/react-core';
 import { Caption, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
@@ -15,6 +26,7 @@ import { useSearchParam } from 'react-use';
 import { ErrorSection } from '../Sections/ErrorSection/ErrorSection';
 import { useManifests } from './useSboms';
 import { openInNewTab } from '@app/utils/openInNewTab';
+import { QueryType } from '@app/types';
 
 const columnNames = {
   id: 'ID',
@@ -25,14 +37,28 @@ const columnNames = {
 };
 
 export const ManifestsTable = () => {
+
   const navigate = useNavigate();
   const paramPage = useSearchParam('page') || 1;
   const paramPageSize = useSearchParam('pageSize') || 10;
 
-  const [{ pageIndex, pageSize, value, loading, total, error }, { setPageIndex, setPageSize }] = useManifests(
+
+
+  const [searchBarValue, setSearchBarValue] = React.useState<string>('');
+  const [searchBarVisible, setSearchBarVisible] = React.useState<boolean>(false);
+
+  const [selectIsOpen, setSelectIsOpen] = React.useState(false);
+  const [selectedQueryType, setSelectedQueryType] = React.useState<QueryType>(QueryType.NoFilter);
+
+
+  const [isButtonVisible, setButtonVisible] = React.useState<boolean>(false);
+
+  // getting the data and applying the filters sent to the backend here
+  const [{ pageIndex, pageSize, value, loading, total, error }, { setPageIndex, setPageSize, setQueryType, setQuery }] = useManifests(
     +paramPage - 1,
     +paramPageSize,
   );
+
 
   const onSetPage = (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number) => {
     setPageIndex(newPage - 1);
@@ -57,8 +83,97 @@ export const ManifestsTable = () => {
     return null;
   }
 
+
+  const onToggleClick = () => {
+    setSelectIsOpen(!selectIsOpen);
+  };
+
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    setSelectedQueryType(value as QueryType);
+    setSelectIsOpen(false);
+    switch (value) {
+      case QueryType.NoFilter:
+        setSearchBarVisible(false);
+        setQueryType(QueryType.NoFilter);
+        setQuery('');
+        setButtonVisible(false)
+        break;
+      default:
+        setSearchBarVisible(true);
+        setButtonVisible(true);
+    }
+
+  };
+
+  const onSearchCall = () => {
+    setQueryType(selectedQueryType)
+    setQuery(searchBarValue)
+    setPageIndex(0);
+  }
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={selectIsOpen}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      {selectedQueryType}
+    </MenuToggle>
+  );
+
+  const select = <Select
+    id="single-select"
+    isOpen={selectIsOpen}
+    selected={selectedQueryType}
+    onSelect={onSelect}
+    onOpenChange={(isOpen) => setSelectIsOpen(isOpen)}
+    toggle={toggle}
+    shouldFocusToggleOnSelect
+  >
+    <SelectList>
+      <SelectGroup>
+        <SelectOption value={QueryType.NoFilter}>{QueryType.NoFilter}</SelectOption>
+      </SelectGroup>
+      <SelectGroup>
+        <SelectOption value={QueryType.Purl}>{QueryType.Purl}</SelectOption>
+      </SelectGroup>
+    </SelectList>
+  </Select>
+
+
+  const searchBar = <SearchInput
+    placeholder="Enter selected id"
+    value={searchBarValue}
+    onChange={(_event, value) => setSearchBarValue(value)}
+    onClear={() => setSearchBarValue('')}
+    isAdvancedSearchOpen={!searchBarVisible}
+  />
+
+  const searchButton = <Button
+    variant='primary'
+    onClick={() => onSearchCall()}>Search</Button>
+
+
   return (
     <>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            {select}
+          </ToolbarItem>
+          <ToolbarItem>
+            {searchBarVisible && searchBar}
+          </ToolbarItem>
+          <ToolbarItem>
+            {isButtonVisible && searchButton}
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
       <Table aria-label="Manifests table" variant="compact">
         <Caption>Latest manifests</Caption>
         <Thead>

--- a/ui/src/app/components/ManifestsTableTable/useSboms.ts
+++ b/ui/src/app/components/ManifestsTableTable/useSboms.ts
@@ -17,6 +17,7 @@
 ///
 
 import { DefaultSbomerApi } from '@app/api/DefaultSbomerApi';
+import { QueryType } from '@app/types';
 import { useCallback, useState } from 'react';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
 
@@ -25,16 +26,28 @@ export function useManifests(initialPage: number, intialPageSize: number) {
   const [total, setTotal] = useState(0);
   const [pageIndex, setPageIndex] = useState(initialPage || 0);
   const [pageSize, setPageSize] = useState(intialPageSize || 10);
+  const [queryType, setQueryType] = useState(QueryType.NoFilter);
+  const [query, setQuery] = useState('');
 
   const getManifests = useCallback(
-    async ({ pageSize, pageIndex }: { pageSize: number; pageIndex: number }) => {
+    async ({
+      pageSize,
+      pageIndex,
+      queryType: queryType,
+      query,
+    }: {
+      pageSize: number;
+      pageIndex: number;
+      queryType: QueryType;
+      query: string;
+    }) => {
       try {
-        return await sbomerApi.getManifests({ pageSize, pageIndex });
+        return await sbomerApi.getManifests({ pageSize, pageIndex }, queryType, query);
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [pageIndex, pageSize],
+    [pageIndex, pageSize, queryType, query],
   );
 
   const { loading, value, error, retry } = useAsyncRetry(
@@ -42,11 +55,13 @@ export function useManifests(initialPage: number, intialPageSize: number) {
       getManifests({
         pageSize: pageSize,
         pageIndex: pageIndex,
+        queryType: queryType,
+        query: query,
       }).then((data) => {
         setTotal(data.total);
         return data.data;
       }),
-    [pageIndex, pageSize],
+    [pageIndex, pageSize, queryType, query],
   );
 
   return [
@@ -61,6 +76,8 @@ export function useManifests(initialPage: number, intialPageSize: number) {
     {
       setPageIndex,
       setPageSize,
+      setQueryType,
+      setQuery,
       retry,
     },
   ] as const;

--- a/ui/src/app/types.ts
+++ b/ui/src/app/types.ts
@@ -120,7 +120,6 @@ export class SbomerRequest {
     // Parse `request_config` if it exists
     if (payload.requestConfig) {
       try {
-        
         this.requestConfig = JSON.stringify(payload.requestConfig);
         var rConfig = JSON.parse(this.requestConfig); // Convert to JSON object
         this.requestConfigTypeName = rConfig.type;
@@ -161,7 +160,6 @@ export class SbomerRequest {
 }
 
 export class SbomerRequestManifest {
-
   public reqId: string;
   public reqReceivalTime: Date;
   public reqEventType: string;
@@ -184,7 +182,6 @@ export class SbomerRequestManifest {
     // Parse `request_config` if it exists
     if (payload.requestConfig) {
       try {
-
         this.reqConfig = JSON.stringify(payload.requestConfig);
         var rConfig = JSON.parse(this.reqConfig); // Convert to JSON object
         this.reqConfigTypeName = rConfig.type;
@@ -233,6 +230,11 @@ export type GenerateParams = {
   config: string;
 };
 
+export enum QueryType {
+  NoFilter = 'No filter',
+  Purl = 'Purl',
+}
+
 export type SbomerApi = {
   getBaseUrl(): string;
   stats(): Promise<SbomerStats>;
@@ -243,7 +245,11 @@ export type SbomerApi = {
     pageIndex: number;
   }): Promise<{ data: SbomerGeneration[]; total: number }>;
 
-  getManifests(pagination: { pageSize: number; pageIndex: number }): Promise<{ data: SbomerManifest[]; total: number }>;
+  getManifests(
+    pagination: { pageSize: number; pageIndex: number },
+    queryType: QueryType,
+    query: string,
+  ): Promise<{ data: SbomerManifest[]; total: number }>;
   getManifestsForGeneration(generationId: string): Promise<{ data: SbomerManifest[]; total: number }>;
 
   getGeneration(id: string): Promise<SbomerGeneration>;
@@ -258,5 +264,4 @@ export type SbomerApi = {
   getRequestEvent(id: string): Promise<SbomerRequestManifest>;
 
   getRequestEventGenerations(id: string): Promise<{ data: SbomerGeneration[]; total: number }>;
-
 };


### PR DESCRIPTION
I am adding menu and search feature to Manifests page.

This planned to be implemented in the Requests page, but with more filters (there is just one additional in Manifests page).


Notes:

- The options of the select (aka 'No filter' and 'Purl') are represented by string, but probably could be represented by enum/type, which could enable us to add more options easily
- Currently, when no filter is applied, the request string contains `query=` with following value of ` ` (nothing), but this the same effect as not having the `query=` at all.