### PR TITLE
fix(SBOMER-427): Add retries for SBOMer client

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/SBOMerClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/SBOMerClient.java
@@ -17,12 +17,21 @@
  */
 package org.jboss.sbomer.cli.feature.sbom.client;
 
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.sbomer.cli.feature.sbom.model.Sbom;
 import org.jboss.sbomer.cli.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.core.rest.faulttolerance.RetryLogger;
 import org.jboss.sbomer.core.utils.PaginationParameters;
+import static org.jboss.sbomer.core.rest.faulttolerance.Constants.SBOMER_CLIENT_DELAY;
+import static org.jboss.sbomer.core.rest.faulttolerance.Constants.SBOMER_CLIENT_MAX_RETRIES;
 
+import java.time.temporal.ChronoUnit;
+
+import io.smallrye.faulttolerance.api.BeforeRetry;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
 import jakarta.enterprise.context.ApplicationScoped;
+
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
@@ -51,6 +60,11 @@ public interface SBOMerClient {
      * @param id the identifier of the SBOM
      * @return the {@link Sbom SBOM}
      */
+    @Retry( maxRetries = SBOMER_CLIENT_MAX_RETRIES,
+            delay = SBOMER_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS)
+    @BeforeRetry(RetryLogger.class)
+    @ExponentialBackoff
     @GET
     @Path("/manifests/{id}")
     Response getById(@HeaderParam("log-process-context") String processContext, @PathParam("id") String id);
@@ -61,6 +75,11 @@ public interface SBOMerClient {
      * @param id the identifier of the SBOM Generation Request
      * @return {@link SbomGenerationRequest SBOM Generation Request}
      */
+    @Retry( maxRetries = SBOMER_CLIENT_MAX_RETRIES,
+            delay = SBOMER_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS)
+    @BeforeRetry(RetryLogger.class)
+    @ExponentialBackoff
     @GET
     @Path("/generations/{id}")
     Response getGenerationRequestById(
@@ -74,6 +93,11 @@ public interface SBOMerClient {
      * @param rsqlQuery the RSQL query
      * @return {@link Response res}
      */
+    @Retry( maxRetries = SBOMER_CLIENT_MAX_RETRIES,
+            delay = SBOMER_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS)
+    @BeforeRetry(RetryLogger.class)
+    @ExponentialBackoff
     @GET
     @Path("/manifests")
     Response searchSboms(
@@ -89,6 +113,11 @@ public interface SBOMerClient {
      * @param rsqlQuery the RSQL query
      * @return {@link Response response}
      */
+    @Retry( maxRetries = SBOMER_CLIENT_MAX_RETRIES,
+            delay = SBOMER_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS)
+    @BeforeRetry(RetryLogger.class)
+    @ExponentialBackoff
     @GET
     @Path("/generations")
     Response searchGenerationRequests(
@@ -97,6 +126,11 @@ public interface SBOMerClient {
             @QueryParam("query") String rsqlQuery,
             @QueryParam("sort") String rsqlSort);
 
+    @Retry( maxRetries = SBOMER_CLIENT_MAX_RETRIES,
+            delay = SBOMER_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS)
+    @BeforeRetry(RetryLogger.class)
+    @ExponentialBackoff
     @GET
     @Path("/stats")
     Response getStats();

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/SBOMerClientTestIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/client/SBOMerClientTestIT.java
@@ -144,4 +144,28 @@ class SBOMerClientTestIT {
             }
         }
     }
+    @Test
+    void testNetworkConnectionTimeout(){
+        PaginationParameters pagParams = new PaginationParameters();
+        pagParams.setPageIndex(0);
+        pagParams.setPageSize(1);
+        String rsqlQuery = "id==AABBCCDD";
+        String sortQuery = "creationTime=desc=";
+        try (Response response = client.searchGenerationRequests("AABBCCDD", pagParams, rsqlQuery, sortQuery)) {
+            String json = response.readEntity(String.class);
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            TypeReference<Page<SbomGenerationRequestRecord>> typeReference = new TypeReference<>() {
+            };
+            try {
+                Page<SbomGenerationRequestRecord> sbomRequests = objectMapper.readValue(json, typeReference);
+                assertNotNull(sbomRequests);
+                assertEquals("AABBCCDD", sbomRequests.getContent().iterator().next().id());
+                assertEquals("QUARKUS", sbomRequests.getContent().iterator().next().identifier());
+            } catch (JsonProcessingException e) {
+                fail(e.getMessage());
+            }
+        }
+
+    }
 }

--- a/cli/src/test/resources/mappings/sbomer/v1beta1/sbom-123-network-timeout.json
+++ b/cli/src/test/resources/mappings/sbomer/v1beta1/sbom-123-network-timeout.json
@@ -1,0 +1,88 @@
+{
+    "mappings": [
+        {
+            "scenarioName": "Bad openshift",
+            "requiredScenarioState": "Started",
+            "newScenarioState": "Service Fully Degraded",
+            "request": {
+                "method": "GET",
+                "url": "/api/v1beta1/generations?pageIndex=0&pageSize=1&query=id%3D%3DAABBCCDD&sort=creationTime%3Ddesc%3D"
+            },
+            "response": {
+                "fault": "RANDOM_DATA_THEN_CLOSE",
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "fixedDelayMilliseconds": 3000
+            }
+        },
+        {
+            "scenarioName": "Bad openshift",
+            "requiredScenarioState": "Service Fully Degraded",
+            "newScenarioState": "Service Partially Degraded",
+            "request": {
+                "method": "GET",
+                "url": "/api/v1beta1/generations?pageIndex=0&pageSize=1&query=id%3D%3DAABBCCDD&sort=creationTime%3Ddesc%3D"
+            },
+            "response": {
+                "fault": "CONNECTION_RESET_BY_PEER",
+                "fixedDelayMilliseconds": 2000
+            }
+        },
+        {
+            "scenarioName": "Bad openshift",
+            "requiredScenarioState": "Service Partially Degraded",
+            "newScenarioState": "Service Working",
+            "request": {
+                "method": "GET",
+                "url": "/api/v1beta1/generations?pageIndex=0&pageSize=1&query=id%3D%3DAABBCCDD&sort=creationTime%3Ddesc%3D"
+            },
+            "response": {
+                "status": 200,
+                "jsonBody": {
+                    "pageIndex": 0,
+                    "pageSize": 1,
+                    "totalPages": 1,
+                    "totalHits": 1,
+                    "content": [
+                        {
+                            "id": "AABBCCDD",
+                            "identifier": "QUARKUS",
+                            "type": "BUILD",
+                            "config": {
+                                "buildId": "QUARKUS",
+                                "type": "pnc-build",
+                                "products": [
+                                    {
+                                        "generator": {
+                                            "args": "--include-non-managed --warn-on-missing-scm",
+                                            "type": "maven-domino",
+                                            "version": "0.0.90"
+                                        },
+                                        "processors": [
+                                            {
+                                                "type": "default"
+                                            },
+                                            {
+                                                "type": "redhat-product",
+                                                "errata": {
+                                                    "productName": "RHBQ",
+                                                    "productVariant": "8Base-RHBQ-2.13",
+                                                    "productVersion": "RHEL-8-RHBQ-2.13"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "apiVersion": "sbomer.jboss.org/v1alpha1"
+                            }
+                        }
+                    ]
+                },
+                "headers": {
+                    "Content-Type": "application/json"
+                }
+            }
+        }
+    ]
+}

--- a/core/src/main/java/org/jboss/sbomer/core/rest/faulttolerance/Constants.java
+++ b/core/src/main/java/org/jboss/sbomer/core/rest/faulttolerance/Constants.java
@@ -24,12 +24,14 @@ public class Constants {
     public static final int PYXIS_CLIENT_MAX_RETRIES = 15;
     public static final int ATLAS_CLIENT_MAX_RETRIES = 15;
     public static final int KOJI_DOWNLOAD_CLIENT_MAX_RETRIES = 15;
+    public static final int SBOMER_CLIENT_MAX_RETRIES=15;
 
     public static final long PNC_CLIENT_DELAY = 1;
     public static final long ERRATA_CLIENT_DELAY = 1;
     public static final long PYXIS_CLIENT_DELAY = 1;
     public static final long ATLAS_CLIENT_DELAY = 1;
     public static final long KOJI_DOWNLOAD_CLIENT_DELAY = 1;
+    public static final long SBOMER_CLIENT_DELAY = 1;
 
     /*
      * In some circumstances Pyxis returns a 200 code but an empty RepositoryDescription, this means it may not yet be


### PR DESCRIPTION
In this commit:

* Add fault tolerance retries with exponential backoff for the sbomer client
* Add constants for future configuration but reuse other common configuration
* Add simple wiremock test payload
* Duplicate existing wiremock test

todo:
* Change timeouts for test
* Count and verify number of retries with wiremock api