### PR TITLE
Add optional forceBuild field to force the generation of build manifests for a given advisory

### DIFF
--- a/core/src/main/java/org/jboss/sbomer/core/config/request/ErrataAdvisoryRequestConfig.java
+++ b/core/src/main/java/org/jboss/sbomer/core/config/request/ErrataAdvisoryRequestConfig.java
@@ -40,13 +40,20 @@ public class ErrataAdvisoryRequestConfig extends RequestConfig {
 
     public static final String IDENTIFIER_KEY = "advisoryId";
 
+    public static final String FORCE_BUILD = "forceBuild";
+
     /**
      * Advisory identifier (number or name).
      */
     private String advisoryId;
+    /**
+     * Boolean to force build manifest generation for the advisory
+     */
+    private boolean forceBuild;
 
     @Override
     public String getType() {
         return TYPE_NAME;
     }
+
 }

--- a/core/src/main/resources/schemas/request/errata-advisory.json
+++ b/core/src/main/resources/schemas/request/errata-advisory.json
@@ -9,10 +9,14 @@
         "type": {
             "const": "errata-advisory"
         },
-
         "advisoryId": {
             "description": "Errata Tool advisory identifier",
             "type": "string"
+        },
+        "forceBuild": {
+            "description": "Force a new build manifest generation for advisory",
+            "type": "boolean",
+            "default": false
         }
     },
     "required": ["advisoryId", "type"],

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/config/RequestConfigSchemaValidatorTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/config/RequestConfigSchemaValidatorTest.java
@@ -1,0 +1,56 @@
+package org.jboss.sbomer.core.test.unit.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.sbomer.core.SchemaValidator.ValidationResult;
+import org.jboss.sbomer.core.config.RequestConfigSchemaValidator;
+import org.jboss.sbomer.core.config.request.ErrataAdvisoryRequestConfig;
+import org.jboss.sbomer.core.config.request.RequestConfig;
+import org.jboss.sbomer.core.test.TestResources;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class RequestConfigSchemaValidatorTest {
+    final RequestConfigSchemaValidator requestConfigValidator = new RequestConfigSchemaValidator();
+
+    @Nested
+    class ErrataAdvisoryRequestConfigTests {
+
+        @Test
+        void validateConfig() throws IOException {
+            String content = TestResources.asString("configs/advisory.json");
+
+            ErrataAdvisoryRequestConfig config = RequestConfig.fromString(content, ErrataAdvisoryRequestConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertEquals("12345", config.getAdvisoryId());
+            // verify that forceBuild defaults to false
+            assertEquals(false, config.isForceBuild());
+
+            ValidationResult result = requestConfigValidator.validate(config);
+            assertTrue(result.isValid());
+            assertTrue(result.getErrors().isEmpty());
+        }
+
+        @Test
+        void validateConfigWithForceBuild() throws IOException {
+            String content = TestResources.asString("configs/advisory-force-build.json");
+
+            ErrataAdvisoryRequestConfig config = RequestConfig.fromString(content, ErrataAdvisoryRequestConfig.class);
+
+            assertEquals("sbomer.jboss.org/v1alpha1", config.getApiVersion());
+            assertEquals("12345", config.getAdvisoryId());
+            // verify that forceBuild is true
+            assertEquals(true, config.isForceBuild());
+
+            ValidationResult result = requestConfigValidator.validate(config);
+            assertTrue(result.isValid());
+            assertTrue(result.getErrors().isEmpty());
+        }
+
+    }
+
+}

--- a/core/src/test/resources/configs/advisory-force-build.json
+++ b/core/src/test/resources/configs/advisory-force-build.json
@@ -1,0 +1,5 @@
+{
+  "type": "errata-advisory",
+  "advisoryId": 12345,
+  "forceBuild": true
+}

--- a/core/src/test/resources/configs/advisory.json
+++ b/core/src/test/resources/configs/advisory.json
@@ -1,0 +1,4 @@
+{
+  "type": "errata-advisory",
+  "advisoryId": 12345
+}

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -117,6 +117,15 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
                 V1Beta1RequestRecord advisoryManifestsRecord = sbomService
                         .searchLastSuccessfulAdvisoryRequestRecord(requestEvent.getId(), config.getAdvisoryId());
 
+                if (config.isForceBuild()) {
+                    advisoryManifestsRecord = null;
+                    log.debug(
+                            "forceBuild has been set to true in request for advisory: '{}'[{}]. "
+                                    + "Ignoring latest generations and generating build manifests again",
+                            erratum.getDetails().get().getFulladvisory(),
+                            erratum.getDetails().get().getId());
+                }
+
                 String toolVersion = statsService.getStats().getVersion();
                 // FIXME: 'Optional.get()' without 'isPresent()' check
                 Component.Type productType = AdvisoryEventUtils

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseStandardAdvisoryEventsListener.java
@@ -117,15 +117,6 @@ public class ReleaseStandardAdvisoryEventsListener extends AbstractEventsListene
                 V1Beta1RequestRecord advisoryManifestsRecord = sbomService
                         .searchLastSuccessfulAdvisoryRequestRecord(requestEvent.getId(), config.getAdvisoryId());
 
-                if (config.isForceBuild()) {
-                    advisoryManifestsRecord = null;
-                    log.debug(
-                            "forceBuild has been set to true in request for advisory: '{}'[{}]. "
-                                    + "Ignoring latest generations and generating build manifests again",
-                            erratum.getDetails().get().getFulladvisory(),
-                            erratum.getDetails().get().getId());
-                }
-
                 String toolVersion = statsService.getStats().getVersion();
                 // FIXME: 'Optional.get()' without 'isPresent()' check
                 Component.Type productType = AdvisoryEventUtils

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
@@ -115,6 +115,16 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
                     // the request event
                     V1Beta1RequestRecord advisoryManifestsRecord = sbomService
                             .searchLastSuccessfulAdvisoryRequestRecord(requestEvent.getId(), config.getAdvisoryId());
+
+                    if (config.isForceBuild()) {
+                        advisoryManifestsRecord = null;
+                        log.debug(
+                                "forceBuild has been set to true in request for advisory: '{}'[{}]. "
+                                        + "Ignoring latest generations and generating build manifests again",
+                                erratum.getDetails().get().getFulladvisory(),
+                                erratum.getDetails().get().getId());
+                    }
+
                     manifestsPurls = advisoryManifestsRecord.manifests()
                             .stream()
                             .map(V1Beta1RequestManifestRecord::rootPurl)

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/errata/event/release/ReleaseTextOnlyAdvisoryEventsListener.java
@@ -116,15 +116,6 @@ public class ReleaseTextOnlyAdvisoryEventsListener extends AbstractEventsListene
                     V1Beta1RequestRecord advisoryManifestsRecord = sbomService
                             .searchLastSuccessfulAdvisoryRequestRecord(requestEvent.getId(), config.getAdvisoryId());
 
-                    if (config.isForceBuild()) {
-                        advisoryManifestsRecord = null;
-                        log.debug(
-                                "forceBuild has been set to true in request for advisory: '{}'[{}]. "
-                                        + "Ignoring latest generations and generating build manifests again",
-                                erratum.getDetails().get().getFulladvisory(),
-                                erratum.getDetails().get().getId());
-                    }
-
                     manifestsPurls = advisoryManifestsRecord.manifests()
                             .stream()
                             .map(V1Beta1RequestManifestRecord::rootPurl)

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
@@ -316,14 +316,16 @@ public class AdvisoryService {
 
             // If the forceBuild flag is enabled on incoming requestConfig, we ignore any successful records found
             // in the previous code block to force a build manifest generation instead of a release.
-            if (requestEvent.getRequestConfig() != null && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
-                ErrataAdvisoryRequestConfig advisoryConfig = (ErrataAdvisoryRequestConfig) requestEvent.getRequestConfig();
+            if (requestEvent.getRequestConfig() != null
+                    && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
+                ErrataAdvisoryRequestConfig advisoryConfig = (ErrataAdvisoryRequestConfig) requestEvent
+                        .getRequestConfig();
                 if (advisoryConfig.isForceBuild()) {
                     successfulRequestRecord = null;
                     log.debug(
-                "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
-                        erratum.getDetails().get().getFulladvisory(),
-                        erratum.getDetails().get().getId());
+                            "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
+                            erratum.getDetails().get().getFulladvisory(),
+                            erratum.getDetails().get().getId());
                 }
             }
 
@@ -460,14 +462,15 @@ public class AdvisoryService {
 
         // If the forceBuild flag is enabled on incoming requestConfig, we ignore any successful records found
         // in the previous code block to force a build manifest generation instead of a release.
-        if (requestEvent.getRequestConfig() != null && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
+        if (requestEvent.getRequestConfig() != null
+                && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
             ErrataAdvisoryRequestConfig advisoryConfig = (ErrataAdvisoryRequestConfig) requestEvent.getRequestConfig();
             if (advisoryConfig.isForceBuild()) {
                 successfulRequestRecord = null;
                 log.debug(
-                "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
-                    erratum.getDetails().get().getFulladvisory(),
-                    erratum.getDetails().get().getId());
+                        "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
+                        erratum.getDetails().get().getFulladvisory(),
+                        erratum.getDetails().get().getId());
             }
         }
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/AdvisoryService.java
@@ -314,6 +314,19 @@ public class AdvisoryService {
                         String.valueOf(erratum.getDetails().get().getId()));
             }
 
+            // If the forceBuild flag is enabled on incoming requestConfig, we ignore any successful records found
+            // in the previous code block to force a build manifest generation instead of a release.
+            if (requestEvent.getRequestConfig() != null && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
+                ErrataAdvisoryRequestConfig advisoryConfig = (ErrataAdvisoryRequestConfig) requestEvent.getRequestConfig();
+                if (advisoryConfig.isForceBuild()) {
+                    successfulRequestRecord = null;
+                    log.debug(
+                "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
+                        erratum.getDetails().get().getFulladvisory(),
+                        erratum.getDetails().get().getId());
+                }
+            }
+
             if (successfulRequestRecord == null) {
                 List<RequestConfig> requestConfigsWithinNotes = parseRequestConfigsFromJsonNotes(
                         notes,
@@ -443,6 +456,19 @@ public class AdvisoryService {
             successfulRequestRecord = sbomService.searchLastSuccessfulAdvisoryRequestRecord(
                     requestEvent.getId(),
                     String.valueOf(erratum.getDetails().get().getId()));
+        }
+
+        // If the forceBuild flag is enabled on incoming requestConfig, we ignore any successful records found
+        // in the previous code block to force a build manifest generation instead of a release.
+        if (requestEvent.getRequestConfig() != null && requestEvent.getRequestConfig() instanceof ErrataAdvisoryRequestConfig) {
+            ErrataAdvisoryRequestConfig advisoryConfig = (ErrataAdvisoryRequestConfig) requestEvent.getRequestConfig();
+            if (advisoryConfig.isForceBuild()) {
+                successfulRequestRecord = null;
+                log.debug(
+                "forceBuild has been set to true in request for advisory: '{}'[{}]. Ignoring latest generations and generating build manifests again",
+                    erratum.getDetails().get().getFulladvisory(),
+                    erratum.getDetails().get().getId());
+            }
         }
 
         if (details.getContentTypes().contains("docker")) {

--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
@@ -140,7 +140,7 @@ public class GenerationsV1Beta1 {
                                     value = "{\"type\": \"pnc-analysis\", \"milestoneId\": \"1234\", \"urls\": [\"https://download.host.com/staging/product-a/release-b/first.zip\", \"https://download.host.com/staging/product-a/release-b/second.zip\"]}"),
                             @ExampleObject(
                                     name = "Errata Tool advisory",
-                                    description = "Requests manifest generation for the 12345 advisory",
+                                    description = "Requests manifest generation for the 12345 advisory. Can also take an optional forceBuild boolean field (defaults to false) to force build manifests to be generated for the advisory.",
                                     value = "{\"type\": \"errata-advisory\", \"advisoryId\": 12345}"),
                             @ExampleObject(
                                     name = "Container image",


### PR DESCRIPTION
I added an optional forceBuild so we can invoke build manifest generation for an advisory even if he has already successful previous build manifests.