### PR TITLE
fix: Fix PURL code

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/catalog/SyftImageCatalogCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/catalog/SyftImageCatalogCommand.java
@@ -157,8 +157,11 @@ public class SyftImageCatalogCommand extends AbstractCatalogCommand {
         try {
             PackageURL purl = new PackageURL(component.getPurl());
             Map<String, String> qualifiers = purl.getQualifiers();
-            if (qualifiers != null && qualifiers.containsKey("arch")) {
-                return qualifiers.get("arch");
+            if (qualifiers != null) {
+                String arch = qualifiers.get("arch");
+                if (arch != null) {
+                    return arch;
+                }
             }
         } catch (MalformedPackageURLException e) {
             log.warn("Could not parse the PURL: {}", component.getPurl(), e);

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/processor/DefaultProcessor.java
@@ -247,7 +247,7 @@ public class DefaultProcessor implements Processor {
                     processContainerImageComponent(c);
                 } else {
                     PackageURL purl = getPackageURL(c);
-                    if ("rpm".equals(purl.getType())) {
+                    if (PackageURL.StandardTypes.RPM.equals(purl.getType())) {
                         processRpmComponent(c, purl);
                     } else {
                         processComponent(c);
@@ -270,11 +270,16 @@ public class DefaultProcessor implements Processor {
 
     private void processRpmComponent(Component component, PackageURL purl) {
         Map<String, String> qualifiers = purl.getQualifiers();
-        if (qualifiers == null || !qualifiers.containsKey("arch")) {
-            log.debug("RPM purl is missing arch qualifier: {}", component.getPurl());
+        String arch = null;
+
+        if (qualifiers != null) {
+            arch = qualifiers.get("arch");
+        }
+
+        if (arch == null) {
+            log.debug("RPM purl is missing arch qualifier: '{}'", component.getPurl());
             return;
         }
-        String arch = qualifiers.get("arch");
 
         KojiBuildInfo buildInfo;
         try {

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/PurlRebuilder.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/PurlRebuilder.java
@@ -36,6 +36,7 @@ public class PurlRebuilder {
     private static final String SYFT_ALPMPKG = "alpm";
     private static final String SYFT_APKPKG = "apk";
     private static final String SYFT_BINARYPKG = "binary";
+    private static final String SYFT_BITNAMIPKG = "bitnami";
     private static final String SYFT_COCOAPODSPKG = "pod";
     private static final String SYFT_CONANPKG = "conan";
     private static final String SYFT_DARTPUBPKG = "dart-pub";
@@ -49,6 +50,7 @@ public class PurlRebuilder {
     private static final String SYFT_GRAALVMNATIVEIMAGEPKG = "graalvm-native-image";
     private static final String SYFT_HACKAGEPKG = "hackage";
     private static final String SYFT_HEXPKG = "hex";
+    private static final String SYFT_HOMEBREWPKG = "homebrew";
     private static final String SYFT_JAVAPKG = "java-archive";
     private static final String SYFT_JENKINSPACKAGE = "jenkins-plugin";
     private static final String SYFT_KBPKG = "msrc-kb";
@@ -56,7 +58,9 @@ public class PurlRebuilder {
     private static final String SYFT_LINUXKERNELMODULEPKG = "linux-kernel-module";
     private static final String SYFT_NIXPKG = "nix";
     private static final String SYFT_NPMPKG = "npm";
+    private static final String SYFT_OPAMPKG = "opam";
     private static final String SYFT_PHPCOMPOSERPKG = "php-composer";
+    private static final String SYFT_PHPPEARPKG = "php-pear";
     private static final String SYFT_PHPPECLPKG = "php-pecl";
     private static final String SYFT_PORTAGEPKG = "portage";
     private static final String SYFT_PYTHONPKG = "python";
@@ -66,17 +70,19 @@ public class PurlRebuilder {
     private static final String SYFT_RUSTPKG = "rust-crate";
     private static final String SYFT_SWIFTPKG = "swift";
     private static final String SYFT_SWIPLPACKPKG = "swiplpack";
-    private static final String SYFT_OPAMPKG = "opam";
+    private static final String SYFT_TERRAFORMPKG = "terraform";
     private static final String SYFT_WORDPRESSPLUGINPKG = "wordpress-plugin";
 
     // Associations taken from https://github.com/anchore/syft/blob/main/syft/pkg/type.go#L91
     private static final Map<String, String> SYFT_PACKAGE_2_PURL_TYPE_MAP = new HashMap<>();
     static {
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_ALPMPKG, "alpm");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_APKPKG, "apk");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_COCOAPODSPKG, "cocoapods");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_CONANPKG, "conan");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_DARTPUBPKG, "pub");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_ALPMPKG, "alpm"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_APKPKG, "apk"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_BINARYPKG, "binary");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_BITNAMIPKG, "bitnami"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_COCOAPODSPKG, "cocoapods"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_CONANPKG, "conan"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_DARTPUBPKG, "pub"); // standard
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_DEBPKG, PackageURL.StandardTypes.DEBIAN);
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_DOTNETPKG, "dotnet");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_ERLANGOTPPKG, "otp");
@@ -84,26 +90,31 @@ public class PurlRebuilder {
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_GITHUBACTIONPKG, PackageURL.StandardTypes.GITHUB);
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_GITHUBACTIONWORKFLOWPKG, PackageURL.StandardTypes.GITHUB);
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_GOMODULEPKG, PackageURL.StandardTypes.GOLANG);
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_GRAALVMNATIVEIMAGEPKG, "graalvm-native-image");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_HACKAGEPKG, "hackage");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_HEXPKG, PackageURL.StandardTypes.HEX);
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_HOMEBREWPKG, "brew"); // candidate
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_JAVAPKG, PackageURL.StandardTypes.MAVEN);
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_JENKINSPACKAGE, PackageURL.StandardTypes.MAVEN);
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_KBPKG, "msrc-kb");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_LINUXKERNELPKG, "generic/linux-kernel");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_LINUXKERNELMODULEPKG, PackageURL.StandardTypes.GENERIC);
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_NIXPKG, "nix");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_NIXPKG, "nix"); // candidate
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_NPMPKG, PackageURL.StandardTypes.NPM);
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_OPAMPKG, "opam"); // candidate
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PHPCOMPOSERPKG, PackageURL.StandardTypes.COMPOSER);
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PHPPECLPKG, "pecl");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PHPPEARPKG, "pear"); // candidate
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PHPPECLPKG, "pecl"); // candidate
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PORTAGEPKG, "portage");
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_PYTHONPKG, PackageURL.StandardTypes.PYPI);
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_RPKG, "cran");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_LUAROCKSPKG, "luarocks");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_RPKG, "cran"); // standard
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_LUAROCKSPKG, "luarocks"); // standard
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_RPMPKG, PackageURL.StandardTypes.RPM);
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_RUSTPKG, PackageURL.StandardTypes.CARGO);
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_SWIFTPKG, "swift");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_SWIFTPKG, "swift"); // standard
         SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_SWIPLPACKPKG, "swiplpack");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_OPAMPKG, "opam");
