### PR TITLE
fix(kerberos): kerberos and retry fixes

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/ErrataClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/ErrataClient.java
@@ -79,7 +79,11 @@ public interface ErrataClient {
     // Retrieve the advisory data, the id could be advisory id or advisory name.
     @GET
     @Path("/erratum/{id}")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     Errata getErratum(@PathParam("id") String erratumId);
@@ -87,7 +91,11 @@ public interface ErrataClient {
     // Get the details of a product by its id or short name
     @GET
     @Path("/products/{id}")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataProduct getProduct(@PathParam("id") String productId);
@@ -95,7 +103,11 @@ public interface ErrataClient {
     // Get the details of a release by its id or name
     @GET
     @Path("/releases/{id}")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataRelease getRelease(@PathParam("id") String releaseId);
@@ -103,7 +115,11 @@ public interface ErrataClient {
     // Get the details of a variant by its name or id
     @GET
     @Path("/variants/{id}")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataVariant getVariant(@PathParam("id") String variantId);
@@ -111,7 +127,11 @@ public interface ErrataClient {
     // Get the details of a variant by its name or id
     @GET
     @Path("/variants")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataPage<ErrataVariant.VariantData> getAllVariants(@Valid @BeanParam ErrataQueryParameters pageParameters);
@@ -119,7 +139,11 @@ public interface ErrataClient {
     // Add a comment to an advisory. Example request body: {"comment": "This is my comment"}
     @POST
     @Path("/erratum/{id}/add_comment")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     Errata addCommentToErratum(@PathParam("id") String erratumId, String comment);
@@ -127,7 +151,11 @@ public interface ErrataClient {
     // Fetch the Brew builds associated with an advisory.
     @GET
     @Path("/erratum/{id}/builds_list")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataBuildList getBuildsList(@PathParam("id") String erratumId);
@@ -135,7 +163,11 @@ public interface ErrataClient {
     // Get the CDN repositories
     @GET
     @Path("/cdn_repos")
-    @Retry(maxRetries = ERRATA_CLIENT_MAX_RETRIES, delay = ERRATA_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = ERRATA_CLIENT_MAX_RETRIES,
+            delay = ERRATA_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     ErrataPage<ErrataCDNRepo> getAllCDNRepos(@Valid @BeanParam ErrataQueryParameters pageParameters);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/ErrataKrb5ClientRequestFilter.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/ErrataKrb5ClientRequestFilter.java
@@ -19,7 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.kerberos;
 
 import java.io.IOException;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.ClientRequestContext;
@@ -35,8 +35,8 @@ public class ErrataKrb5ClientRequestFilter implements ClientRequestFilter {
     @Inject
     ErrataCachingKerberosClientSupport kerberosClientSupport;
 
-    @ConfigProperty(name = "sbomer.features.kerberos.enabled")
-    private static boolean enabled;
+    private static boolean enabled = ConfigProvider.getConfig()
+            .getValue("sbomer.features.kerberos.enabled", Boolean.class);
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/ErrataKrb5ClientRequestFilter.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/ErrataKrb5ClientRequestFilter.java
@@ -19,7 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.kerberos;
 
 import java.io.IOException;
 
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.ClientRequestContext;
@@ -35,13 +35,14 @@ public class ErrataKrb5ClientRequestFilter implements ClientRequestFilter {
     @Inject
     ErrataCachingKerberosClientSupport kerberosClientSupport;
 
-    private static boolean enabled = ConfigProvider.getConfig()
-            .getValue("sbomer.features.kerberos.enabled", Boolean.class);
+    @ConfigProperty(name = "sbomer.features.kerberos.enabled", defaultValue = "false")
+    private boolean enabled;
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         if (!enabled)
             return;
+            
         String serviceTicket = kerberosClientSupport.getServiceTicket();
         requestContext.getHeaders().add(AUTHORIZATION, NEGOTIATE + " " + serviceTicket);
     }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/PyxisKrb5ClientRequestFilter.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/PyxisKrb5ClientRequestFilter.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.feature.sbom.kerberos;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.inject.Inject;
@@ -32,8 +33,8 @@ public class PyxisKrb5ClientRequestFilter implements ClientRequestFilter {
     private static final String AUTHORIZATION = "Authorization";
     private static final String NEGOTIATE = "Negotiate";
 
-    @ConfigProperty(name = "sbomer.features.kerberos.enabled")
-    private static boolean enabled;
+    private static boolean enabled = ConfigProvider.getConfig()
+            .getValue("sbomer.features.kerberos.enabled", Boolean.class);
 
     @Inject
     PyxisCachingKerberosClientSupport kerberosClientSupport;

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/PyxisKrb5ClientRequestFilter.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/kerberos/PyxisKrb5ClientRequestFilter.java
@@ -19,7 +19,6 @@ package org.jboss.sbomer.service.feature.sbom.kerberos;
 
 import java.io.IOException;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.inject.Inject;
@@ -33,11 +32,11 @@ public class PyxisKrb5ClientRequestFilter implements ClientRequestFilter {
     private static final String AUTHORIZATION = "Authorization";
     private static final String NEGOTIATE = "Negotiate";
 
-    private static boolean enabled = ConfigProvider.getConfig()
-            .getValue("sbomer.features.kerberos.enabled", Boolean.class);
-
     @Inject
     PyxisCachingKerberosClientSupport kerberosClientSupport;
+
+    @ConfigProperty(name = "sbomer.features.kerberos.enabled", defaultValue = "false")
+    private boolean enabled;
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/pyxis/PyxisClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/pyxis/PyxisClient.java
@@ -71,7 +71,11 @@ public interface PyxisClient {
 
     @GET
     @Path("/images/nvr/{nvr}")
-    @Retry(maxRetries = PYXIS_CLIENT_MAX_RETRIES, delay = PYXIS_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = PYXIS_CLIENT_MAX_RETRIES,
+            delay = PYXIS_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     PyxisRepositoryDetails getRepositoriesDetails(
@@ -80,7 +84,11 @@ public interface PyxisClient {
 
     @GET
     @Path("/repositories/registry/{registry}/repository/{repository}")
-    @Retry(maxRetries = PYXIS_CLIENT_MAX_RETRIES, delay = PYXIS_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS)
+    @Retry(
+            maxRetries = PYXIS_CLIENT_MAX_RETRIES,
+            delay = PYXIS_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            abortOn = UnauthorizedException.class)
     @ExponentialBackoff
     @BeforeRetry(RetryLogger.class)
     PyxisRepository getRepository(


### PR DESCRIPTION
In this commit:

* Add abortOn so we don't retry when we get an unuathorised exception
* Set client filters from config file in a way compatible with static var