### PR TITLE
Feat mequal rest client

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/FeatureFlags.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/FeatureFlags.java
@@ -68,6 +68,9 @@ public class FeatureFlags implements UnleashSubscriber {
     public static final String TOGGLE_STANDARD_ERRATA_IMAGE_RELEASE_MANIFEST_GENERATION = "errata-standard-image-release-manifest-generation";
     public static final String TOGGLE_TEXTONLY_ERRATA_RELEASE_MANIFEST_GENERATION = "errata-textonly-release-manifest-generation";
 
+    // Mequal
+    public static final String TOGGLE_MEQUAL = "mequal";
+
     /**
      * A map holding all toggle values we are interested in. This is used for logging purposes. We are retrieving the
      * state of the toggle via {@link Unleash} object instead.
@@ -114,6 +117,9 @@ public class FeatureFlags implements UnleashSubscriber {
 
     @ConfigProperty(name = "SBOMER_FEATURE_TEXTONLY_ERRATA_RELEASE_MANIFEST_ENABLED", defaultValue = "false")
     boolean textonlyErrataReleaseGeneration;
+
+    @ConfigProperty(name = "SBOMER_FEATURE_MEQUAL_ENABLED", defaultValue = "false")
+    boolean mequalEnabled;
 
     /**
      * Returns {@code true} in case the dry-run mode is enabled.
@@ -223,6 +229,16 @@ public class FeatureFlags implements UnleashSubscriber {
     }
 
     /**
+     * Returns {@code true} if mequal sbom policy checking is enabled.
+     *
+     * @return {@code true} if mequal sbom policy checking is enabled and requests will be made to the OPA server,
+     *         {@code false} otherwise
+     */
+    public boolean mequalEnabled() {
+        return unleash.isEnabled(TOGGLE_MEQUAL, mequalEnabled);
+    }
+
+    /**
      * Returns {@code true} if we should send a UMB message for a successfully generated manifest where the generation
      * request source is of a given type.
      *
@@ -255,7 +271,8 @@ public class FeatureFlags implements UnleashSubscriber {
                 TOGGLE_ERRATA_COMMENTS_GENERATION,
                 TOGGLE_STANDARD_ERRATA_RPM_RELEASE_MANIFEST_GENERATION,
                 TOGGLE_STANDARD_ERRATA_IMAGE_RELEASE_MANIFEST_GENERATION,
-                TOGGLE_TEXTONLY_ERRATA_RELEASE_MANIFEST_GENERATION)) {
+                TOGGLE_TEXTONLY_ERRATA_RELEASE_MANIFEST_GENERATION,
+                TOGGLE_MEQUAL)) {
             FeatureToggle toggle = toggleResponse.getToggleCollection().getToggle(toggleName);
             Boolean previousValue = toggleValues.put(toggleName, toggle.isEnabled());
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/MequalClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/MequalClient.java
@@ -43,13 +43,11 @@ import jakarta.ws.rs.core.Response;
 @ClientHeaderParam(name = "User-Agent", value = "SBOMer")
 @RegisterRestClient(configKey = "mequal")
 @Path("/v1")
-// @RegisterProvider() We probably need a provider to handle mTLS?
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface MequalClient {
 
     @POST
-    // @Blocking
     @Path("/query")
     @Consumes(MediaType.APPLICATION_JSON)
     MequalQueryResponse getQuery(@QueryParam("pretty") boolean pretty, QueryPayload qr);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/MequalClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/MequalClient.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.meqaul;
+
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.sbomer.core.errors.ClientException;
+import org.jboss.sbomer.core.errors.ForbiddenException;
+import org.jboss.sbomer.core.errors.NotFoundException;
+import org.jboss.sbomer.core.errors.UnauthorizedException;
+import org.jboss.sbomer.service.feature.sbom.meqaul.dto.MequalQueryResponse;
+import org.jboss.sbomer.service.feature.sbom.meqaul.dto.QueryPayload;
+
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+@ClientHeaderParam(name = "User-Agent", value = "SBOMer")
+@RegisterRestClient(configKey = "mequal")
+@Path("/v1")
+// @RegisterProvider() We probably need a provider to handle mTLS?
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface MequalClient {
+
+    @POST
+    // @Blocking
+    @Path("/query")
+    @Consumes(MediaType.APPLICATION_JSON)
+    MequalQueryResponse getQuery(@QueryParam("pretty") boolean pretty, QueryPayload qr);
+
+    @ClientExceptionMapper
+    @Blocking
+    static RuntimeException toException(Response response) {
+        String message = response.readEntity(String.class);
+
+        return switch (response.getStatus()) {
+            case 400 -> new ClientException("Bad request", List.of(message));
+            case 401 ->
+                new UnauthorizedException("Caller is unauthorized to access resource; {}", message, List.of(message));
+            case 403 -> new ForbiddenException("Caller is forbidden to access resource; {}", message, List.of(message));
+            case 404 -> new NotFoundException("Requested resource was not found; {}", message, List.of(message));
+            default -> null;
+        };
+
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/QueryPayloadHelper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/QueryPayloadHelper.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.meqaul;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.sbomer.service.feature.sbom.meqaul.dto.QueryPayload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class QueryPayloadHelper {
+
+    public static final String DEFAULT_QUERY_STRING = ConfigProvider.getConfig()
+            .getValue("quarkus.rest-client.mequal.defaultQuery", String.class);
+
+    public static QueryPayload fromBomFilePath(String bomFilePath) throws IOException {
+        return fromBomFilePath(DEFAULT_QUERY_STRING, bomFilePath);
+    }
+
+    public static QueryPayload fromBomFilePath(String query, String bomFilePath) throws IOException {
+        try {
+            Path p = Paths.get(bomFilePath);
+            String bomContents = new String(Files.readAllBytes(p));
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode fileJsonNode = objectMapper.readTree(bomContents);
+            ObjectNode parentNode = objectMapper.createObjectNode();
+            parentNode.set("input", fileJsonNode);
+            return new QueryPayload(query, objectMapper.writeValueAsString(parentNode));
+        } catch (IOException e) {
+            throw new IOException("Error while processing file: " + bomFilePath, e);
+        }
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/QueryResponseHelper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/QueryResponseHelper.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.meqaul;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.sbomer.service.feature.sbom.meqaul.dto.MequalQueryResponse;
+import org.jboss.sbomer.service.feature.sbom.meqaul.dto.QueryPayload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class QueryResponseHelper {
+
+    public static Path toPath(MequalQueryResponse resp, Path bomPath) throws IOException {
+        BufferedWriter bw = null;
+        Path mequalFile = Path.of(bomPath.getParent().toString(), "mequal.json");
+        try {
+            File mfh = mequalFile.toFile();
+            if (!mfh.exists()) {
+                mfh.createNewFile();
+                FileWriter fw = new FileWriter(mfh);
+                bw = new BufferedWriter(fw);
+                bw.write(resp.toString());
+            }
+        } catch (IOException e) {
+            throw new IOException("Error while processing file: " + mequalFile, e);
+        } finally {
+            try {
+                if (bw != null) {
+                    bw.close();
+                }
+            } catch (IOException e) {
+                throw new IOException("Error while closing file: " + mequalFile.toString());
+            }
+        }
+        return mequalFile;
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/dto/MequalQueryResponse.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/dto/MequalQueryResponse.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.sbomer.service.feature.sbom.meqaul.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MequalQueryResponse {
+
+    @JsonProperty("result")
+    public JsonNode results;
+
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/dto/QueryPayload.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/meqaul/dto/QueryPayload.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.meqaul.dto;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.Data;
+
+@Data
+public class QueryPayload {
+
+    private String bomFilePath;
+
+    @JsonProperty("query")
+    private final String query;
+
+    @JsonProperty("input")
+    private final String input;
+
+    public static QueryPayload fromBomFilePath(String query, String bomFilePath) throws IOException {
+        try {
+            Path p = Paths.get(bomFilePath);
+            String bomContents = new String(Files.readAllBytes(p));
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode fileJsonNode = objectMapper.readTree(bomContents);
+            ObjectNode parentNode = objectMapper.createObjectNode();
+            parentNode.set("input", fileJsonNode);
+            return new QueryPayload(query, objectMapper.writeValueAsString(parentNode));
+        } catch (IOException e) {
+            throw new IOException("Error while processing file: " + bomFilePath, e);
+        }
+    }
+}

--- a/service/src/main/resources/application-test.yaml
+++ b/service/src/main/resources/application-test.yaml
@@ -38,6 +38,9 @@ quarkus:
       url: "https://dummy"
     "pyxis":
       url: "https://dummy"
+    "mequal":
+      url: "https://dummy"
+      defaultQuery: "data.mequal.main;data.prodsec.main"
 
   operator-sdk:
     start-operator: false
@@ -72,7 +75,7 @@ sbomer:
     #  url:
 
   purl-qualifiers-allow-list:
-    - repository_url
+  - repository_url
 
   features:
     umb:
@@ -80,8 +83,8 @@ sbomer:
       producer:
         enabled: false
     kerberos:
-        enabled: false
-        errata:
-          service-principal-name: errata-service-principal
-        pyxis:
-          service-principal-name: pyxis-service-principal
+      enabled: false
+      errata:
+        service-principal-name: errata-service-principal
+      pyxis:
+        service-principal-name: pyxis-service-principal

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -82,6 +82,9 @@ quarkus:
       url: "https://${sbomer.errata.host}"
     "pyxis":
       url: "https://${sbomer.pyxis.host}"
+    "mequal":
+      url: "https://${sbomer.mequal.host}"
+      defaultQuery: "data.mequal.main;data.prodsec.main"
 
   # Support for feature-flags
   unleash:

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/s3/S3FeatureTest.java
@@ -40,7 +40,7 @@ import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.service.test.integ.feature.s3.S3FeatureTest.S3ClientConfig;
-import org.jboss.sbomer.service.test.integ.feature.sbom.MequalClientMock;
+import org.jboss.sbomer.service.test.integ.feature.sbom.MequalClientWireMock;
 import org.jboss.sbomer.service.test.utils.umb.TestUmbProfile;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ import io.restassured.http.ContentType;
 
 @QuarkusTest
 @TestProfile(S3ClientConfig.class)
-@WithTestResource(MequalClientMock.class)
+@WithTestResource(MequalClientWireMock.class)
 class S3FeatureTest {
 
     @Inject

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/MequalClientMock.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/MequalClientMock.java
@@ -1,0 +1,29 @@
+package org.jboss.sbomer.service.test.integ.feature.sbom;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class MequalClientMock implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
+        wireMockServer.start();
+        return Collections.singletonMap("quarkus.rest-client.mequal.url", wireMockServer.baseUrl());
+    }
+
+    @Override
+    public void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+}

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/MequalClientWireMock.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/MequalClientWireMock.java
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
-public class MequalClientMock implements QuarkusTestResourceLifecycleManager {
+public class MequalClientWireMock implements QuarkusTestResourceLifecycleManager {
 
     private WireMockServer wireMockServer;
 


### PR DESCRIPTION
Added [Mequal](https://github.com/project-ncl/mequal) feature ([OPA Service](https://www.openpolicyagent.org/docs/latest/rest-api/)) to the S3 Storage handler

Whats included in this commit

* Mequal, a barebones single endpoint REST client for OPA
  * A DTO for payload and response from OPA
  * Helper methods to create payload from bom.json and to write the
    reponse to file
* Additional `SBOMER_FEATURE_MEQUAL_ENABLED` unleashed feature flag
* Injection of `MequalClient` into S3 storage handler
  * If Mequal is enabled before the upload to S3 the `bom.json` is sent
    to OPA service and the response saved as `mequal.json`
  * Additional test added to `S3FeatureTest` using wiremock

Todo:

* Integration tests for misbehaving OPA service
* Integration tests for misbehaving IO
* Real world tests for sizeable bom and mequal responses
* mTLS 