-        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_WORDPRESSPLUGINPKG, "wordpress-plugin");
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_TERRAFORMPKG, "terraform"); // candidate
+        SYFT_PACKAGE_2_PURL_TYPE_MAP.put(SYFT_WORDPRESSPLUGINPKG, "wordpress"); // candidate
     }
 
     private PurlRebuilder() {
@@ -141,7 +152,7 @@ public class PurlRebuilder {
         String version = PurlSanitizer.sanitizeVersion(component.getVersion());
 
         PackageURL purl = new PackageURL(type, namespace, name, version, null, null);
-        return purl.canonicalize();
+        return purl.toString();
     }
 
 }

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/PurlSanitizer.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/PurlSanitizer.java
@@ -54,7 +54,7 @@ public class PurlSanitizer {
             return parsedPurl.canonicalize();
         } catch (MalformedPackageURLException e) {
             // If parsing fails, proceed to manual sanitization
-            log.error("Malformed PURL detected, attempting to sanitize: {}", purl);
+            log.error("Malformed PURL detected, attempting to sanitize: '{}'", purl, e);
         }
 
         // Manually parse and sanitize the PURL components
@@ -121,8 +121,8 @@ public class PurlSanitizer {
             PackageURL sanitizedPurl = new PackageURL(type, namespace, name, version, qualifiers, subpath);
             return sanitizedPurl.canonicalize();
 
-        } catch (Exception ex) {
-            throw new IllegalArgumentException("Failed to sanitize PURL: " + purl, ex);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to sanitize PURL: '" + purl + "'", e);
         }
     }
 
