### PR TITLE
Fix invalid deployment variable replacement

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ mp:
 
 quarkus:
   application:
-    version: ${buildNumber:dev}
+    version: ${buildNumber}
 
   # Make the startup a bit nicer
   banner:


### PR DESCRIPTION
Fix invalid configuration. App wasn't able to parse the current syntax and the `quarkus.application.version` variable was defaulting to `dev`.