### PR TITLE
Update Text-Only Release SBOM builder to use redhat: prefixed properties

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
@@ -244,7 +244,7 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
         Component metadataComponent = manifestBom.getMetadata().getComponent();
         // If there are no components or the manifest is a ZIP manifest, get the main component from the metadata
         if (!SbomUtils.isNotEmpty(manifestBom.getComponents())
-                || SbomUtils.hasProperty(metadataComponent, "deliverable-url")) {
+                || SbomUtils.hasProperty(metadataComponent, Constants.SBOM_RED_HAT_DELIVERABLE_URL)) {
             manifestMainComponent = metadataComponent;
         } else {
             manifestMainComponent = manifestBom.getComponents().get(0);
@@ -252,7 +252,7 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
         String evidencePurl = SbomUtils.addQualifiersToPurlOfComponent(
                 manifestMainComponent,
                 Map.of("repository_url", Constants.MRRC_URL),
-                !SbomUtils.hasProperty(manifestMainComponent, "deliverable-url"));
+                !SbomUtils.hasProperty(manifestMainComponent, Constants.SBOM_RED_HAT_DELIVERABLE_URL));
 
         // Finally, create the root component for this build (NVR) from the manifest
         Component sbomRootComponent = SbomUtils.createComponent(manifestMainComponent);
@@ -402,7 +402,7 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
         String evidencePurl = SbomUtils.addQualifiersToPurlOfComponent(
                 component,
                 Map.of("repository_url", Constants.MRRC_URL),
-                !SbomUtils.hasProperty(component, "deliverable-url"));
+                !SbomUtils.hasProperty(component, Constants.SBOM_RED_HAT_DELIVERABLE_URL));
         log.debug("Calculated evidence purl: {}", evidencePurl);
         component.setPurl(evidencePurl);
         SbomUtils.setEvidenceIdentities(component, Set.of(evidencePurl), Field.PURL);

--- a/service/src/test/resources/errata/release/textOnly/deliverables/A8342BD50FB9496.json
+++ b/service/src/test/resources/errata/release/textOnly/deliverables/A8342BD50FB9496.json
@@ -31,11 +31,11 @@
           "version": "sha256:1c2a89f755d5fdddef08c9f6f3b89e1e15cfa6d316055327bfe3f806acdbfca1",
           "properties": [
             {
-              "name": "deliverable-url",
+              "name": "redhat:deliverable-url",
               "value": "http://download/1.0.0-Beta1/jboss-unified-push-1.0.0.Beta1-maven-repository.zip"
             },
             {
-              "name": "deliverable-checksum",
+              "name": "redhat:deliverable-checksum",
               "value": "sha256:1c2a89f755d5fdddef08c9f6f3b89e1e15cfa6d316055327bfe3f806acdbfca1"
             }
           ],


### PR DESCRIPTION
- Tries to address SBOMER-434
- I updated the test SBOM for deliverables for it to now use redhat: prefixed deliverable-url and deliverable-checksum properties in alignment with the build SBOMs that get produced
- I updated the release sbom building part of the code to now use these redhat: prefixed properties that were also available in Constants