### PR TITLE
fix(SBOMER-442): Include checksum for pnc operations

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
@@ -175,8 +175,7 @@ public class CycloneDxGenerateOperationCommand extends AbstractGenerateOperation
 
             // Return optional list of hashes from the first artifact (distro)
             distributionHashes = !artifactsToManifest.isEmpty()
-                    ? Optional.ofNullable(
-                            getHashesFromAnalyzedDistribution(artifactsToManifest.get(0).getDistribution()))
+                    ? Optional.of(getHashesFromAnalyzedDistribution(artifactsToManifest.get(0).getDistribution()))
                     : Optional.empty();
 
             distributionSha256 = distributionHashes.stream()

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/command/CycloneDxGenerateOperationCommand.java
@@ -24,7 +24,7 @@ import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createBom;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createComponent;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createDefaultSbomerMetadata;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.createDependency;
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHashesFromAnalyzedDistroribution;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHashesFromAnalyzedDistribution;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setArtifactMetadata;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPncBuildMetadata;
 import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.setPncOperationMetadata;
@@ -176,7 +176,7 @@ public class CycloneDxGenerateOperationCommand extends AbstractGenerateOperation
             // Return optional list of hashes from the first artifact (distro)
             distributionHashes = !artifactsToManifest.isEmpty()
                     ? Optional.ofNullable(
-                            getHashesFromAnalyzedDistroribution(artifactsToManifest.get(0).getDistribution()))
+                            getHashesFromAnalyzedDistribution(artifactsToManifest.get(0).getDistribution()))
                     : Optional.empty();
 
             distributionSha256 = distributionHashes.stream()

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -429,7 +429,7 @@ public class SbomUtils {
         component.setEvidence(evidence);
     }
 
