### PR TITLE
Optimize API to not pull dependent collections automatically

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/EventRecord.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/EventRecord.java
@@ -18,7 +18,6 @@
 package org.jboss.sbomer.service.nextgen.core.dto.model;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 
 import org.jboss.sbomer.service.nextgen.core.enums.EventStatus;
@@ -29,7 +28,6 @@ import com.fasterxml.jackson.databind.JsonNode;
  * Representation of the Event entity.
  */
 public record EventRecord(String id, EventRecord parent, Instant created, Instant updated, Instant finished,
-        Map<String, String> metadata, JsonNode request, List<GenerationRecord> generations, EventStatus status,
-        String reason) {
+        Map<String, String> metadata, JsonNode request, EventStatus status, String reason) {
 
 }

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/GenerationRecord.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/GenerationRecord.java
@@ -18,7 +18,6 @@
 package org.jboss.sbomer.service.nextgen.core.dto.model;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.sbomer.service.nextgen.core.dto.api.GenerationRequest;
@@ -35,8 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public record GenerationRecord(@RestLinkId String id, Instant created, Instant updated, Instant finished,
-        ObjectNode request, ObjectNode metadata, List<ManifestRecord> manifests, GenerationStatus status, String result,
-        String reason) {
+        ObjectNode request, ObjectNode metadata, GenerationStatus status, String result, String reason) {
 
     public boolean isSupported(Set<String> types) {
         if (request() == null) {

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/GenerationRecord.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/core/dto/model/GenerationRecord.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.Set;
 
 import org.jboss.sbomer.service.nextgen.core.dto.api.GenerationRequest;
+import org.jboss.sbomer.service.nextgen.core.enums.GenerationResult;
 import org.jboss.sbomer.service.nextgen.core.enums.GenerationStatus;
 import org.jboss.sbomer.service.nextgen.core.utils.JacksonUtils;
 
@@ -34,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public record GenerationRecord(@RestLinkId String id, Instant created, Instant updated, Instant finished,
-        ObjectNode request, ObjectNode metadata, GenerationStatus status, String result, String reason) {
+        ObjectNode request, ObjectNode metadata, GenerationStatus status, GenerationResult result, String reason) {
 
     public boolean isSupported(Set<String> types) {
         if (request() == null) {

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/core/rest/SBOMerClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/core/rest/SBOMerClient.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.sbomer.service.nextgen.core.rest;
 
+import java.util.List;
+
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.sbomer.service.nextgen.core.dto.model.EventRecord;
 import org.jboss.sbomer.service.nextgen.core.dto.model.GenerationRecord;
@@ -96,6 +98,12 @@ public interface SBOMerClient {
     @PATCH
     @Path("/events/{eventId}/status")
     public EventRecord updateEventStatus(@PathParam("eventId") String eventId, EventStatusUpdatePayload payload);
+
+    @Traced
+    @SpanName("sbomer.get.events.generations")
+    @PATCH
+    @Path("/events/{eventId}/generations")
+    public List<GenerationRecord> getEventGenerations(@PathParam("eventId") String eventId);
 
     //
     // Manifests

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/core/rest/SBOMerClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/core/rest/SBOMerClient.java
@@ -70,6 +70,12 @@ public interface SBOMerClient {
     public GenerationRecord getGeneration(@PathParam("generationId") String generationId);
 
     @Traced
+    @SpanName("sbomer.generations.get.id")
+    @GET
+    @Path("/generations/{generationId}/manifests")
+    public List<ManifestRecord> getGenerationManifests(@PathParam("generationId") String generationId);
+
+    @Traced
     @SpanName("sbomer.generations.status.update")
     @PATCH
     @Path("/generations/{generationId}/status")
@@ -81,7 +87,7 @@ public interface SBOMerClient {
     @SpanName("sbomer.generations.manifests.upload")
     @POST
     @Path("/generations/{generationId}/manifests")
-    ManifestRecord uploadManifest(@PathParam("generationId") String generationId, JsonNode manifest);
+    public ManifestRecord uploadManifest(@PathParam("generationId") String generationId, JsonNode manifest);
 
     //
     // Events

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/generator/rhrelease/RedHatReleaseGenerator.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/generator/rhrelease/RedHatReleaseGenerator.java
@@ -78,12 +78,12 @@ public class RedHatReleaseGenerator extends AbstractGenerator {
 
         log.debug("Reading generation request...");
         GenerationRequest request = JacksonUtils.parse(GenerationRequest.class, generationRecord.request());
-        EventRecord eventRecord;
 
-        log.debug("Fetching event with identifier '{}'...", request.target().identifier());
+        log.debug("Fetching generations related to event with identifier '{}'...", request.target().identifier());
+        List<GenerationRecord> generations;
 
         try {
-            eventRecord = sbomerClient.getEvent(request.target().identifier());
+            generations = sbomerClient.getEventGenerations(request.target().identifier());
         } catch (NotFoundException ex) {
             throw new ApplicationException(
                     "Event with id '{}' could not be found, cannot process generation",
@@ -95,7 +95,7 @@ public class RedHatReleaseGenerator extends AbstractGenerator {
 
         // Iterate over each generation that was part of that particular event and create copies
         // updates
-        for (GenerationRecord g : eventRecord.generations()) {
+        for (GenerationRecord g : generations) {
             log.info("Processing generation '{}'", g.id());
 
             for (ManifestRecord m : g.manifests()) {

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/service/config/GeneratorConfigProvider.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/service/config/GeneratorConfigProvider.java
@@ -106,7 +106,7 @@ public class GeneratorConfigProvider {
     /**
      * Fetches generator profile for a given generator name and version. If version is not provided, default version
      * will be used.
-     * 
+     *
      * @param name Generator name
      * @param version Generator version
      * @return {@link GeneratorVersionProfile} representing the configuration

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/service/rest/v1beta2/EventsApi.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/service/rest/v1beta2/EventsApi.java
@@ -91,19 +91,20 @@ public class EventsApi {
     @APIResponse(
             responseCode = "200",
             description = "Paginated list of events",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON))
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(type = SchemaType.ARRAY, implementation = EventRecord.class)))
     @APIResponse(
             responseCode = "500",
             description = "Internal server error",
             content = @Content(mediaType = MediaType.APPLICATION_JSON))
-    public List<EventRecord> search( // TODO: USE pagination
-            @Valid @BeanParam PaginationParameters paginationParams,
-            @QueryParam("query") String query,
-            @DefaultValue("creationTime=desc=") @QueryParam("sort") String sort) {
+    public Response search(@Valid @BeanParam PaginationParameters paginationParams) {
+        List<EventRecord> events = Generation.findAll()
+                .project(EventRecord.class)
+                .page(paginationParams.getPageIndex(), paginationParams.getPageSize())
+                .list();
 
-        List<Event> events = Event.findAll().list();
-
-        return mapper.toEventRecords(events);
+        return Response.ok(events).header("X-Total-Count", events.size()).build();
     }
 
     @GET

--- a/service/src/main/java/org/jboss/sbomer/service/nextgen/service/rest/v1beta2/EventsApi.java
+++ b/service/src/main/java/org/jboss/sbomer/service/nextgen/service/rest/v1beta2/EventsApi.java
@@ -35,6 +35,7 @@ import org.jboss.sbomer.core.errors.NotFoundException;
 import org.jboss.sbomer.core.utils.PaginationParameters;
 import org.jboss.sbomer.service.nextgen.core.dto.model.EventRecord;
 import org.jboss.sbomer.service.nextgen.core.dto.model.EventStatusRecord;
+import org.jboss.sbomer.service.nextgen.core.dto.model.GenerationRecord;
 import org.jboss.sbomer.service.nextgen.core.enums.GenerationStatus;
 import org.jboss.sbomer.service.nextgen.core.events.EventStatusChangeEvent;
 import org.jboss.sbomer.service.nextgen.core.payloads.generation.EventStatusUpdatePayload;
@@ -162,6 +163,24 @@ public class EventsApi {
         }
 
         return mapper.toEventStatusRecords(event.getStatuses());
+    }
+
+    @GET
+    @Path("/{eventId}/generations")
+    @Operation(summary = "Get generations related to an event")
+    @APIResponse(
+            responseCode = "200",
+            description = "Generation list",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON))
+    @APIResponse(responseCode = "404", description = "Event not found")
+    public List<GenerationRecord> getGenerationsForEvent(@PathParam("eventId") String eventId) {
+        Event event = Event.findById(eventId); // NOSONAR
+
+        if (event == null) {
+            throw new NotFoundException("Event with id '{}' could not be found", eventId);
+        }
+
+        return mapper.toGenerationRecords(event.getGenerations());
     }
 
     @PATCH

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/generator/rhrelease/RedHatReleaseGeneratorTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/generator/rhrelease/RedHatReleaseGeneratorTest.java
@@ -20,7 +20,6 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.sbomer.service.nextgen.core.dto.api.GenerationRequest;
 import org.jboss.sbomer.service.nextgen.core.dto.api.Generator;
 import org.jboss.sbomer.service.nextgen.core.dto.api.Target;
-import org.jboss.sbomer.service.nextgen.core.dto.model.EventRecord;
 import org.jboss.sbomer.service.nextgen.core.dto.model.GenerationRecord;
 import org.jboss.sbomer.service.nextgen.core.dto.model.ManifestRecord;
 import org.jboss.sbomer.service.nextgen.core.enums.GenerationStatus;
@@ -53,14 +52,7 @@ public class RedHatReleaseGeneratorTest {
         generator = spy(new RedHatReleaseGenerator(client, managedExecutor));
     }
 
-    /**
-     * A method to generate test data.
-     *
-     * @param numGenerations
-     * @param numManifests
-     * @return
-     */
-    private EventRecord genEvent(int numGenerations, int numManifests) {
+    private List<GenerationRecord> genGenrations(int numGenerations, int numManifests) {
         List<GenerationRecord> generations = new ArrayList<>();
 
         for (int i = 0; i < numGenerations; i++) {
@@ -87,7 +79,7 @@ public class RedHatReleaseGeneratorTest {
                             null));
         }
 
-        return new EventRecord("E1", null, Instant.now(), Instant.now(), null, null, null, generations, null, null);
+        return generations;
     }
 
     @Test
@@ -194,7 +186,7 @@ public class RedHatReleaseGeneratorTest {
 
     @Test
     void handleGeneration() {
-        when(client.getEvent("E1MMM")).thenReturn(genEvent(2, 2));
+        when(client.getEventGenerations("E1MMM")).thenReturn(genGenrations(2, 2));
 
         GenerationRecord generationRecord = new GenerationRecord(
                 "G1",
@@ -221,6 +213,6 @@ public class RedHatReleaseGeneratorTest {
 
         verify(client, times(4)).getManifestContent(anyString());
         verify(client, times(5)).uploadManifest(anyString(), any());
-        verify(client, times(1)).getEvent(anyString());
+        verify(client, times(1)).getEventGenerations(anyString());
     }
 }


### PR DESCRIPTION
Introduction of the `/events{id}/generations` endpoint in the API to retrieve generations for a given event.

Similarly, for generation, the `/generation/{id}/manifest` endpoint will be used.