### PR TITLE
feat(SBOMER-352): add permalinks to the manifests page filters

### DIFF
--- a/ui/src/app/components/ManifestsTableTable/useManifestsFilters.ts
+++ b/ui/src/app/components/ManifestsTableTable/useManifestsFilters.ts
@@ -1,0 +1,64 @@
+///
+/// JBoss, Home of Professional Open Source.
+/// Copyright 2023 Red Hat, Inc., and individual contributors
+/// as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { ManifestsQueryType } from '@app/types';
+
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export function useManifestsFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const queryType = (searchParams.get('queryType') as ManifestsQueryType) || ManifestsQueryType.NoFilter;
+  const queryValue = searchParams.get('queryValue') as string;
+  const pageIndex = +(searchParams.get('page') || 1);
+  const pageSize = +(searchParams.get('pageSize') || 10);
+
+  const setFilters = useCallback(
+    (queryType: ManifestsQueryType, queryValue: string, pageIndex: number, pageSize: number) => {
+      setSearchParams((params) => {
+        if (queryType) {
+          params.set('queryType', queryType);
+        } else {
+          params.set('queryType', ManifestsQueryType.NoFilter);
+        }
+        if (queryValue) {
+          params.set('queryValue', queryValue);
+        } else {
+          params.delete('queryValue');
+        }
+
+        if (pageIndex) {
+          params.set('page', pageIndex.toString());
+        } else {
+          params.delete('page');
+        }
+        if (pageSize) {
+          params.set('pageSize', pageSize.toString());
+        } else {
+          params.delete('pageSize');
+        }
+
+        return params;
+      });
+    },
+    [],
+  );
+
+  return { queryType, queryValue, pageIndex, pageSize, setFilters };
+}

--- a/ui/src/app/components/ManifestsTableTable/useSboms.ts
+++ b/ui/src/app/components/ManifestsTableTable/useSboms.ts
@@ -20,64 +20,58 @@ import { DefaultSbomerApi } from '@app/api/DefaultSbomerApi';
 import { ManifestsQueryType } from '@app/types';
 import { useCallback, useState } from 'react';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
+import { useManifestsFilters } from './useManifestsFilters';
 
-export function useManifests(initialPage: number, intialPageSize: number) {
+export function useManifests() {
   const sbomerApi = DefaultSbomerApi.getInstance();
   const [total, setTotal] = useState(0);
-  const [pageIndex, setPageIndex] = useState(initialPage || 0);
-  const [pageSize, setPageSize] = useState(intialPageSize || 10);
-  const [queryType, setQueryType] = useState(ManifestsQueryType.NoFilter);
-  const [query, setQuery] = useState('');
+
+  const { queryType, queryValue, pageIndex, pageSize } = useManifestsFilters();
 
   const getManifests = useCallback(
     async ({
       pageSize,
       pageIndex,
       queryType: queryType,
-      query,
+      queryValue,
     }: {
       pageSize: number;
       pageIndex: number;
       queryType: ManifestsQueryType;
-      query: string;
+      queryValue: string;
     }) => {
       try {
-        return await sbomerApi.getManifests({ pageSize, pageIndex }, queryType, query);
+        const pageIndexOffsetted = pageIndex - 1;
+        return await sbomerApi.getManifests({ pageSize, pageIndex: pageIndexOffsetted }, queryType, queryValue);
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [pageIndex, pageSize, queryType, query],
+    [pageIndex, pageSize, queryType, queryValue],
   );
 
   const { loading, value, error, retry } = useAsyncRetry(
     () =>
       getManifests({
-        pageSize: pageSize,
-        pageIndex: pageIndex,
+        pageSize: +pageSize,
+        pageIndex: +pageIndex,
         queryType: queryType,
-        query: query,
+        queryValue: queryValue,
       }).then((data) => {
         setTotal(data.total);
         return data.data;
       }),
-    [pageIndex, pageSize, queryType, query],
+    [pageIndex, pageSize, queryType, queryValue],
   );
 
   return [
     {
-      pageIndex,
-      pageSize,
       total,
       value,
       loading,
       error,
     },
     {
-      setPageIndex,
-      setPageSize,
-      setQueryType,
-      setQuery,
       retry,
     },
   ] as const;


### PR DESCRIPTION
New user features:
- Applying filters applies to the URL
- URL is permalink, meaning it can be shared along with the applied filters
- works for URL history (i.e. you can go back and forth to previously applied filters)




Note:

This PR shifts the state management of the page from using useState to using URL state (using useSearchParams) AKA all state of filters ( current queryType, queryValue, pageIndex and pageSize) is now in the URL, meaning this state can be shared using just URL.
This also means that URL history also works with filter states.
Some state management is still left to useState where it made sense, such as with searchBar and visibility of searchButton.
