### PR TITLE
Focus on Pending Request Event upon a DelA Finished

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -248,11 +248,19 @@ public class PncNotificationHandler {
         if (!pendingRequests.isEmpty()) {
             // Get the oldest pending generation request and create a new ConfigMap with the existing id
             pendingRequest = pendingRequests.get(0);
+            // if we have a pending request, use that request event instead and ignore the one from UMB
+            RequestEvent requestEventToIgnore = requestEvent;
+            requestEvent = pendingRequest.getRequest();
+            ignoreRequestEvent(
+                    requestEventToIgnore,
+                    "Operation belongs to previous request event " + pendingRequest.getRequest().getId()
+                            + ". Ignoring UMB event: " + requestEventToIgnore.getId());
         }
 
         // Update the requestEvent with the requestConfig
         requestEvent = addPncOperationRequestConfig(requestEvent, String.valueOf(messageBody.getOperationId()));
-
+        // A null pendingRequest getting passed would lead to a new configmap, and lead it to
+        // get synced with the UMB request event
         GenerationRequest req = createDelAnalysisGenerationRequest(messageBody, pendingRequest);
         SbomGenerationRequest sbomGenerationRequest = SbomGenerationRequest.sync(requestEvent, req);
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -255,10 +255,12 @@ public class PncNotificationHandler {
                     requestEventToIgnore,
                     "Operation belongs to previous request event " + pendingRequest.getRequest().getId()
                             + ". Ignoring UMB event: " + requestEventToIgnore.getId());
+        } else {
+            // Update the requestEvent with the requestConfig
+            // Leave original request event if related to pending request event
+            requestEvent = addPncOperationRequestConfig(requestEvent, String.valueOf(messageBody.getOperationId()));
         }
 
