### PR TITLE
feat(SBOMER-381): propagate the MDCContext across the services and tasks

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/AbstractGenerateCommand.java
@@ -126,7 +126,7 @@ public abstract class AbstractGenerateCommand implements Callable<Integer> {
     public Integer call() {
         // Make sure there is no context
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(parent.getBuildId());
+        MDCUtils.addIdentifierContext(parent.getBuildId());
 
         // Fetch build information
         Build build = pncService.getBuild(parent.getBuildId());

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/DefaultProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/DefaultProcessCommand.java
@@ -59,6 +59,6 @@ public class DefaultProcessCommand extends AbstractProcessCommand {
 
     @Override
     protected void addContext() {
-        MDCUtils.addBuildContext(parent.getParent().getParent().getBuildId());
+        MDCUtils.addIdentifierContext(parent.getParent().getParent().getBuildId());
     }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/RedHatProductProcessCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/RedHatProductProcessCommand.java
@@ -63,6 +63,6 @@ public class RedHatProductProcessCommand extends AbstractProcessCommand {
 
     @Override
     protected void addContext() {
-        MDCUtils.addBuildContext(parent.getParent().getParent().getBuildId());
+        MDCUtils.addIdentifierContext(parent.getParent().getParent().getBuildId());
     }
 }

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateCommand.java
@@ -119,7 +119,7 @@ public class GenerateCommand implements Callable<Integer> {
 
         // Make sure there is no context
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(config.getBuildId());
+        MDCUtils.addIdentifierContext(config.getBuildId());
 
         if (index != null) {
 

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateConfigCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/auto/GenerateConfigCommand.java
@@ -331,7 +331,7 @@ public class GenerateConfigCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         // Make sure there is no context
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(this.buildId);
+        MDCUtils.addIdentifierContext(this.buildId);
 
         PncBuildConfig config = null;
 

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/MDCUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/MDCUtils.java
@@ -19,8 +19,6 @@ package org.jboss.sbomer.core.features.sbom.utils;
 
 import java.util.Map;
 
-import org.jboss.pnc.api.constants.MDCHeaderKeys;
-import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.pnc.common.Strings;
 import org.slf4j.MDC;
 
@@ -29,29 +27,25 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MDCUtils {
 
+    public static final String MDC_IDENTIFIER_KEY = "identifier";
+    public static final String MDC_TRACE_ID_KEY = "traceId";
+    public static final String MDC_SPAN_ID_KEY = "spanId";
+    public static final String MDC_TRACEPARENT_KEY = "traceparent";
+    public static final String MDC_TRACE_FLAGS_KEY = "traceFlags";
+    public static final String MDC_TRACE_STATE_KEY = "traceState";
+
     private MDCUtils() {
         // This is a utility class
     }
 
-    public static void addProcessContext(String processContext) {
-        String current = MDC.get(MDCKeys.PROCESS_CONTEXT_KEY);
+    public static void addIdentifierContext(String identifier) {
+        String current = MDC.get(MDC_IDENTIFIER_KEY);
         if (Strings.isEmpty(current)) {
-            if (!Strings.isEmpty(processContext)) {
-                MDC.put(MDCKeys.PROCESS_CONTEXT_KEY, processContext);
+            if (!Strings.isEmpty(identifier)) {
+                MDC.put(MDC_IDENTIFIER_KEY, identifier);
             }
         } else {
-            log.warn("Did not set new processContext [{}] as value already exists [{}].", processContext, current);
-        }
-    }
-
-    public static void addBuildContext(String buildContext) {
-        String current = MDC.get(MDCKeys.BUILD_ID_KEY);
-        if (Strings.isEmpty(current)) {
-            if (!Strings.isEmpty(buildContext)) {
-                MDC.put(MDCKeys.BUILD_ID_KEY, buildContext);
-            }
-        } else {
-            log.warn("Did not set new buildContext [{}] as value already exists [{}].", buildContext, current);
+            log.warn("Did not set new identifierContext [{}] as value already exists [{}].", identifier, current);
         }
     }
 
@@ -69,23 +63,18 @@ public class MDCUtils {
         }
     }
 
-    public static void removeProcessContext() {
-        MDC.remove(MDCKeys.PROCESS_CONTEXT_KEY);
-    }
-
-    public static void removeBuildContext() {
-        MDC.remove(MDCKeys.BUILD_ID_KEY);
+    public static void removeIdentifierContext() {
+        MDC.remove(MDC_IDENTIFIER_KEY);
     }
 
     public static void removeOtelContext() {
-        MDC.remove(MDCKeys.TRACE_ID_KEY);
-        MDC.remove(MDCKeys.SPAN_ID_KEY);
-        MDC.remove(MDCHeaderKeys.TRACEPARENT.getMdcKey());
+        MDC.remove(MDC_TRACE_ID_KEY);
+        MDC.remove(MDC_SPAN_ID_KEY);
+        MDC.remove(MDC_TRACEPARENT_KEY);
     }
 
     public static void removeContext() {
-        removeProcessContext();
-        removeBuildContext();
+        removeIdentifierContext();
         removeOtelContext();
     }
 

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/MDCUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/MDCUtils.java
@@ -17,6 +17,9 @@
  */
 package org.jboss.sbomer.core.features.sbom.utils;
 
+import java.util.Map;
+
+import org.jboss.pnc.api.constants.MDCHeaderKeys;
 import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.pnc.common.Strings;
 import org.slf4j.MDC;
@@ -52,6 +55,20 @@ public class MDCUtils {
         }
     }
 
+    public static void addOtelContext(Map<String, String> otelContextMap) {
+        if (otelContextMap == null || otelContextMap.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) otelContextMap).entrySet()) {
+            final Object key = entry.getKey();
+            final Object value = entry.getValue();
+            if (key != null && value != null) {
+                MDC.put(key.toString(), value.toString());
+            }
+        }
+    }
+
     public static void removeProcessContext() {
         MDC.remove(MDCKeys.PROCESS_CONTEXT_KEY);
     }
@@ -60,8 +77,16 @@ public class MDCUtils {
         MDC.remove(MDCKeys.BUILD_ID_KEY);
     }
 
+    public static void removeOtelContext() {
+        MDC.remove(MDCKeys.TRACE_ID_KEY);
+        MDC.remove(MDCKeys.SPAN_ID_KEY);
+        MDC.remove(MDCHeaderKeys.TRACEPARENT.getMdcKey());
+    }
+
     public static void removeContext() {
         removeProcessContext();
         removeBuildContext();
+        removeOtelContext();
     }
+
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/s3/S3StorageHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/s3/S3StorageHandler.java
@@ -18,7 +18,6 @@
 
 package org.jboss.sbomer.service.feature.s3;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/EventNotificationFiringUtil.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/EventNotificationFiringUtil.java
@@ -22,9 +22,8 @@ import org.jboss.sbomer.service.feature.sbom.errata.event.release.StandardAdviso
 import org.jboss.sbomer.service.feature.sbom.errata.event.release.TextOnlyAdvisoryReleaseEvent;
 import org.jboss.sbomer.service.feature.sbom.errata.event.umb.AdvisoryUmbStatusChangeEvent;
 import org.jboss.sbomer.service.feature.sbom.errata.event.umb.PncBuildUmbStatusChangeEvent;
+import org.jboss.sbomer.service.feature.sbom.errata.event.util.MdcWrapperUtil;
 
-import io.quarkus.arc.Arc;
-import jakarta.enterprise.event.Event;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -39,8 +38,8 @@ public class EventNotificationFiringUtil {
                 "Firing async event for status update of request event with id: {} and config: {}",
                 requestEvent.getRequestEventId(),
                 requestEvent.getRequestEventConfig());
-        Event<Object> event = Arc.container().beanManager().getEvent();
-        event.fireAsync(requestEventNotification).whenComplete((result, throwable) -> {
+
+        MdcWrapperUtil.fireAsync(requestEventNotification).whenComplete((result, throwable) -> {
             if (throwable != null) {
                 log.error("Error occurred while processing the async event.", throwable);
             }
@@ -59,8 +58,7 @@ public class EventNotificationFiringUtil {
                     releaseEvent.getRequestEventId());
         }
 
-        Event<Object> event = Arc.container().beanManager().getEvent();
-        event.fireAsync(advisoryReleaseNotification).whenComplete((result, throwable) -> {
+        MdcWrapperUtil.fireAsync(advisoryReleaseNotification).whenComplete((result, throwable) -> {
             if (throwable != null) {
                 log.error("Error occurred while processing the async event.", throwable);
             }
@@ -71,8 +69,8 @@ public class EventNotificationFiringUtil {
         log.info(
                 "Firing async event for advisory UMB status update, with request event id: {} ",
                 ((AdvisoryUmbStatusChangeEvent) advisoryStatusNotification).getRequestEventId());
-        Event<Object> event = Arc.container().beanManager().getEvent();
-        event.fireAsync(advisoryStatusNotification).whenComplete((result, throwable) -> {
+
+        MdcWrapperUtil.fireAsync(advisoryStatusNotification).whenComplete((result, throwable) -> {
             if (throwable != null) {
                 log.error("Error occurred while processing the async event.", throwable);
             }
@@ -83,8 +81,8 @@ public class EventNotificationFiringUtil {
         log.info(
                 "Firing async event for PNC build UMB status update, with request event id: {} ",
                 ((PncBuildUmbStatusChangeEvent) pncBuildStatusNotification).getRequestEventId());
-        Event<Object> event = Arc.container().beanManager().getEvent();
-        event.fireAsync(pncBuildStatusNotification).whenComplete((result, throwable) -> {
+
+        MdcWrapperUtil.fireAsync(pncBuildStatusNotification).whenComplete((result, throwable) -> {
             if (throwable != null) {
                 log.error("Error occurred while processing the async event.", throwable);
             }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/comment/CommentAdvisoryOnRelevantEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/comment/CommentAdvisoryOnRelevantEventsListener.java
@@ -39,7 +39,6 @@ import org.jboss.sbomer.service.feature.sbom.errata.ErrataClient;
 import org.jboss.sbomer.service.feature.sbom.errata.dto.Errata;
 import org.jboss.sbomer.service.feature.sbom.errata.dto.enums.ErrataStatus;
 import org.jboss.sbomer.service.feature.sbom.errata.event.AdvisoryEventUtils;
-import org.jboss.sbomer.service.feature.sbom.errata.event.release.StandardAdvisoryReleaseEvent;
 import org.jboss.sbomer.service.feature.sbom.errata.event.util.MdcEventWrapper;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
@@ -73,7 +72,7 @@ public class CommentAdvisoryOnRelevantEventsListener {
     @Inject
     FeatureFlags featureFlags;
 
-    public void onRequestEventStatusUpdate(@ObservesAsync MdcEventWrapper<RequestEventStatusUpdateEvent> wrapper) {
+    public void onRequestEventStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -81,7 +80,7 @@ public class CommentAdvisoryOnRelevantEventsListener {
             MDC.clear();
         }
 
-        RequestEventStatusUpdateEvent event = wrapper.getPayload();
+        RequestEventStatusUpdateEvent event = (RequestEventStatusUpdateEvent) wrapper.getPayload();
         log.debug("Event received for request event status update...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -90,7 +90,7 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
 
     private static final String NVR_STANDARD_SEPARATOR = "-";
 
-    public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper) {
+    public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper wrapper) {
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -98,7 +98,7 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
             MDC.clear();
         }
 
-        StandardAdvisoryReleaseEvent event = wrapper.getPayload();
+        StandardAdvisoryReleaseEvent event = (StandardAdvisoryReleaseEvent) wrapper.getPayload();
         log.debug("Event received for standard advisory release ...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
@@ -64,7 +64,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListener {
 
-    public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper<TextOnlyAdvisoryReleaseEvent> wrapper) {
+    public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper wrapper) {
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -72,7 +72,7 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
             MDC.clear();
         }
 
-        TextOnlyAdvisoryReleaseEvent event = wrapper.getPayload();
+        TextOnlyAdvisoryReleaseEvent event = (TextOnlyAdvisoryReleaseEvent) wrapper.getPayload();
         log.debug("Event received for text-only advisory release ...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/AdvisoryUmbStatusChangeEventListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/AdvisoryUmbStatusChangeEventListener.java
@@ -41,7 +41,7 @@ public class AdvisoryUmbStatusChangeEventListener {
     @Inject
     ErrataNotificationHandler errataNotificationHandler;
 
-    public void onAdvisoryStatusUpdate(@ObservesAsync MdcEventWrapper<AdvisoryUmbStatusChangeEvent> wrapper) {
+    public void onAdvisoryStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
 
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
@@ -50,7 +50,7 @@ public class AdvisoryUmbStatusChangeEventListener {
             MDC.clear();
         }
 
-        AdvisoryUmbStatusChangeEvent event = wrapper.getPayload();
+        AdvisoryUmbStatusChangeEvent event = (AdvisoryUmbStatusChangeEvent) wrapper.getPayload();
 
         try {
             errataNotificationHandler.handle(event.getRequestEventId());

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/PncBuildUmbStatusChangeEventListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/PncBuildUmbStatusChangeEventListener.java
@@ -42,7 +42,7 @@ public class PncBuildUmbStatusChangeEventListener {
     @Inject
     PncNotificationHandler pncNotificationHandler;
 
-    public void onPncBuildStatusUpdate(@ObservesAsync MdcEventWrapper<PncBuildUmbStatusChangeEvent> wrapper) {
+    public void onPncBuildStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -50,7 +50,7 @@ public class PncBuildUmbStatusChangeEventListener {
             MDC.clear();
         }
 
-        PncBuildUmbStatusChangeEvent event = wrapper.getPayload();
+        PncBuildUmbStatusChangeEvent event = (PncBuildUmbStatusChangeEvent) wrapper.getPayload();
 
         try {
             pncNotificationHandler.handle(event.getRequestEventId());

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcEventWrapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcEventWrapper.java
@@ -20,16 +20,16 @@ package org.jboss.sbomer.service.feature.sbom.errata.event.util;
 import java.io.Serializable;
 import java.util.Map;
 
-public class MdcEventWrapper<T> implements Serializable {
-    private final T payload;
+public class MdcEventWrapper implements Serializable {
+    private final Object payload;
     private final Map<String, String> mdcContext;
 
-    public MdcEventWrapper(T payload, Map<String, String> mdcContext) {
+    public MdcEventWrapper(Object payload, Map<String, String> mdcContext) {
         this.payload = payload;
         this.mdcContext = mdcContext;
     }
 
-    public T getPayload() {
+    public Object getPayload() {
         return payload;
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcEventWrapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcEventWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.errata.event.util;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class MdcEventWrapper<T> implements Serializable {
+    private final T payload;
+    private final Map<String, String> mdcContext;
+
+    public MdcEventWrapper(T payload, Map<String, String> mdcContext) {
+        this.payload = payload;
+        this.mdcContext = mdcContext;
+    }
+
+    public T getPayload() {
+        return payload;
+    }
+
+    public Map<String, String> getMdcContext() {
+        return mdcContext;
+    }
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcWrapperUtil.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcWrapperUtil.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.sbomer.service.feature.sbom.errata.event.util;
+
+import io.quarkus.arc.Arc;
+import jakarta.enterprise.event.Event;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import org.slf4j.MDC;
+
+public class MdcWrapperUtil {
+
+    private MdcWrapperUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static <T> CompletionStage<MdcEventWrapper<T>> fireAsync(T payload) {
+        Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+        Event<Object> event = Arc.container().beanManager().getEvent();
+
+        return event.fireAsync(new MdcEventWrapper<>(payload, mdcContext));
+    }
+
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcWrapperUtil.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/util/MdcWrapperUtil.java
@@ -29,11 +29,11 @@ public class MdcWrapperUtil {
         throw new IllegalStateException("Utility class");
     }
 
-    public static <T> CompletionStage<MdcEventWrapper<T>> fireAsync(T payload) {
+    public static CompletionStage<MdcEventWrapper> fireAsync(Object payload) {
         Map<String, String> mdcContext = MDC.getCopyOfContextMap();
         Event<Object> event = Arc.container().beanManager().getEvent();
 
-        return event.fireAsync(new MdcEventWrapper<>(payload, mdcContext));
+        return event.fireAsync(new MdcEventWrapper(payload, mdcContext));
     }
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
@@ -160,6 +160,10 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
      */
     @Transactional
     protected List<Sbom> storeBoms(GenerationRequest generationRequest, List<Bom> boms) {
+        MDCUtils.removeOtelContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         // First, update the status of the GenerationRequest entity.
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
 
@@ -257,6 +261,10 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
 
     @Override
     public DeleteControl cleanup(GenerationRequest resource, Context<GenerationRequest> context) {
+        MDCUtils.removeOtelContext();
+        MDCUtils.addBuildContext(resource.getIdentifier());
+        MDCUtils.addOtelContext(resource.getMDCOtel());
+
         log.debug("GenerationRequest '{}' was removed from the system", resource.getMetadata().getName());
         return DeleteControl.defaultDelete();
     }
@@ -265,7 +273,10 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
     public UpdateControl<GenerationRequest> reconcile(
             GenerationRequest generationRequest,
             Context<GenerationRequest> context) throws Exception {
+
         MDCUtils.removeContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status is set, it should be "NEW", let's do it.
         // "NEW" starts everything.
@@ -281,8 +292,6 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
                 "Handling update for GenerationRequest '{}', current status: '{}'",
                 generationRequest.getMetadata().getName(),
                 generationRequest.getStatus());
-
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
 
         switch (generationRequest.getStatus()) {
             case NEW:

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/AbstractController.java
@@ -161,7 +161,7 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
     @Transactional
     protected List<Sbom> storeBoms(GenerationRequest generationRequest, List<Bom> boms) {
         MDCUtils.removeOtelContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // First, update the status of the GenerationRequest entity.
@@ -262,7 +262,7 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
     @Override
     public DeleteControl cleanup(GenerationRequest resource, Context<GenerationRequest> context) {
         MDCUtils.removeOtelContext();
-        MDCUtils.addBuildContext(resource.getIdentifier());
+        MDCUtils.addIdentifierContext(resource.getIdentifier());
         MDCUtils.addOtelContext(resource.getMDCOtel());
 
         log.debug("GenerationRequest '{}' was removed from the system", resource.getMetadata().getName());
@@ -275,7 +275,7 @@ public abstract class AbstractController implements Reconciler<GenerationRequest
             Context<GenerationRequest> context) throws Exception {
 
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status is set, it should be "NEW", let's do it.

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/rpm/controller/TaskRunBrewRPMGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/generator/rpm/controller/TaskRunBrewRPMGenerateDependentResource.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.BrewRPMConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.GenerateResourceDiscriminator;
@@ -79,6 +80,9 @@ public class TaskRunBrewRPMGenerateDependentResource
     @Override
     protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
 
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}' GenerationRequest",
                 SbomGenerationPhase.GENERATE,
@@ -87,6 +91,9 @@ public class TaskRunBrewRPMGenerateDependentResource
 
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.GENERATE.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         Duration timeout;
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequest.java
@@ -19,6 +19,8 @@ package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
 import java.util.Map;
 
+import org.jboss.pnc.api.constants.MDCHeaderKeys;
+import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.Config;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
@@ -251,4 +253,30 @@ public class GenerationRequest extends ConfigMap {
         return getMetadata().getName();
     }
 
+    @JsonIgnore
+    public String getTraceId() {
+        return getMetadata().getLabels().get(Labels.LABEL_OTEL_TRACE_ID);
+    }
+
+    @JsonIgnore
+    public String getSpanId() {
+        return getMetadata().getLabels().get(Labels.LABEL_OTEL_SPAN_ID);
+    }
+
+    @JsonIgnore
+    public String getTraceParent() {
+        return getMetadata().getLabels().get(Labels.LABEL_OTEL_TRACEPARENT);
+    }
+
+    @JsonIgnore
+    public Map<String, String> getMDCOtel() {
+
+        return Map.of(
+                MDCKeys.TRACE_ID_KEY,
+                getTraceId(),
+                MDCKeys.SPAN_ID_KEY,
+                getSpanId(),
+                MDCHeaderKeys.TRACEPARENT.getMdcKey(),
+                getTraceParent());
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestBuilder.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.sbomer.service.feature.sbom.k8s.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
@@ -40,7 +42,7 @@ public class GenerationRequestBuilder extends GenerationRequestFluent<Generation
     public GenerationRequest build() {
         withNewMetadataLike(
                 new ObjectMetaBuilder().withName("sbom-request-" + getId().toLowerCase())
-                        .withLabels(Labels.defaultLabelsToMap(getType()))
+                        .withLabels(buildLabelsMap())
                         .build())
                 .endMetadata();
 
@@ -70,5 +72,21 @@ public class GenerationRequestBuilder extends GenerationRequestFluent<Generation
         buildable.setAdditionalProperties(getAdditionalProperties());
 
         return buildable;
+    }
+
+    private Map<String, String> buildLabelsMap() {
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.putAll(Labels.defaultLabelsToMap(getType()));
+
+        if (getTraceId() != null) {
+            labels.put(Labels.LABEL_OTEL_TRACE_ID, getTraceId());
+        }
+        if (getSpanId() != null) {
+            labels.put(Labels.LABEL_OTEL_SPAN_ID, getSpanId());
+        }
+        if (getTraceParent() != null) {
+            labels.put(Labels.LABEL_OTEL_TRACEPARENT, getTraceParent());
+        }
+        return labels;
     }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/model/GenerationRequestFluent.java
@@ -38,6 +38,9 @@ public class GenerationRequestFluent<A extends GenerationRequestFluent<A>> exten
     private String config;
     private String envConfig;
     private GenerationResult result;
+    private String traceId;
+    private String spanId;
+    private String traceParent;
 
     public A withType(GenerationRequestType type) {
         this.type = type;
@@ -89,4 +92,18 @@ public class GenerationRequestFluent<A extends GenerationRequestFluent<A>> exten
         return (A) this;
     }
 
+    public A withTraceId(String traceId) {
+        this.traceId = traceId;
+        return (A) this;
+    }
+
+    public A withSpanId(String spanId) {
+        this.spanId = spanId;
+        return (A) this;
+    }
+
+    public A withTraceParent(String traceParent) {
+        this.traceParent = traceParent;
+        return (A) this;
+    }
 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
@@ -474,6 +474,8 @@ public class BuildController extends AbstractController {
             Context<GenerationRequest> context) throws Exception {
 
         MDCUtils.removeContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status is set, it should be "NEW", let's do it.
         // "NEW" starts everything.
@@ -494,8 +496,6 @@ public class BuildController extends AbstractController {
                 "Handling update for GenerationRequest '{}', current status: '{}'",
                 generationRequest.getMetadata().getName(),
                 generationRequest.getStatus());
-
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
 
         switch (generationRequest.getStatus()) {
             case NEW:
@@ -548,6 +548,10 @@ public class BuildController extends AbstractController {
     }
 
     protected List<Sbom> storeSboms(GenerationRequest generationRequest) {
+        MDCUtils.removeOtelContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
 
         log.info(

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/BuildController.java
@@ -474,7 +474,7 @@ public class BuildController extends AbstractController {
             Context<GenerationRequest> context) throws Exception {
 
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status is set, it should be "NEW", let's do it.
@@ -549,7 +549,7 @@ public class BuildController extends AbstractController {
 
     protected List<Sbom> storeSboms(GenerationRequest generationRequest) {
         MDCUtils.removeOtelContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
@@ -486,7 +486,7 @@ public class OperationController extends AbstractController {
             Context<GenerationRequest> context) throws Exception {
 
         MDCUtils.removeContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status set set, it should be "NEW", let's do it.
@@ -561,7 +561,7 @@ public class OperationController extends AbstractController {
     protected List<Sbom> storeOperationSboms(GenerationRequest generationRequest) {
 
         MDCUtils.removeOtelContext();
-        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addIdentifierContext(generationRequest.getIdentifier());
         MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/reconciler/OperationController.java
@@ -486,6 +486,8 @@ public class OperationController extends AbstractController {
             Context<GenerationRequest> context) throws Exception {
 
         MDCUtils.removeContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
 
         // No status set set, it should be "NEW", let's do it.
         // "NEW" starts everything.
@@ -557,6 +559,11 @@ public class OperationController extends AbstractController {
     }
 
     protected List<Sbom> storeOperationSboms(GenerationRequest generationRequest) {
+
+        MDCUtils.removeOtelContext();
+        MDCUtils.addBuildContext(generationRequest.getIdentifier());
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(generationRequest);
 
         log.info(

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/Labels.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/Labels.java
@@ -32,6 +32,10 @@ public class Labels {
     public static final String LABEL_PHASE = "sbomer.jboss.org/phase";
     public static final String LABEL_IDENTIFIER = "sbomer.jboss.org/identifier";
     public static final String LABEL_GENERATION_REQUEST_ID = "sbomer.jboss.org/generation-request-id";
+    public static final String LABEL_OTEL_TRACE_ID = "sbomer.jboss.org/otel-trace-id";
+    public static final String LABEL_OTEL_SPAN_ID = "sbomer.jboss.org/otel-span-id";
+    public static final String LABEL_OTEL_TRACEPARENT = "sbomer.jboss.org/otel-traceparent";
+
     // The selector used but the only (atm) reconciler is generic, without the generation request type label, so to
     // select all types
     public static final String LABEL_SELECTOR = "app.kubernetes.io/part-of=sbomer,app.kubernetes.io/component=sbom,app.kubernetes.io/managed-by=sbom,sbomer.jboss.org/type=generation-request";

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunGenerateBuildDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunGenerateBuildDependentResource.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.PncBuildConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
@@ -103,6 +104,10 @@ public class TaskRunGenerateBuildDependentResource extends KubernetesDependentRe
     }
 
     private TaskRun desired(PncBuildConfig config, int index, GenerationRequest generationRequest) {
+
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}' GenerationRequest",
                 SbomGenerationPhase.GENERATE,
@@ -113,6 +118,9 @@ public class TaskRunGenerateBuildDependentResource extends KubernetesDependentRe
         labels.put(Labels.LABEL_IDENTIFIER, generationRequest.getIdentifier());
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.GENERATE.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         String configStr;
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunInitDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunInitDependentResource.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 
@@ -71,6 +72,9 @@ public class TaskRunInitDependentResource extends CRUDNoGCKubernetesDependentRes
     @Override
     protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
 
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}'",
                 SbomGenerationPhase.INIT,
@@ -81,6 +85,9 @@ public class TaskRunInitDependentResource extends CRUDNoGCKubernetesDependentRes
         labels.put(Labels.LABEL_IDENTIFIER, generationRequest.getIdentifier());
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.INIT.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         return new TaskRunBuilder().withNewMetadata()
                 .withNamespace(generationRequest.getMetadata().getNamespace())

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationGenerateDependentResource.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.OperationConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
@@ -105,6 +106,9 @@ public class TaskRunOperationGenerateDependentResource extends KubernetesDepende
 
     private TaskRun desired(OperationConfig config, int index, GenerationRequest generationRequest) {
 
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}' GenerationRequest",
                 SbomGenerationPhase.OPERATIONGENERATE,
@@ -115,6 +119,9 @@ public class TaskRunOperationGenerateDependentResource extends KubernetesDepende
         labels.put(Labels.LABEL_IDENTIFIER, generationRequest.getIdentifier());
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.OPERATIONGENERATE.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         String configStr;
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationInitDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/k8s/resources/TaskRunOperationInitDependentResource.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.features.sbom.config.OperationConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 
@@ -72,6 +73,9 @@ public class TaskRunOperationInitDependentResource
     @Override
     protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
 
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}'",
                 SbomGenerationPhase.OPERATIONINIT,
@@ -82,6 +86,9 @@ public class TaskRunOperationInitDependentResource
         labels.put(Labels.LABEL_IDENTIFIER, generationRequest.getIdentifier());
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.OPERATIONINIT.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         OperationConfig config = generationRequest.getConfig(OperationConfig.class, true);
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/model/SbomGenerationRequest.java
@@ -29,8 +29,6 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.type.SqlTypes;
-import org.jboss.pnc.api.constants.MDCHeaderKeys;
-import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.sbomer.core.features.sbom.config.Config;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
@@ -68,6 +66,10 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_TRACE_ID_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_SPAN_ID_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_TRACEPARENT_KEY;
 
 @JsonInclude(Include.NON_NULL)
 @DynamicUpdate
@@ -166,9 +168,9 @@ public class SbomGenerationRequest extends PanacheEntityBase {
         // Update the OTEL metadata
         if (generationRequest.getTraceId() != null) {
             ObjectNode otelMetadata = ObjectMapperProvider.json().createObjectNode();
-            otelMetadata.put(MDCKeys.TRACE_ID_KEY, generationRequest.getTraceId());
-            otelMetadata.put(MDCKeys.SPAN_ID_KEY, generationRequest.getSpanId());
-            otelMetadata.put(MDCHeaderKeys.TRACEPARENT.getMdcKey(), generationRequest.getTraceParent());
+            otelMetadata.put(MDC_TRACE_ID_KEY, generationRequest.getTraceId());
+            otelMetadata.put(MDC_SPAN_ID_KEY, generationRequest.getSpanId());
+            otelMetadata.put(MDC_TRACEPARENT_KEY, generationRequest.getTraceParent());
             sbomGenerationRequest.setOtelMetadata(otelMetadata);
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -293,7 +293,7 @@ public class SbomService {
             PncBuildConfig config) {
         try {
             PncBuildRequestConfig pncRequestConfig = (PncBuildRequestConfig) requestConfig;
-            MDCUtils.addBuildContext(pncRequestConfig.getBuildId());
+            MDCUtils.addIdentifierContext(pncRequestConfig.getBuildId());
 
             log.info("New generation request for build id '{}'", pncRequestConfig.getBuildId());
             log.debug(
@@ -338,7 +338,7 @@ public class SbomService {
 
             return sbomGenerationRequest;
         } finally {
-            MDCUtils.removeBuildContext();
+            MDCUtils.removeIdentifierContext();
         }
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/generator/image/controller/TaskRunSyftImageGenerateDependentResource.java
+++ b/service/src/main/java/org/jboss/sbomer/service/generator/image/controller/TaskRunSyftImageGenerateDependentResource.java
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.core.errors.ApplicationException;
 import org.jboss.sbomer.core.features.sbom.config.SyftImageConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
+import org.jboss.sbomer.core.features.sbom.utils.MDCUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationPhase;
 import org.jboss.sbomer.service.feature.sbom.k8s.resources.GenerateResourceDiscriminator;
@@ -76,6 +77,9 @@ public class TaskRunSyftImageGenerateDependentResource
     @Override
     protected TaskRun desired(GenerationRequest generationRequest, Context<GenerationRequest> context) {
 
+        MDCUtils.removeOtelContext();
+        MDCUtils.addOtelContext(generationRequest.getMDCOtel());
+
         log.debug(
                 "Preparing dependent resource for the '{}' phase related to '{}' GenerationRequest",
                 SbomGenerationPhase.GENERATE,
@@ -84,6 +88,9 @@ public class TaskRunSyftImageGenerateDependentResource
 
         labels.put(Labels.LABEL_PHASE, SbomGenerationPhase.GENERATE.name().toLowerCase());
         labels.put(Labels.LABEL_GENERATION_REQUEST_ID, generationRequest.getId());
+        labels.put(Labels.LABEL_OTEL_TRACE_ID, generationRequest.getTraceId());
+        labels.put(Labels.LABEL_OTEL_SPAN_ID, generationRequest.getSpanId());
+        labels.put(Labels.LABEL_OTEL_TRACEPARENT, generationRequest.getTraceParent());
 
         Duration timeout;
 

--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1alpha3/ApiV1Alpha3.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1alpha3/ApiV1Alpha3.java
@@ -472,12 +472,12 @@ public class ApiV1Alpha3 {
     public Response deleteGenerationRequest(@PathParam("id") final String id) {
 
         try {
-            MDCUtils.addProcessContext(id);
+            MDCUtils.addIdentifierContext(id);
             sbomService.deleteSbomRequest(id);
 
             return Response.ok().build();
         } finally {
-            MDCUtils.removeProcessContext();
+            MDCUtils.removeIdentifierContext();
         }
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
@@ -317,12 +317,12 @@ public class GenerationsV1Beta1 {
     public Response deleteGenerationRequest(@PathParam("id") final String id) {
 
         try {
-            MDCUtils.addProcessContext(id);
+            MDCUtils.addIdentifierContext(id);
             sbomService.deleteSbomRequest(id);
 
             return Response.ok().build();
         } finally {
-            MDCUtils.removeProcessContext();
+            MDCUtils.removeIdentifierContext();
         }
     }
 

--- a/service/src/main/java/org/jboss/sbomer/service/scheduler/GenerationRequestScheduler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/scheduler/GenerationRequestScheduler.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.pnc.api.constants.MDCKeys;
 import org.jboss.pnc.common.otel.OtelUtils;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.GenerationRequestBuilder;
@@ -45,6 +44,12 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.Transactional.TxType;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_TRACE_ID_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_SPAN_ID_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_TRACE_FLAGS_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_TRACE_STATE_KEY;
+import static org.jboss.sbomer.core.features.sbom.utils.MDCUtils.MDC_IDENTIFIER_KEY;
 
 @ApplicationScoped
 @Slf4j
@@ -170,12 +175,12 @@ public class GenerationRequestScheduler {
                 GlobalOpenTelemetry.get().getTracer(""),
                 "GenerationRequestScheduler.schedule",
                 SpanKind.CLIENT,
-                MDC.get(MDCKeys.TRACE_ID_KEY),
-                MDC.get(MDCKeys.SPAN_ID_KEY),
-                MDC.get(MDCKeys.TRACE_FLAGS_KEY),
-                MDC.get(MDCKeys.TRACE_STATE_KEY),
+                MDC.get(MDC_TRACE_ID_KEY),
+                MDC.get(MDC_SPAN_ID_KEY),
+                MDC.get(MDC_TRACE_FLAGS_KEY),
+                MDC.get(MDC_TRACE_STATE_KEY),
                 Span.current().getSpanContext(),
-                Map.of(MDCKeys.BUILD_ID_KEY, sbomGenerationRequest.getIdentifier()));
+                Map.of(MDC_IDENTIFIER_KEY, sbomGenerationRequest.getIdentifier()));
         Span span = spanBuilder.startSpan();
 
         log.debug(

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -119,7 +119,7 @@ quarkus:
       # Disable JSON logging for console by default
       json:
         ~: false
-      format: "%d{HH:mm:ss,SSS} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{3.}] (%t) %s%e mdc:[%X]%n"
+      format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
     file:
       level: DEBUG
       # Disable file logging

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -119,7 +119,7 @@ quarkus:
       # Disable JSON logging for console by default
       json:
         ~: false
-      format: "%d{HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e mdc:[%X]%n"
+      format: "%d{HH:mm:ss,SSS} %-5p traceId=%X{traceId} parentId=%X{parentId} spanId=%X{spanId} [%c{3.}] (%t) %s%e mdc:[%X]%n"
     file:
       level: DEBUG
       # Disable file logging

--- a/service/src/main/resources/db-update/00023.sql
+++ b/service/src/main/resources/db-update/00023.sql
@@ -1,0 +1,26 @@
+--
+-- JBoss, Home of Professional Open Source.
+-- Copyright 2023 Red Hat, Inc., and individual contributors
+-- as indicated by the @author tags.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--------------------------------------------------------------------------
+-- Add the new 'otel_metadata' column to 'sbom_generation_request' table
+--------------------------------------------------------------------------
+BEGIN;
+    ALTER TABLE sbom_generation_request ADD COLUMN otel_metadata jsonb;
+    CREATE INDEX idx_request_otel_metadata ON sbom_generation_request USING GIN (otel_metadata);
+    INSERT INTO db_version(version, creation_time) VALUES ('00023', now());
+COMMIT;

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/errata/ReleaseAdvisoryEventsListenerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/errata/ReleaseAdvisoryEventsListenerTest.java
@@ -753,9 +753,7 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        MdcEventWrapper<TextOnlyAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<TextOnlyAdvisoryReleaseEvent>(
-                event,
-                MDC.getCopyOfContextMap());
+        MdcEventWrapper wrapper = new MdcEventWrapper(event, MDC.getCopyOfContextMap());
 
         listenerTextOnlyManifests.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
@@ -816,9 +814,7 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        MdcEventWrapper<TextOnlyAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<TextOnlyAdvisoryReleaseEvent>(
-                event,
-                MDC.getCopyOfContextMap());
+        MdcEventWrapper wrapper = new MdcEventWrapper(event, MDC.getCopyOfContextMap());
 
         listenerTextOnlyDeliverables.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
@@ -904,9 +900,7 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
-                event,
-                MDC.getCopyOfContextMap());
+        MdcEventWrapper wrapper = new MdcEventWrapper(event, MDC.getCopyOfContextMap());
 
         listenerSingleContainer.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
@@ -1055,9 +1049,7 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
-                event,
-                MDC.getCopyOfContextMap());
+        MdcEventWrapper wrapper = new MdcEventWrapper(event, MDC.getCopyOfContextMap());
         listenerMultiContainers.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
@@ -1144,9 +1136,7 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
-                event,
-                MDC.getCopyOfContextMap());
+        MdcEventWrapper wrapper = new MdcEventWrapper(event, MDC.getCopyOfContextMap());
         listenerSingleRpm.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/errata/ReleaseAdvisoryEventsListenerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/errata/ReleaseAdvisoryEventsListenerTest.java
@@ -60,6 +60,7 @@ import org.jboss.sbomer.service.feature.sbom.errata.dto.ErrataCDNRepoNormalized;
 import org.jboss.sbomer.service.feature.sbom.errata.dto.ErrataVariant;
 import org.jboss.sbomer.service.feature.sbom.errata.event.release.StandardAdvisoryReleaseEvent;
 import org.jboss.sbomer.service.feature.sbom.errata.event.release.TextOnlyAdvisoryReleaseEvent;
+import org.jboss.sbomer.service.feature.sbom.errata.event.util.MdcEventWrapper;
 import org.jboss.sbomer.service.feature.sbom.errata.event.release.ReleaseStandardAdvisoryEventsListener;
 import org.jboss.sbomer.service.feature.sbom.errata.event.release.ReleaseTextOnlyAdvisoryEventsListener;
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
@@ -76,6 +77,7 @@ import org.jboss.sbomer.service.feature.sbom.service.SbomGenerationRequestReposi
 import org.jboss.sbomer.service.feature.sbom.service.SbomService;
 import org.jboss.sbomer.service.stats.StatsService;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -751,7 +753,11 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        listenerTextOnlyManifests.onReleaseAdvisoryEvent(event);
+        MdcEventWrapper<TextOnlyAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<TextOnlyAdvisoryReleaseEvent>(
+                event,
+                MDC.getCopyOfContextMap());
+
+        listenerTextOnlyManifests.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
                 .forEach(request -> assertNotEquals(RequestEventStatus.FAILED, request.getRequest().getEventStatus()));
@@ -810,7 +816,11 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        listenerTextOnlyDeliverables.onReleaseAdvisoryEvent(event);
+        MdcEventWrapper<TextOnlyAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<TextOnlyAdvisoryReleaseEvent>(
+                event,
+                MDC.getCopyOfContextMap());
+
+        listenerTextOnlyDeliverables.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
                 .forEach(request -> assertNotEquals(RequestEventStatus.FAILED, request.getRequest().getEventStatus()));
@@ -894,7 +904,11 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        listenerSingleContainer.onReleaseAdvisoryEvent(event);
+        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
+                event,
+                MDC.getCopyOfContextMap());
+
+        listenerSingleContainer.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
                 .forEach(request -> assertNotEquals(RequestEventStatus.FAILED, request.getRequest().getEventStatus()));
@@ -1041,7 +1055,10 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        listenerMultiContainers.onReleaseAdvisoryEvent(event);
+        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
+                event,
+                MDC.getCopyOfContextMap());
+        listenerMultiContainers.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
                 .forEach(request -> assertNotEquals(RequestEventStatus.FAILED, request.getRequest().getEventStatus()));
@@ -1127,7 +1144,10 @@ class ReleaseAdvisoryEventsListenerTest {
                 .withRequestEventId(requestEvent.getId())
                 .withReleaseGenerations(pvToGenerations)
                 .build();
-        listenerSingleRpm.onReleaseAdvisoryEvent(event);
+        MdcEventWrapper<StandardAdvisoryReleaseEvent> wrapper = new MdcEventWrapper<StandardAdvisoryReleaseEvent>(
+                event,
+                MDC.getCopyOfContextMap());
+        listenerSingleRpm.onReleaseAdvisoryEvent(wrapper);
         event.getReleaseGenerations()
                 .values()
                 .forEach(request -> assertNotEquals(RequestEventStatus.FAILED, request.getRequest().getEventStatus()));


### PR DESCRIPTION
@goldmann Hi this a first set of changes to propagate correctly the MDC context across the service.
Main highlights:

- I have simplified the logs removing the duplicated tracing information. Now `traceId`, `spanId` etc are only displayed once inside the MDC context (at the end of the log line)
- I have created WrapperUtils to propagate the MDCContext across threads (e.g. the async firing utils)
- The `GenerationRequestScheduler` is responsible for creating `GenerationRequest` with `traceId`, `spandId` and `traceparent` values. A new span is created for every new `GenerationRequest` so that it's easier to differentiate generations having the same `traceId`. Searching via `spanId` is going to be much more precise.
- The `GenerationRequestBuilder` will create ConfigMaps containing new LABELS `sbomer.jboss.org/otel-trace-id`, `sbomer.jboss.org/otel-span-id`, `sbomer.jboss.org/otel-traceparent` with the values of the corresponding `GenerationRequest`.
- Similarly, the `TaskRun*DependentResource` classes will create TaskRuns having the above LABELS, so that we propagate the MDCContext values in the TektonRuns
- The various controllers are able to use the MDCContext coming from `Tasks` and `GenerationRequest` and use them accordingly.
- The entity `SbomGenerationRequest` has now an additional `otelMetadata` JsonNode, where we store the otel information for every request. This will make it simple to search relevant logs of a generation.

There might be more adjustments to add but I have seen great improvement in logs with these changes.

I will work in another PR to use the LABELS inside the Tekton Tasks, so that we can add them in the log ouptut and have a full searchable history via OTEL metadata.
