### PR TITLE
feat(SBOMER-81): Add license information to components

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
@@ -217,7 +217,7 @@ public class CycloneDxGenerateOperationCommand extends AbstractGenerateOperation
             // pom.xml)
             if (!purlToComponents.containsKey(artifact.getArtifact().getPurl())) {
                 // Create a component entry for the artifact
-                Component component = createComponent(artifact.getArtifact(), Scope.REQUIRED, Type.LIBRARY);
+                Component component = createComponent(artifact, Scope.REQUIRED, Type.LIBRARY);
                 setArtifactMetadata(component, artifact.getArtifact(), pncService.getApiUrl());
                 setPncBuildMetadata(component, artifact.getArtifact().getBuild(), pncService.getApiUrl());
 

--- a/cli/src/test/resources/mappings/pnc/operation-delivered-artifacts.json
+++ b/cli/src/test/resources/mappings/pnc/operation-delivered-artifacts.json
@@ -51,12 +51,21 @@
             "my-7.11.5.CR3-maven-repository.zip!/my-7.11.5.GA-maven-repository/org/jboss/jboss-parent/19.0.0.redhat-1/jboss-parent-19.0.0.redhat-1.pom"
           ],
           "archiveUnmatchedFilenames": [
-            
+
           ],
           "distribution": {
             "distributionUrl": "https://download.com/my-7.11.5.CR3-maven-repository.zip",
             "creationTime": "2024-01-08T18:14:17.877+00:00"
-          }
+          },
+          "licenses": [
+            {
+              "distribution": "repo",
+              "name": "Public Domain",
+              "url": "http://repository.jboss.org/licenses/cc0-1.0.txt",
+              "spdxLicenseId": "CC0-1.0",
+              "source": "POM"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
If given an `AnalyzedArtifact`, add any SPDX license identifers to the licenses of the component. Only licenses for which an SPDX license identifier assertion could be made are listed here.

Since URLs are not unique per identifier, do not add any URL to the licenses of the component. Add any valid absolute URLs to the external references of the component.

Add the full list of licenses, including any licenses which have an SPDX license identifier of `NOASSERTION` or `NONE` to the license evidence of the component. The evidence licenses include URL and source information.