### PR TITLE
Update product version to the one currently used for pnc id test

### DIFF
--- a/cli/src/main/resources/mapping/stage/product-mapping.yaml
+++ b/cli/src/main/resources/mapping/stage/product-mapping.yaml
@@ -37,7 +37,7 @@
       generator:
         type: maven-domino
         args: "--warn-on-missing-scm --legacy-scm-locator --hashes=false"
-"283":
+"532":
   type: pnc-build
   products:
     - processors:


### PR DESCRIPTION
The current e2e test are failing because one of the product versions of the build ids we use to generate manifests has been changed in PNC. To address this, this PR updates the product version ID to the new one this build uses