### PR TITLE
Adding flag in Renovate config to enable auto-merge for "patch" updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
         "labels": ["security"]
     },
     "prConcurrentLimit": 20,
+    "separateMinorPatch": true,
     "packageRules": [
         {
             "description": "lockFileMaintenance",


### PR DESCRIPTION
By default, updates are takes major and non-major (minor and patch). adding the separateMinorPatch flag to true separates these types, making it possible to auto-merge only "patch" updates.