-        // Update the requestEvent with the requestConfig
-        requestEvent = addPncOperationRequestConfig(requestEvent, String.valueOf(messageBody.getOperationId()));
         // A null pendingRequest getting passed would lead to a new configmap, and lead it to
         // get synced with the UMB request event
         GenerationRequest req = createDelAnalysisGenerationRequest(messageBody, pendingRequest);

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/features/umb/consumer/PncNotificationHandler.java
@@ -253,7 +253,7 @@ public class PncNotificationHandler {
             requestEvent = pendingRequest.getRequest();
             ignoreRequestEvent(
                     requestEventToIgnore,
-                    "Operation belongs to previous request event " + pendingRequest.getRequest().getId()
+                    "Operation belongs to previous request event " + requestEvent.getId()
                             + ". Ignoring UMB event: " + requestEventToIgnore.getId());
         } else {
             // Update the requestEvent with the requestConfig

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildTest.java
@@ -19,6 +19,7 @@ package org.jboss.sbomer.service.test.integ.feature.sbom.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -34,6 +35,7 @@ import org.jboss.sbomer.core.config.request.PncOperationRequestConfig;
 import org.jboss.sbomer.core.config.request.RequestConfig;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationRequestType;
 import org.jboss.sbomer.core.features.sbom.enums.GenerationResult;
+import org.jboss.sbomer.core.features.sbom.enums.RequestEventStatus;
 import org.jboss.sbomer.core.features.sbom.enums.RequestEventType;
 import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 import org.jboss.sbomer.core.test.TestResources;
@@ -45,6 +47,7 @@ import org.jboss.sbomer.service.feature.sbom.features.umb.producer.AmqpMessagePr
 import org.jboss.sbomer.service.feature.sbom.k8s.model.SbomGenerationStatus;
 import org.jboss.sbomer.service.feature.sbom.model.RequestEvent;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
+import org.jboss.sbomer.service.feature.sbom.service.RequestEventRepository;
 import org.jboss.sbomer.service.feature.sbom.service.SbomGenerationRequestRepository;
 import org.jboss.sbomer.service.test.PncWireMock;
 import org.jboss.sbomer.service.test.utils.AmqpMessageHelper;
@@ -53,6 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.WithTestResource;
@@ -85,6 +89,9 @@ class PncBuildTest {
 
     @Inject
     SbomGenerationRequestRepository sbomGenerationRequestRepository;
+
+    @Inject
+    RequestEventRepository requestEventRepository;
 
     @Inject
     @Connector("smallrye-in-memory")
@@ -228,6 +235,74 @@ class PncBuildTest {
         assertEquals(GenerationResult.ERR_GENERAL, updatedRequest.getResult());
     }
 
+    @Test
+    void testUMBConsumeSuccessfulDelAnalysisOperationWithPendingRequest() throws Exception {
+        log.info("Running testUMBConsumeSuccessfulDelAnalysisOperationWithPendingRequest...");
+
+        // --- ARRANGE (Pre-conditions) ---
+        final String TEST_OPERATION_ID = "A6DFVW2SACABC"; // Must match preparePNCDelAnalysisMsg()
+        final String TEST_SBOM_REQUEST_ID = "TEST_PENDING_REQ_ID"; // Unique ID for our pending request
+
+        // 1. Create a RequestEvent using the provided method
+        ObjectNode dummyEventPayload = ObjectMapperProvider.json().createObjectNode();
+        dummyEventPayload.put("type", "InitialApiCall");
+        dummyEventPayload.put("data", "some-initial-data");
+
+        RequestEvent initialRequestEvent = requestEventRepository
+                .createRequestEvent(RequestEventStatus.IN_PROGRESS, dummyEventPayload, "Created by UMB Message");
+
+        // 2. Prepare initial NO_OP SbomGenerationRequest linked to the RequestEvent
+        SbomGenerationRequest pendingSbomRequest = SbomGenerationRequest.builder()
+                .withId(TEST_SBOM_REQUEST_ID)
+                .withIdentifier(TEST_OPERATION_ID)
+                .withType(GenerationRequestType.OPERATION)
+                .withStatus(SbomGenerationStatus.NO_OP)
+                .withRequest(initialRequestEvent)
+                .build();
+        sbomGenerationRequestRepository.save(pendingSbomRequest);
+
+        log.info(
+                "Pre-created SbomGenerationRequest ID: {} with status {} and linked to RequestEvent ID: {}",
+                pendingSbomRequest.getId(),
+                pendingSbomRequest.getStatus(),
+                pendingSbomRequest.getRequest().getId());
+
+        InMemorySource<Message<String>> builds = connector.source("builds");
+        Message<String> txgMsg = preparePNCDelAnalysisMsgPending();
+
+        // Send the message to notify that the build failed.
+        builds.send(txgMsg);
+
+        ArgumentCaptor<RequestEvent> requestEventArgumentCaptor = ArgumentCaptor.forClass(RequestEvent.class);
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
+            SbomGenerationRequest updated = sbomGenerationRequestRepository.findById(TEST_SBOM_REQUEST_ID);
+
+            return updated != null && updated.getStatus().equals(SbomGenerationStatus.INITIALIZED);
+        });
+
+        // Verify we handled a message
+        verify(handler, times(1)).handle(requestEventArgumentCaptor.capture());
+
+        // Check if the sbom generation request is now initialized and ready to be picked up
+        SbomGenerationRequest updatedRequest = sbomGenerationRequestRepository.findById(TEST_SBOM_REQUEST_ID);
+        assertEquals(SbomGenerationStatus.INITIALIZED, updatedRequest.getStatus());
+
+        // Check if the initial event request is the same as the one that ends up attached to the sbom generation
+        // request
+        RequestEvent initialRequestEventUpdated = requestEventRepository.findById(initialRequestEvent.getId());
+        RequestEvent requestEventConnectedToGenerationRequest = updatedRequest.getRequest();
+        assertNotNull(initialRequestEventUpdated, "The original RequestEvent should still exist in the database.");
+        assertNotNull(requestEventConnectedToGenerationRequest, "RequestEvent of Generation should not be null");
+        assertEquals(
+                initialRequestEventUpdated.getId(),
+                requestEventConnectedToGenerationRequest.getId(),
+                "They should be the same request event, thus the IDs should be the same, but got different:\n"
+                        + initialRequestEventUpdated.toString() + "\n"
+                        + requestEventConnectedToGenerationRequest.toString());
+
+    }
+
     private Message<String> preparePNCBuildMsg() throws IOException {
         JsonObject headers = new JsonObject();
 
@@ -268,6 +343,27 @@ class PncBuildTest {
         headers.put("timestamp", 1698076061381L);
 
         return AmqpMessageHelper.toMessage(TestResources.asString("payloads/umb-pnc-del-analysis-body.json"), headers);
+    }
+
+    private Message<String> preparePNCDelAnalysisMsgPending() throws IOException {
+        JsonObject headers = new JsonObject();
+        headers.put("type", "DeliverableAnalysisStateChange");
+        headers.put("attribute", "deliverable-analysis-state-change");
+        headers.put("name", "org.kie-kie-jpmml-integration-7.67.0.Final-7.13.3");
+        headers.put("milestoneId", "2712");
+        headers.put("operationId", "A6DFVW2SACABC");
+        headers.put("status", "FINISHED");
+        headers.put("JMSXUserID", "projectnewcastle");
+        headers.put("amq6100_originalDestination", "topic://VirtualTopic.eng.pnc.builds");
+        headers.put("correlationId", "a420416c-d184-4ced-9277-500667305139");
+        headers.put("destination", "/topic/VirtualTopic.eng.pnc.builds");
+        headers.put("messageId", "ID:analysis-70-z4tx6-43917-1678809685060-25:1:8557:1:5");
+        headers.put("persistent", "true");
+        headers.put("producer", "PNC");
+        headers.put("timestamp", 1698076061381L);
+
+        return AmqpMessageHelper
+                .toMessage(TestResources.asString("payloads/umb-pnc-del-analysis-body-pending.json"), headers);
     }
 
     private Message<String> prepareFailedPNCDelAnalysisMsg() throws IOException {

--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/messaging/PncBuildTest.java
@@ -275,7 +275,7 @@ class PncBuildTest {
 
         ArgumentCaptor<RequestEvent> requestEventArgumentCaptor = ArgumentCaptor.forClass(RequestEvent.class);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
             SbomGenerationRequest updated = sbomGenerationRequestRepository.findById(TEST_SBOM_REQUEST_ID);
 
             return updated != null && updated.getStatus().equals(SbomGenerationStatus.INITIALIZED);

--- a/service/src/test/resources/mappings/pnc/operation/A6DFVW2SACABC-success.json
+++ b/service/src/test/resources/mappings/pnc/operation/A6DFVW2SACABC-success.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/pnc-rest/v2/operations/deliverable-analyzer/A6DFVW2SACABC"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "A6DFVW2SACABC",
+      "submitTime": "2024-02-05T05:51:29.609Z",
+      "startTime": "2024-02-05T05:51:29.896Z",
+      "endTime": "2024-02-05T06:22:09.452Z",
+      "progressStatus": "FINISHED",
+      "result": "SUCCESSFUL",
+      "user": { "id": "1013", "username": "service-account-rh-messaging-ci" },
+      "parameters": {
+        "url-1": "https://host/broker-7.10.6.CR1/amq-broker-7.10.6.CR1-maven-repository.zip"
+      },
+      "productMilestone": {
+        "id": "2712",
+        "version": "7.10.6.CR1",
+        "endDate": null,
+        "startingDate": "2024-02-02T00:00:00Z",
+        "plannedEndDate": "2024-02-03T00:00:00Z"
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/service/src/test/resources/payloads/umb-pnc-del-analysis-body-pending.json
+++ b/service/src/test/resources/payloads/umb-pnc-del-analysis-body-pending.json
@@ -1,0 +1,9 @@
+{
+  "attribute": "deliverable-analysis-state-change",
+  "deliverablesUrls": [
+    "https://download.com/my-7.10.6.CR1-maven-repository.zip"
+  ],
+  "milestoneId": "2712",
+  "operationId": "A6DFVW2SACABC",
+  "status": "FINISHED"
+}


### PR DESCRIPTION
A fix attempt for SBOMER-426.
This PR:
- Introduces a new test case where a Request Event already triggered for the DelA we were waiting for.
- Tries to solve the issue of a DelA result being connected to 2 request events at once when finished
- Looks if pending requests for this DelA operation exists. If so, prioritizes the request event of the pending request and not the one coming from the UMB. 
- After setting the pending request's request event to be the one to use, ignores the UMB one, citing the reasoning and pointing to the request event that was originally waiting for it.

Basically looks at if it the finished operation has an owner already, if so gives that ownership to them.