### PR TITLE
Adding automergePatch config in Renovate config to fix auto-merge for "patch" updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":automergeDigest"],
+    "extends": ["config:recommended", ":automergePatch", ":automergeDigest"],
     "username": "renovate-release",
     "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
     "onboarding": false,
@@ -17,7 +17,6 @@
         "labels": ["security"]
     },
     "prConcurrentLimit": 20,
-    "separateMinorPatch": true,
     "packageRules": [
         {
             "description": "lockFileMaintenance",
@@ -43,9 +42,7 @@
             "enabled": false
         },
         {
-            "extends": ["monorepo:aws-java-sdk-v2", "monorepo:typescript-eslint", "monorepo:mapstruct", "monorepo:commitlint", "group:postcss"],
-            "matchUpdateTypes": ["patch"],
-            "automerge": true
+            "extends": ["monorepo:aws-java-sdk-v2", "monorepo:typescript-eslint", "monorepo:mapstruct", "monorepo:commitlint", "group:postcss"]
         }
     ],
     "platformAutomerge": true


### PR DESCRIPTION
Changing to use preset `:automergePatch` instead of manually setting automerge.
Removed now unnecessary flags, which are the applied by adding the config preset.