### PR TITLE
Requests permalink, queryType restriction added

### DIFF
--- a/ui/src/app/components/ManifestsTableTable/useManifestsFilters.ts
+++ b/ui/src/app/components/ManifestsTableTable/useManifestsFilters.ts
@@ -17,6 +17,7 @@
 ///
 
 import { ManifestsQueryType } from '@app/types';
+import { isManifestsQueryType } from '@app/utils/Utils';
 
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -24,8 +25,9 @@ import { useSearchParams } from 'react-router-dom';
 export function useManifestsFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const queryType = (searchParams.get('queryType') as ManifestsQueryType) || ManifestsQueryType.NoFilter;
-  const queryValue = searchParams.get('queryValue') as string;
+  const queryTypeValue = searchParams.get('queryType') as ManifestsQueryType;
+  const queryType = isManifestsQueryType(queryTypeValue) ? queryTypeValue : ManifestsQueryType.NoFilter;
+  const queryValue = isManifestsQueryType(queryTypeValue) ? (searchParams.get('queryValue') as string) : '';
   const pageIndex = +(searchParams.get('page') || 1);
   const pageSize = +(searchParams.get('pageSize') || 10);
 

--- a/ui/src/app/components/RequestEventTable/useRequestEvents.ts
+++ b/ui/src/app/components/RequestEventTable/useRequestEvents.ts
@@ -17,17 +17,16 @@
 ///
 
 import { DefaultSbomerApi } from '@app/api/DefaultSbomerApi';
-import { RequestsQueryType, SbomerRequest } from '@app/types';
+import { RequestsQueryType } from '@app/types';
 import { useCallback, useState } from 'react';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
+import { useRequestEventsFilters } from './useRequestEventsFilters';
 
