### PR TITLE
test(SBOMER-469): Fix test failures

### DIFF
--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseSyftGenerationRequestReconcilerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseSyftGenerationRequestReconcilerTest.java
@@ -182,7 +182,7 @@ class GenerationPhaseSyftGenerationRequestReconcilerTest {
 
     @Test
     void testBulkheadExceptionOnExceededRetries(@TempDir Path tmpDir) throws Exception {
-        int totalRequests = 500;
+        int totalRequests = 100;
         List<GenerationRequest> requests = createGenerationRequests(totalRequests, tmpDir, TASKRUN_COUNT);
         executorService = Executors.newFixedThreadPool(totalRequests);
         List<Future<UpdateControl<GenerationRequest>>> futures = new ArrayList<>();

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TestControllerProfile.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TestControllerProfile.java
@@ -14,6 +14,7 @@ public class TestControllerProfile implements QuarkusTestProfile {
         return Set.of(AlternativeRequestEventRepository.class, AlternativeGeneratorConfigProvider.class);
     }
 
+    // Override fault tolerance and logging
     @Override
     public Map<String, String> getConfigOverrides() {
         return Map.of(
@@ -32,6 +33,10 @@ public class TestControllerProfile implements QuarkusTestProfile {
                 "Retry/maxDurationUnit",
                 "millis",
                 "Timeout/unit",
-                "millis");
+                "millis",
+                "quarkus.log.console.enable",
+                "false",
+                "quarkus.log.file.enable",
+                "false");
     }
 }


### PR DESCRIPTION
In this commit:

* Turn off logging in this test profile (we exceed our max log size in stage)
* Reduce number of generations to 100 (500 might of been excessive)