### PR TITLE
feature(datasource-metrics): To help investigate SBOMER-469 add metrics

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -222,6 +222,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-metrics</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -177,6 +177,10 @@
       <artifactId>quarkus-opentelemetry</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-jdbc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.tektonclient</groupId>
       <artifactId>quarkus-tekton-client</artifactId>
       <version>${version.tekton-client}</version>

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -153,7 +153,8 @@ quarkus:
   # Database configuration
   datasource:
     db-kind: postgresql
-    metrics: true
+    metrics:
+      enabled: true
     jdbc:
       max-size: 20
       min-size: 0

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -153,6 +153,7 @@ quarkus:
   # Database configuration
   datasource:
     db-kind: postgresql
+    metrics: true
     jdbc:
       max-size: 20
       min-size: 0

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -156,6 +156,7 @@ quarkus:
     metrics:
       enabled: true
     jdbc:
+      telemetry: true
       max-size: 20
       min-size: 0
       initial-size: 1


### PR DESCRIPTION
In this commit:

* Add smallrye-metrics to service pom
* Enable metrics for datasource

Once added to the pom.xml metrics can be accessed at http://localhost:8080/q/metrics the metrics we are interested in are `vendor_agroal_*`