-export function useRequestEvents(initialPage: number, intialPageSize: number) {
+export function useRequestEvents() {
   const sbomerApi = DefaultSbomerApi.getInstance();
   const [total, setTotal] = useState(0);
-  const [pageIndex, setPageIndex] = useState(initialPage || 1);
-  const [pageSize, setPageSize] = useState(intialPageSize || 10);
-  const [queryType, setQueryType] = useState(RequestsQueryType.NoFilter);
-  const [query, setQuery] = useState('');
+
+  const { queryType, queryValue, pageIndex, pageSize } = useRequestEventsFilters();
 
   const getRequestEvents = useCallback(
     async ({
@@ -37,46 +36,45 @@ export function useRequestEvents(initialPage: number, intialPageSize: number) {
       pageSize: number;
       pageIndex: number;
       queryType: RequestsQueryType;
-      query: string;
+      queryValue: string;
     }) => {
       try {
-        const response = await sbomerApi.getRequestEvents({ pageSize, pageIndex }, queryType, query);
+        const pageIndexOffsetted = pageIndex - 1;
+        const response = await sbomerApi.getRequestEvents(
+          { pageSize, pageIndex: pageIndexOffsetted },
+          queryType,
+          queryValue,
+        );
         return response;
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [pageIndex, pageSize, queryType, query],
+    [pageIndex, pageSize, queryType, queryValue],
   );
 
   const { loading, value, error, retry } = useAsyncRetry(
     () =>
       getRequestEvents({
-        pageSize: pageSize,
-        pageIndex: pageIndex,
+        pageSize: +pageSize,
+        pageIndex: +pageIndex,
         queryType: queryType,
-        query: query,
+        queryValue: queryValue,
       }).then((data) => {
         setTotal(data.total);
         return data.data;
       }),
-    [pageIndex, pageSize, queryType, query],
+    [pageIndex, pageSize, queryType, queryValue],
   );
 
   return [
     {
-      pageIndex,
-      pageSize,
       total,
       value,
       loading,
       error,
     },
     {
-      setPageIndex,
-      setPageSize,
-      setQueryType,
-      setQuery,
       retry,
     },
   ] as const;

--- a/ui/src/app/components/RequestEventTable/useRequestEventsFilters.ts
+++ b/ui/src/app/components/RequestEventTable/useRequestEventsFilters.ts
@@ -17,14 +17,16 @@
 ///
 
 import { RequestsQueryType } from '@app/types';
+import { isRequestsQueryType } from '@app/utils/Utils';
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export function useRequestEventsFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const queryType = (searchParams.get('queryType') as RequestsQueryType) || RequestsQueryType.NoFilter;
-  const queryValue = searchParams.get('queryValue') as string;
+  const queryTypeValue = searchParams.get('queryType') as RequestsQueryType;
+  const queryType = isRequestsQueryType(queryTypeValue) ? queryTypeValue : RequestsQueryType.NoFilter;
+  const queryValue = isRequestsQueryType(queryTypeValue) ? (searchParams.get('queryValue') as string) : '';
   const pageIndex = +(searchParams.get('page') || 1);
   const pageSize = +(searchParams.get('pageSize') || 10);
 

--- a/ui/src/app/components/RequestEventTable/useRequestEventsFilters.ts
+++ b/ui/src/app/components/RequestEventTable/useRequestEventsFilters.ts
@@ -1,0 +1,63 @@
+///
+/// JBoss, Home of Professional Open Source.
+/// Copyright 2023 Red Hat, Inc., and individual contributors
+/// as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { RequestsQueryType } from '@app/types';
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export function useRequestEventsFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const queryType = (searchParams.get('queryType') as RequestsQueryType) || RequestsQueryType.NoFilter;
+  const queryValue = searchParams.get('queryValue') as string;
+  const pageIndex = +(searchParams.get('page') || 1);
+  const pageSize = +(searchParams.get('pageSize') || 10);
+
+  const setFilters = useCallback(
+    (queryType: RequestsQueryType, queryValue: string, pageIndex: number, pageSize: number) => {
+      setSearchParams((params) => {
+        if (queryType) {
+          params.set('queryType', queryType);
+        } else {
+          params.set('queryType', RequestsQueryType.NoFilter);
+        }
+        if (queryValue) {
+          params.set('queryValue', queryValue);
+        } else {
+          params.delete('queryValue');
+        }
+
+        if (pageIndex) {
+          params.set('page', pageIndex.toString());
+        } else {
+          params.delete('page');
+        }
+        if (pageSize) {
+          params.set('pageSize', pageSize.toString());
+        } else {
+          params.delete('pageSize');
+        }
+
+        return params;
+      });
+    },
+    [],
+  );
+
+  return { queryType, queryValue, pageIndex, pageSize, setFilters };
+}

--- a/ui/src/app/utils/Utils.ts
+++ b/ui/src/app/utils/Utils.ts
@@ -16,7 +16,7 @@
 /// limitations under the License.
 ///
 
-import { SbomerGeneration, SbomerRequest } from '@app/types';
+import { ManifestsQueryType, RequestsQueryType, SbomerGeneration, SbomerRequest } from '@app/types';
 import { Label } from '@patternfly/react-core';
 
 const GenerationRequestTypes = new Map<string, { description?: string }>([
@@ -156,4 +156,11 @@ export function isInProgress(request: SbomerGeneration): boolean {
 
 export function isSuccess(request: SbomerGeneration): boolean {
   return request.result == 'SUCCESS' ? true : false;
+}
+
+export function isManifestsQueryType(value: string): value is ManifestsQueryType {
+  return Object.values<string>(ManifestsQueryType).includes(value);
+}
+export function isRequestsQueryType(value: string): value is RequestsQueryType {
+  return Object.values<string>(RequestsQueryType).includes(value);
 }


### PR DESCRIPTION
User features:
- Permalinks for URL in Requests page filters (same as for Manifests page)
- added restriction that allows only valid QueryType input from URL, if not defaults to "No filter"