### PR TITLE
test(SBOMER-469): Fix test failures again

### DIFF
--- a/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseSyftGenerationRequestReconcilerTest.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/integ/feature/sbom/k8s/reconciler/GenerationPhaseSyftGenerationRequestReconcilerTest.java
@@ -162,7 +162,7 @@ class GenerationPhaseSyftGenerationRequestReconcilerTest {
         List<Future<UpdateControl<GenerationRequest>>> futures = new ArrayList<>();
 
         for (GenerationRequest request : requests) {
-            Context<GenerationRequest> context = mockContextWithTaskRuns(3, "True");
+            Context<GenerationRequest> context = mockContextWithTaskRuns(TASKRUN_COUNT, "True");
             futures.add(executorService.submit(() -> sic.reconcile(request, context)));
         }
 
@@ -181,7 +181,7 @@ class GenerationPhaseSyftGenerationRequestReconcilerTest {
 
     @Test
     void testBulkheadExceptionOnExceededRetries(@TempDir Path tmpDir) throws Exception {
-        int totalRequests = 500;
+        int totalRequests = 100;
         List<GenerationRequest> requests = createGenerationRequests(totalRequests, tmpDir, TASKRUN_COUNT);
         executorService = Executors.newFixedThreadPool(totalRequests);
         List<Future<UpdateControl<GenerationRequest>>> futures = new ArrayList<>();

--- a/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TestControllerProfile.java
+++ b/service/src/test/java/org/jboss/sbomer/service/test/unit/feature/sbom/syftimage/TestControllerProfile.java
@@ -19,13 +19,13 @@ public class TestControllerProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "Retry/maxRetries",
-                "2",
+                "3",
                 "Retry/delay",
-                "200",
+                "250",
                 "Retry/delayUnit",
                 "millis",
                 "ExponentialBackoff/maxDelay",
-                "450",
+                "500",
                 "Retry/maxDelayUnit",
                 "millis",
                 "Retry/maxDurationUnit",


### PR DESCRIPTION
In this commit:

* Tune Fault Tolerance API values
  * Increase retries and increase delay (we are less likely to hit bulkhead exception)
* Reduce number of requests
  * This doesn't seem to be that relevant
* Use static var where it should of been used