### PR TITLE
Disable hashes for domino e2e tests

### DIFF
--- a/cli/src/main/resources/mapping/stage/product-mapping.yaml
+++ b/cli/src/main/resources/mapping/stage/product-mapping.yaml
@@ -36,7 +36,7 @@
             productVariant: 8Base-RHBQ-2.13
       generator:
         type: maven-domino
-        args: "--warn-on-missing-scm --legacy-scm-locator"
+        args: "--warn-on-missing-scm --legacy-scm-locator --hashes=false"
 "283":
   type: pnc-build
   products:
@@ -48,4 +48,4 @@
             productVariant: TESTPRODUCTVARIANT
       generator:
         type: maven-domino
-        args: "--warn-on-missing-scm --legacy-scm-locator"
+        args: "--warn-on-missing-scm --legacy-scm-locator --hashes=false"


### PR DESCRIPTION
In order to successfully complete e2e tests for Domino we need to disable the new hash calculation feature.