### PR TITLE
chore: Change shebangs in hack scripts to /usr/bin/env

### DIFF
--- a/hack/build-images-docker.sh
+++ b/hack/build-images-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/build-images-minikube.sh
+++ b/hack/build-images-minikube.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/build-images-podman.sh
+++ b/hack/build-images-podman.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/build-ui.sh
+++ b/hack/build-ui.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/docs-generate.sh
+++ b/hack/docs-generate.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/docs-preview.sh
+++ b/hack/docs-preview.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/generate-release-notes.sh
+++ b/hack/generate-release-notes.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/internal/build-image.sh
+++ b/hack/internal/build-image.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-delete.sh
+++ b/hack/minikube-delete.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-expose-cache.sh
+++ b/hack/minikube-expose-cache.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-expose-db.sh
+++ b/hack/minikube-expose-db.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-setup.sh
+++ b/hack/minikube-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-start.sh
+++ b/hack/minikube-start.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/minikube-stop.sh
+++ b/hack/minikube-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-cli-dev.sh
+++ b/hack/run-cli-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-maven.sh
+++ b/hack/run-maven.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-service-dev.sh
+++ b/hack/run-service-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-test-e2e.sh
+++ b/hack/run-test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-test-integ.sh
+++ b/hack/run-test-integ.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-test-unit.sh
+++ b/hack/run-test-unit.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/run-ui-dev.sh
+++ b/hack/run-ui-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.

--- a/hack/sdkman-setup.sh
+++ b/hack/sdkman-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # JBoss, Home of Professional Open Source.


### PR DESCRIPTION
In order to be more portable across systems, I've changed the shebangs for the scripts within the hack directory to /usr/bin/env instead of /bin/env

This was necessary for me to run the scripts on MacOS