### PR TITLE
fix(SBOMER-381): check the payload types before processing to avoid class cast exceptions

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/comment/CommentAdvisoryOnRelevantEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/comment/CommentAdvisoryOnRelevantEventsListener.java
@@ -73,6 +73,11 @@ public class CommentAdvisoryOnRelevantEventsListener {
     FeatureFlags featureFlags;
 
     public void onRequestEventStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
+        Object payload = wrapper.getPayload();
+        if (!(payload instanceof RequestEventStatusUpdateEvent event)) {
+            return;
+        }
+
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -80,7 +85,6 @@ public class CommentAdvisoryOnRelevantEventsListener {
             MDC.clear();
         }
 
-        RequestEventStatusUpdateEvent event = (RequestEventStatusUpdateEvent) wrapper.getPayload();
         log.debug("Event received for request event status update...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -91,6 +91,11 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
     private static final String NVR_STANDARD_SEPARATOR = "-";
 
     public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper wrapper) {
+        Object payload = wrapper.getPayload();
+        if (!(payload instanceof StandardAdvisoryReleaseEvent event)) {
+            return;
+        }
+
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -98,7 +103,6 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
             MDC.clear();
         }
 
-        StandardAdvisoryReleaseEvent event = (StandardAdvisoryReleaseEvent) wrapper.getPayload();
         log.debug("Event received for standard advisory release ...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
@@ -65,6 +65,11 @@ import lombok.extern.slf4j.Slf4j;
 public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListener {
 
     public void onReleaseAdvisoryEvent(@ObservesAsync MdcEventWrapper wrapper) {
+        Object payload = wrapper.getPayload();
+        if (!(payload instanceof TextOnlyAdvisoryReleaseEvent event)) {
+            return;
+        }
+
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
@@ -72,7 +77,6 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
             MDC.clear();
         }
 
-        TextOnlyAdvisoryReleaseEvent event = (TextOnlyAdvisoryReleaseEvent) wrapper.getPayload();
         log.debug("Event received for text-only advisory release ...");
 
         try {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/AdvisoryUmbStatusChangeEventListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/AdvisoryUmbStatusChangeEventListener.java
@@ -42,6 +42,10 @@ public class AdvisoryUmbStatusChangeEventListener {
     ErrataNotificationHandler errataNotificationHandler;
 
     public void onAdvisoryStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
+        Object payload = wrapper.getPayload();
+        if (!(payload instanceof AdvisoryUmbStatusChangeEvent event)) {
+            return;
+        }
 
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
@@ -49,8 +53,6 @@ public class AdvisoryUmbStatusChangeEventListener {
         } else {
             MDC.clear();
         }
-
-        AdvisoryUmbStatusChangeEvent event = (AdvisoryUmbStatusChangeEvent) wrapper.getPayload();
 
         try {
             errataNotificationHandler.handle(event.getRequestEventId());

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/PncBuildUmbStatusChangeEventListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/umb/PncBuildUmbStatusChangeEventListener.java
@@ -43,14 +43,17 @@ public class PncBuildUmbStatusChangeEventListener {
     PncNotificationHandler pncNotificationHandler;
 
     public void onPncBuildStatusUpdate(@ObservesAsync MdcEventWrapper wrapper) {
+        Object payload = wrapper.getPayload();
+        if (!(payload instanceof PncBuildUmbStatusChangeEvent event)) {
+            return;
+        }
+
         Map<String, String> mdcContext = wrapper.getMdcContext();
         if (mdcContext != null) {
             MDC.setContextMap(mdcContext);
         } else {
             MDC.clear();
         }
-
-        PncBuildUmbStatusChangeEvent event = (PncBuildUmbStatusChangeEvent) wrapper.getPayload();
 
         try {
             pncNotificationHandler.handle(event.getRequestEventId());


### PR DESCRIPTION
Now that the events are wrapped in a single class, we need to instruct the listeners to discard non-relevant events.