### PR TITLE
Changed cursor behavior to be style 'pointer' only on appropriate elements in UI

### DIFF
--- a/ui/src/app/components/GenerationRequestTable/GenerationRequestTable.tsx
+++ b/ui/src/app/components/GenerationRequestTable/GenerationRequestTable.tsx
@@ -62,6 +62,7 @@ export const GenerationRequestTable = () => {
           <Tr
             key={generation.id}
             isClickable
+            style={{ cursor: 'auto' }}
           >
             <Td dataLabel={columnNames.id}>
               <Link to={`/generations/${generation.id}`}>
@@ -80,7 +81,7 @@ export const GenerationRequestTable = () => {
                   </div>
                 }
               >
-                <Label style={{ cursor: 'pointer' }} color={statusToColor(generation)}>
+                <Label color={statusToColor(generation)}>
                   {statusToDescription(generation)}
                 </Label>
 
@@ -89,7 +90,7 @@ export const GenerationRequestTable = () => {
             </Td>
             <Td dataLabel={columnNames.type}>
               <Tooltip isContentLeftAligned={true} content={<code>{generation.identifier}</code>}>
-                <Label style={{ cursor: 'pointer' }} color="purple">
+                <Label color="purple">
                   {typeToDescription(generation)}
                 </Label>
               </Tooltip>

--- a/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
+++ b/ui/src/app/components/ManifestsTableTable/ManifestsTable.tsx
@@ -161,6 +161,7 @@ export const ManifestsTable = () => {
           <Tr
             key={manifest.id}
             isClickable
+            style={{ cursor: 'auto' }}
           >
             <Td dataLabel={columnNames.id}>
               <Link to={`/manifests/${manifest.id}`}>
@@ -168,7 +169,7 @@ export const ManifestsTable = () => {
               </Link>
             </Td>
             <Td dataLabel={columnNames.type}>
-              <Label style={{ cursor: 'pointer' }} color="purple">
+              <Label color="purple">
                 {typeToDescription(manifest.generation)}
               </Label>
             </Td>

--- a/ui/src/app/components/RequestEventTable/RequestEventTable.tsx
+++ b/ui/src/app/components/RequestEventTable/RequestEventTable.tsx
@@ -168,6 +168,7 @@ export const RequestEventTable = () => {
           <Tr
             key={requestEvent.id}
             isClickable
+            style={{ cursor: 'auto' }}
           >
             <Td dataLabel={columnNames.id}>
               <Link to={`/requestevents/${requestEvent.id}`}>
@@ -186,7 +187,7 @@ export const RequestEventTable = () => {
                   </div>
                 }
               >
-                <Label style={{ cursor: 'pointer' }} color={requestEventStatusToColor(requestEvent.eventStatus)}>
+                <Label color={requestEventStatusToColor(requestEvent.eventStatus)}>
                   {requestEventStatusToDescription(requestEvent.eventStatus)}
                 </Label>
 
@@ -194,7 +195,7 @@ export const RequestEventTable = () => {
               </Tooltip>
             </Td>
             <Td dataLabel={columnNames.eventType}>
-              <Label style={{ cursor: 'pointer' }} color="yellow">
+              <Label color="yellow">
                 {requestEvent.eventType}
               </Label>
             </Td>


### PR DESCRIPTION
Previously the cursor was style 'pointer' (hand pointing) for the each row of the table.
These changes make the cursor style 'auto', meaning we get expected behavior while pointing to certain elements.

These changes could also be implemented via removing the `isClickable` property from `<Tr>` tag, however this wouldn't let us keep a desired feature that highlights the current row on cursor hover.