@@ -163,7 +163,7 @@ public class PurlSanitizer {
         }
         TreeMap<String, String> sanitized = new TreeMap<>();
         for (Map.Entry<String, String> entry : qualifiers.entrySet()) {
-            String key = entry.getKey().replaceAll(NAME_VERSION_QKEY_QVALUE, "");
+            String key = entry.getKey().replaceAll(NAME_VERSION_QKEY_QVALUE, "-");
             String value = entry.getValue().replaceAll(NAME_VERSION_QKEY_QVALUE, "-");
             sanitized.put(key, value);
         }

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1463,21 +1463,8 @@ public class SbomUtils {
 
         try {
             PackageURL purl = new PackageURL(component.getPurl());
-            PackageURLBuilder builder = PackageURLBuilder.aPackageURL()
-                    .withName(purl.getName())
-                    .withNamespace(purl.getNamespace())
-                    .withSubpath(purl.getSubpath())
-                    .withType(purl.getType())
-                    .withVersion(purl.getVersion());
-
-            if (purl.getQualifiers() != null) {
-                // Copy all the original qualifiers
-                purl.getQualifiers().forEach(builder::withQualifier);
-            }
-
-            // Add the qualifiers
+            PackageURLBuilder builder = purl.toBuilder();
             qualifiers.forEach(builder::withQualifier);
-
             return builder.build().toString();
         } catch (MalformedPackageURLException | IllegalArgumentException e) {
             log.warn("Error while adding new qualifiers to component with purl {}", component.getPurl(), e);

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/UrlUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/UrlUtils.java
@@ -23,10 +23,10 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
 
 public class UrlUtils {
 
@@ -43,39 +43,26 @@ public class UrlUtils {
     }
 
     /**
-     * Removes from the provided purl the qualifiers that are present (if any) in the allowList. If the purl does not
+     * Removes from the provided purl the qualifiers that are present (if any) in the removeList. If the purl does not
      * contain any qualifier that needs to be removed, the original purl is returned, otherwise a new purl is built and
      * returned.
      *
      * @param purl the purl from which the qualifiers should be removed
-     * @param allowList the list of qualifiers which should be removed from the purl
+     * @param removeList the list of qualifiers which should be removed from the purl
      * @return the purl with the qualifiers removed
      */
-    public static String removeAllowedQualifiersFromPurl(String purl, List<String> allowList) {
+    public static String removeQualifiersFromPurl(String purl, List<String> removeList) {
         try {
             PackageURL packageURL = new PackageURL(purl);
             Map<String, String> qualifiers = packageURL.getQualifiers();
-            if (qualifiers == null || qualifiers.isEmpty() || allowList == null || allowList.isEmpty()) {
+            if (qualifiers == null || qualifiers.isEmpty() || removeList == null || removeList.isEmpty()) {
                 // Nothing to remove!
                 return purl;
             }
 
-            if (allowList.stream().noneMatch(qualifiers::containsKey)) {
-                // The qualifiers do not include any allowedQualifier
-                return purl;
-            }
-
-            // Qualifiers are not modifiable, we need to recreate the purl with the new map of qualifiers
-            TreeMap<String, String> modifiableQualifiers = new TreeMap<>(qualifiers);
-            allowList.forEach(modifiableQualifiers.keySet()::remove);
-
-            return new PackageURL(
-                    packageURL.getType(),
-                    packageURL.getNamespace(),
-                    packageURL.getName(),
-                    packageURL.getVersion(),
-                    modifiableQualifiers,
-                    packageURL.getSubpath()).toString();
+            PackageURLBuilder builder = packageURL.toBuilder();
+            removeList.forEach(builder::withoutQualifier);
+            return builder.build().toString();
         } catch (MalformedPackageURLException e) {
             // Just return the originally provided purl
             return purl;

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/UrlUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/UrlUtilsTest.java
@@ -34,14 +34,14 @@ class UrlUtilsTest {
 
         @Test
         void testHandleNullValues() {
-            assertNull(UrlUtils.removeAllowedQualifiersFromPurl(null, null));
+            assertNull(UrlUtils.removeQualifiersFromPurl(null, null));
         }
 
         @Test
         void testHandleNullAllowList() {
             assertEquals(
                     "pkg:maven/org.jboss.arquillian.container/arquillian-container-impl-base@1.6.0.Final?type=jar",
-                    UrlUtils.removeAllowedQualifiersFromPurl(
+                    UrlUtils.removeQualifiersFromPurl(
                             "pkg:maven/org.jboss.arquillian.container/arquillian-container-impl-base@1.6.0.Final?type=jar",
                             null));
         }
@@ -50,7 +50,7 @@ class UrlUtilsTest {
         void testHandleEmptyAllowList() {
             assertEquals(
                     "pkg:maven/org.jboss.arquillian.container/arquillian-container-impl-base@1.6.0.Final?type=jar",
-                    UrlUtils.removeAllowedQualifiersFromPurl(
+                    UrlUtils.removeQualifiersFromPurl(
                             "pkg:maven/org.jboss.arquillian.container/arquillian-container-impl-base@1.6.0.Final?type=jar",
                             Collections.emptyList()));
         }
@@ -59,7 +59,7 @@ class UrlUtilsTest {
         void testHandleAllowList() {
             assertEquals(
                     "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?type=pom",
-                    UrlUtils.removeAllowedQualifiersFromPurl(
+                    UrlUtils.removeQualifiersFromPurl(
                             "pkg:maven/org.apache.logging.log4j/log4j@2.19.0.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=pom",
                             List.of("repository_url")));
         }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/AdvisoryEventUtils.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/AdvisoryEventUtils.java
@@ -204,11 +204,17 @@ public class AdvisoryEventUtils {
 
         try {
             PackageURL componentPurl = new PackageURL(purl);
-            if (componentPurl.getQualifiers() == null || !componentPurl.getQualifiers().containsKey("arch")) {
+
+            if (componentPurl.getQualifiers() == null) {
                 return Collections.emptySet();
             }
 
             String componentArch = componentPurl.getQualifiers().get("arch");
+
+            if (componentArch == null) {
+                return Collections.emptySet();
+            }
+
             if (componentArch.equals("src")) {
                 // Select the "-source-rpms" CDN repositories and include all the archs provided
                 return cdns.stream()
@@ -272,17 +278,7 @@ public class AdvisoryEventUtils {
         try {
 
             PackageURL purl = new PackageURL(originalPurl);
-            PackageURLBuilder builder = PackageURLBuilder.aPackageURL()
-                    .withName(purl.getName())
-                    .withNamespace(purl.getNamespace())
-                    .withSubpath(purl.getSubpath())
-                    .withType(purl.getType())
-                    .withVersion(purl.getVersion());
-
-            if (purl.getQualifiers() != null) {
-                // Copy all the original qualifiers
-                purl.getQualifiers().forEach(builder::withQualifier);
-            }
+            PackageURLBuilder builder = purl.toBuilder();
 
             // Add the repository_id name
             builder.withQualifier("repository_id", cdn.getCdnName());
@@ -308,17 +304,7 @@ public class AdvisoryEventUtils {
         try {
 
             PackageURL purl = new PackageURL(originalPurl);
-            PackageURLBuilder builder = PackageURLBuilder.aPackageURL()
-                    .withName(repository.getRepositoryFragment())
-                    .withNamespace(purl.getNamespace())
-                    .withSubpath(purl.getSubpath())
-                    .withType(purl.getType())
-                    .withVersion(purl.getVersion());
-
-            if (purl.getQualifiers() != null) {
-                // Copy all the original qualifiers
-                purl.getQualifiers().forEach(builder::withQualifier);
-            }
+            PackageURLBuilder builder = purl.toBuilder();
 
             // Override tag and set repository url
             builder.withQualifier("tag", repository.getTag())

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -913,9 +913,9 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
             try {
                 PackageURL purl = new PackageURL(component.getPurl());
                 Map<String, String> qualifiers = purl.getQualifiers();
-                if (qualifiers != null && qualifiers.containsKey("arch")) {
+                if (qualifiers != null) {
                     String archValue = qualifiers.get("arch");
-                    if (!"src".equals(archValue)) {
+                    if (archValue != null && !"src".equals(archValue)) {
                         manifestArches.add(archValue);
                     }
                 }

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -502,7 +502,7 @@ public class SbomService {
      * @return The latest generated SBOM or {@code null}.
      */
     public Sbom findByPurl(String purl) {
-        String polishedPurl = UrlUtils.removeAllowedQualifiersFromPurl(purl, sbomerConfig.purlQualifiersAllowList());
+        String polishedPurl = UrlUtils.removeQualifiersFromPurl(purl, sbomerConfig.purlQualifiersAllowList());
         log.debug("Trying to find latest generated SBOM for purl: '{}' (polished to '{}')", purl, polishedPurl);
 
         QueryParameters parameters = QueryParameters.builder()


### PR DESCRIPTION
* Use `PackageURL::StandardTypes::RPM` constant
* Use `PackageURL::toString` instead of `PackageURL::canonicalize` for consistency
* Look up qualifier keys only once
* Use `PackageURL::toBuilder` insead of constructor for existing PURLs
* Add/fix Syft types: bitnami, terraform, wordpress -> wordpress-plugin
* Replace invalid key character with "-" to match value replacement