### PR TITLE
Add workflow based on labels

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,25 @@
+name: On Label
+
+on:
+    pull_request:
+        types:
+            - labeled
+
+jobs:
+  build:
+    if: github.event.label.name == 'ok-to-build'
+    name: "Code"
+    uses: ./.github/workflows/build-code.yml
+    secrets: inherit
+
+  build-ui:
+    if: github.event.label.name == 'ok-to-build'
+    name: "UI"
+    uses: ./.github/workflows/build-ui.yml
+    secrets: inherit
+
+
+
+
+
+


### PR DESCRIPTION
Related issue ([SBOMER-9](https://issues.redhat.com/browse/SBOMER-9))

Currently, the build workflows check whether the creator of PR has a write access and if not, the runs fail, needing a restart from the maintainer. 

This PR (once tweaked to our needs) can solve this problem by triggering the workflow on specific labels given to the PR.

TODOs:

- decide which workflows should be triggered by label assigned (only 'tests' workflows?)
- should the label be auto-assigned to PR creators with write rights
- settle on the names of the label to use