### PR TITLE
fix: Avoid NPE in release advisory in docker

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -637,7 +637,7 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
                     SbomUtils.addMissingMetadataSupplier(manifestBom);
 
                     // 2.4 Update rootPurl, metadata.component.purl, bom.component[0].purl with the rebuiltPurl
-                    String rebuiltPurl = originalToRebuiltPurl.get(buildManifest.getRootPurl());
+                    String rebuiltPurl = originalToRebuiltPurl.get(buildManifestRecord.rootPurl());
                     buildManifest.setRootPurl(rebuiltPurl);
                     log.debug("Updated manifest '{}' to rootPurl '{}'", buildManifestRecord.id(), rebuiltPurl);
 


### PR DESCRIPTION
The saveReleaseManifestForDockerGeneration method can be called several times with the same advisoryManifestsRecord which then can lead to updating the same Sbom multiple times. When root purl is regenerated, the first time we can lookup in the originalToRebuiltPurl table the the original root purl of the Sbom, but on subsequent passes, the root purl of the Sbom is already updated, so when we query the originalToRebuilPurl table by the updated root purl, we get null.