### PR TITLE
Do not consider in progress requests with no manifests when checking build requests

### DIFF
--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/service/SbomService.java
@@ -617,7 +617,7 @@ public class SbomService {
         // The generations of _build_ manifests have config != null
         List<V1Beta1RequestRecord> advisoryBuildRequestRecords = allAdvisoryRequestRecordsFiltered.stream()
                 .filter(
-                        record -> record.manifests()
+                        record -> !record.manifests().isEmpty() && record.manifests()
                                 .stream()
                                 .noneMatch(
                                         manifest -> manifest.generation() != null


### PR DESCRIPTION
When we have an in progress manifest generation (either build or release), it will not have any manifests produced, so if a request gets stuck in progress, it will stay like that without any manifests. So the current attempt at filtering of build manifest requests will accidentally include "in progress" release requests in its check for if the last build manifest was successful.

This means when we have a stuck-in-progress release, the current filter isn't able to do a check if it's a build manifest and by default considers it a build manifest to check if it was successful. This change should throw out the in progress requests from consideration, so it will catch the one before and check if that one was successful.

This would hopefully allow us to re-do release manifest generations that have been stuck in progress if their last build manifest request was successful. 

**Edge case to consider**
If it gets triggered when there's build manifest still in progress, it would ignore it and still do the last successful one. This makes sense to me, even if it could be undesirable. The service will work with what it has.

Sorry if none of this text makes sense 🤣 I hope the code change itself gives more context