-    public static List<Hash> getHashesFromAnalyzedDistroribution(AnalyzedDistribution analyzedDistribution) {
+    public static List<Hash> getHashesFromAnalyzedDistribution(AnalyzedDistribution analyzedDistribution) {
         List<Hash> hashes = new ArrayList<>();
 
         if (analyzedDistribution == null) {

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -429,10 +429,10 @@ public class SbomUtils {
         component.setEvidence(evidence);
     }
 
-    public static List<Hash> getDistroHashesFromAnalyzedArtifact(AnalyzedArtifact analyzedArtifact) {
+    public static List<Hash> getHashesFromAnalyzedDistroribution(AnalyzedDistribution analyzedDistribution) {
         List<Hash> hashes = new ArrayList<>();
 
-        if (analyzedArtifact.getDistribution() == null) {
+        if (analyzedDistribution == null) {
             return hashes;
         }
 
@@ -440,9 +440,9 @@ public class SbomUtils {
         for (HashAlgorithmMapping m : DIST_HASH_DEFINITIONS) {
 
             // eg. Call analyzedArtifact.getDistribution.getSha256 and return a cdx Hash of type SHA_256
-            String hashValue = (String) m.getter.apply(analyzedArtifact.getDistribution());
+            String hashValue = (String) m.getter.apply(analyzedDistribution);
 
-            if (Objects.nonNull(hashValue) && !hashValue.isEmpty()) {
+            if (Objects.nonNull(hashValue)) {
                 hashes.add(new Hash(m.algorithm, hashValue));
             }
         }

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -96,6 +97,7 @@ import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.DeliverableAnalyzerOperation;
 import org.jboss.pnc.dto.response.AnalyzedArtifact;
+import org.jboss.pnc.dto.response.AnalyzedDistribution;
 import org.jboss.pnc.restclient.util.ArtifactUtil;
 import org.jboss.sbomer.core.features.sbom.Constants;
 import org.jboss.sbomer.core.features.sbom.config.Config;
@@ -118,6 +120,21 @@ public class SbomUtils {
     public static final String COMPONENT_LICENSE_ACKNOWLEDGEMENT = "concluded";
 
     public static final String EVIDENCE_LICENSE_ACKNOWLEDGEMENT = "declared";
+
+    private static class HashAlgorithmMapping<T> {
+        final Hash.Algorithm algorithm;
+        final Function<T, String> getter; // Function takes T and returns String
+
+        HashAlgorithmMapping(Hash.Algorithm algorithm, Function<T, String> getter) {
+            this.algorithm = algorithm;
+            this.getter = getter;
+        }
+    }
+
+    private static final List<HashAlgorithmMapping<AnalyzedDistribution>> DIST_HASH_DEFINITIONS = List.of(
+            new HashAlgorithmMapping<>(Hash.Algorithm.MD5, AnalyzedDistribution::getMd5),
+            new HashAlgorithmMapping<>(Hash.Algorithm.SHA1, AnalyzedDistribution::getSha1),
+            new HashAlgorithmMapping<>(Hash.Algorithm.SHA_256, AnalyzedDistribution::getSha256));
 
     private SbomUtils() {
         // This is a utility class
@@ -410,6 +427,26 @@ public class SbomUtils {
                         .toList());
         evidence.setLicenses(licenseChoice);
         component.setEvidence(evidence);
+    }
+
+    public static List<Hash> getDistroHashesFromAnalyzedArtifact(AnalyzedArtifact analyzedArtifact) {
+        List<Hash> hashes = new ArrayList<>();
+
+        if (analyzedArtifact.getDistribution() == null) {
+            return hashes;
+        }
+
+        // Use our pre-defined Algo to getter mapper here (DIST_HASH_DEFINTIONS)
+        for (HashAlgorithmMapping m : DIST_HASH_DEFINITIONS) {
+
+            // eg. Call analyzedArtifact.getDistribution.getSha256 and return a cdx Hash of type SHA_256
+            String hashValue = (String) m.getter.apply(analyzedArtifact.getDistribution());
+
+            if (Objects.nonNull(hashValue) && !hashValue.isEmpty()) {
+                hashes.add(new Hash(m.algorithm, hashValue));
+            }
+        }
+        return hashes;
     }
 
     public static Component createComponent(AnalyzedArtifact analyzedArtifact, Scope scope, Type type) {

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.sbomer.core.test.unit;
 
-import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHashesFromAnalyzedDistroribution;
+import static org.jboss.sbomer.core.features.sbom.utils.SbomUtils.getHashesFromAnalyzedDistribution;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -457,7 +457,7 @@ class SbomUtilsTest {
         when(mockedDistribution.getSha256())
                 .thenReturn("01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b");
 
-        List<Hash> hashes = getHashesFromAnalyzedDistroribution(mockedDistribution);
+        List<Hash> hashes = getHashesFromAnalyzedDistribution(mockedDistribution);
         assertNotNull(hashes);
 
         // We've set 3 hash types we should get
@@ -472,14 +472,14 @@ class SbomUtilsTest {
 
         // If we ever add more hash types in the future we might get null from records
         when(mockedDistribution.getSha256()).thenReturn(null);
-        List<Hash> hasheswnull = getHashesFromAnalyzedDistroribution(mockedDistribution);
+        List<Hash> hasheswnull = getHashesFromAnalyzedDistribution(mockedDistribution);
         assertNotNull(hasheswnull);
         assertEquals(2, hasheswnull.size());
         assertTrue(hasheswnull.contains(new Hash(Hash.Algorithm.MD5, "68b329da9893e34099c7d8ad5cb9c940")));
         assertTrue(hasheswnull.contains(new Hash(Hash.Algorithm.SHA1, "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc")));
 
         // Finally what if an artifact has no distro
-        List<Hash> hashesnullobj = getHashesFromAnalyzedDistroribution(null);
+        List<Hash> hashesnullobj = getHashesFromAnalyzedDistribution(null);
         assertNotNull(hashesnullobj);
     }
 
@@ -501,12 +501,12 @@ class SbomUtilsTest {
         Optional<String> distributionSha256;
         Optional<String> distributionSha2562;
 
-        // IF OLD DELA 
+        // IF OLD DELA
         distributionHashes2 = Optional.empty();
         distributionSha2562 = Optional.empty();
 
         distributionHashes = !artifactsToManifest.isEmpty()
-                ? Optional.ofNullable(getHashesFromAnalyzedDistroribution(artifactsToManifest.get(0).getDistribution()))
+                ? Optional.of(getHashesFromAnalyzedDistribution(artifactsToManifest.get(0).getDistribution()))
                 : Optional.empty();
 
         distributionSha256 = distributionHashes.stream()


### PR DESCRIPTION
In this commit:

* Added new method in `SbomUtils`
  * `getDistroHashesFromAnalyzedArtifact` takes a AnalyzedArtifact and gets checksums (md5, sha1 & sha256) from AnalyzedDistro
  * A getter AnalyzedDistro to cyclonedx `Hash` mapper is provided
  * This should allow easier additions of other hashing algorithms in future
* Added simple tests for `getDistroHashesFromAnalyzedArtifact`
* During `CycloneDxGenerateOperationCommand` the main component is created and the hashes are set after the creation