### PR TITLE
feat(ui): remove link behavior on whole row in all tables

### DIFF
--- a/ui/src/app/components/GenerationRequestTable/GenerationRequestTable.tsx
+++ b/ui/src/app/components/GenerationRequestTable/GenerationRequestTable.tsx
@@ -74,8 +74,6 @@ export const GenerationRequestTable = () => {
             <Tr
               key={generation.id}
               isClickable
-              onRowClick={() => navigate(`/generations/${generation.id}`)}
-              onAuxClick={() => openInNewTab(`/generations/${generation.id}`)}
             >
               <Td dataLabel={columnNames.id}>
                 <Link to={`/generations/${generation.id}`}>

--- a/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
+++ b/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
@@ -174,8 +174,6 @@ export const ManifestsTable = () => {
           <Tr
             key={manifest.id}
             isClickable
-            onRowClick={() => navigate(`/manifests/${manifest.id}`)}
-            onAuxClick={() => openInNewTab(`/manifests/${manifest.id}`)}
           >
             <Td dataLabel={columnNames.id}>
               <Link to={`/manifests/${manifest.id}`}>

--- a/ui/src/app/components/RequestEventTable/RequestEventTable.tsx
+++ b/ui/src/app/components/RequestEventTable/RequestEventTable.tsx
@@ -175,8 +175,6 @@ export const RequestEventTable = () => {
           <Tr
             key={requestEvent.id}
             isClickable
-            onRowClick={() => navigate(`/requestevents/${requestEvent.id}`)}
-            onAuxClick={() => openInNewTab(`/requestevents/${requestEvent.id}`)}
           >
             <Td dataLabel={columnNames.id}>
               <Link to={`/requestevents/${requestEvent.id}`}>


### PR DESCRIPTION
The "Link" functionality is already handled by a Link with the ID for each row.
Redirect after a click made it impossible to copy part of text from the row (for example Errata advisory Id in Request config column for Request tables).

We are losing a bit of functionality in the whole row being non-clickable, but this way is better for overall usability, for example for using shortcuts like `CTRL + Left Click` or `Middle Button Click`.