### PR TITLE
SBOMER-480 Fix E2E tests

### DIFF
--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
@@ -109,13 +109,12 @@ public abstract class E2EBase {
             }
 
             final String status = jsonPath.getString("eventStatus");
-            final String identifier = jsonPath.getString("requestConfig.identifier");
+            final String requestConfig  = jsonPath.getString("requestConfig");
 
             log.info(
-                    "Generation '{}' (type: '{}', identifier: '{}') current status: {}",
+                    "Generation '{}' (requestConfig '{}') current status: {}",
                     requestId,
-                    type,
-                    identifier,
+                    requestConfig,
                     status);
 
             if ("[FAILED]".equals(status)) {
@@ -275,7 +274,7 @@ public abstract class E2EBase {
 
     public List<String> generationIdsFromRequest(String requestID) {
         final Response response = getRequest(requestID);
-        //Flatten and dedupe the generation IDs we get back
+        // Flatten and dedupe the generation IDs we get back
         List<String> ids = response.jsonPath().getList("manifests.generation.id.flatten()");
         return ids.stream().distinct().collect(Collectors.toList());
     }

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
@@ -109,13 +109,9 @@ public abstract class E2EBase {
             }
 
             final String status = jsonPath.getString("eventStatus");
-            final String requestConfig  = jsonPath.getString("requestConfig");
+            final String requestConfig = jsonPath.getString("requestConfig");
 
-            log.info(
-                    "Generation '{}' (requestConfig '{}') current status: {}",
-                    requestId,
-                    requestConfig,
-                    status);
+            log.info("Generation '{}' (requestConfig '{}') current status: {}", requestId, requestConfig, status);
 
             if ("[FAILED]".equals(status)) {
                 log.error("Generation '{}' failed: {}", requestId, response.asPrettyString());

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/E2EBase.java
@@ -23,6 +23,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.awaitility.Awaitility;
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import lombok.Data;
@@ -88,6 +90,47 @@ public abstract class E2EBase {
         }
 
         return uri;
+    }
+
+    /*
+     * This also means we will await completion of generations
+     */
+    protected void waitForRequest(String requestId, long time, TimeUnit unit) {
+        Awaitility.await().atMost(time, unit).pollInterval(10, TimeUnit.SECONDS).until(() -> {
+            final Response response = getRequest(requestId);
+            final JsonPath jsonPath = response.body().jsonPath();
+
+            final String type = jsonPath.getString("requestConfig.type");
+
+            if (type == null) {
+                // The request type hasn't got a manifest/generation attached yet, continue to poll
+                log.info("Generation '{}': 'requestConfig.type' not available yet, continuing to poll...", requestId);
+                return false;
+            }
+
+            final String status = jsonPath.getString("eventStatus");
+            final String identifier = jsonPath.getString("requestConfig.identifier");
+
+            log.info(
+                    "Generation '{}' (type: '{}', identifier: '{}') current status: {}",
+                    requestId,
+                    type,
+                    identifier,
+                    status);
+
+            if ("[FAILED]".equals(status)) {
+                log.error("Generation '{}' failed: {}", requestId, response.asPrettyString());
+                throw new Exception(String.format("GenerationRequest '%s' failed, see logs above", requestId));
+            }
+
+            return "[SUCCESS]".equals(status);
+        });
+
+        log.info("Generation '{}' successfully finished", requestId);
+    }
+
+    protected void waitForRequest(String generationRequestId) {
+        waitForRequest(generationRequestId, 30, TimeUnit.MINUTES);
     }
 
     protected void waitForGeneration(String generationRequestId) {
@@ -167,6 +210,23 @@ public abstract class E2EBase {
         consumer.accept(atomicResponse.get());
     }
 
+    public Response getRequest(String requestId) {
+        log.info("Fetching request with id '{}'", requestId);
+
+        Response response = RestAssured.given()
+                .baseUri(getSbomerBaseUri())
+                .contentType(ContentType.JSON)
+                .pathParam("id", requestId)
+                .log()
+                .all()
+                .when()
+                .get("/api/v1beta1/requests/id={id}");
+
+        log.info("Got request: {}", response.body().asPrettyString());
+
+        return response;
+    }
+
     public Response getGeneration(String generationId) {
         log.info("Fetching generation with id '{}'", generationId);
 
@@ -195,7 +255,7 @@ public abstract class E2EBase {
         return response;
     }
 
-    public List<String> requestGeneration(String jsonBody) {
+    public String requestGeneration(String jsonBody) {
         log.info("Requesting generation of manifest with jsonBody: {}", jsonBody);
 
         Response response = RestAssured.given()
@@ -210,6 +270,13 @@ public abstract class E2EBase {
 
         log.info("Got request generation: {}", response.body().asPrettyString());
 
-        return response.jsonPath().getList("id");
+        return response.jsonPath().getString("id");
+    }
+
+    public List<String> generationIdsFromRequest(String requestID) {
+        final Response response = getRequest(requestID);
+        //Flatten and dedupe the generation IDs we get back
+        List<String> ids = response.jsonPath().getList("manifests.generation.id.flatten()");
+        return ids.stream().distinct().collect(Collectors.toList());
     }
 }

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/AdvisoryGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/AdvisoryGenerationRequestIT.java
@@ -49,13 +49,13 @@ class AdvisoryGenerationRequestIT extends E2EStageBase {
     @Disabled("Container image not accessible anymore, need to find new image/advisory")
     void testContainerGenerationOfQEAdvisory() throws IOException {
         String requestBody = Files.readString(sbomPath("advisory-88484.json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
 
         log.info("Advisory in QE status with Container - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         final Response response = getManifestsForGeneration(generationId);
 
@@ -71,13 +71,13 @@ class AdvisoryGenerationRequestIT extends E2EStageBase {
     @Test
     void testRPMGenerationOfQEAdvisory() throws IOException {
         String requestBody = Files.readString(sbomPath("advisory-89769.json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
-        String generationId = generationIds.get(0);
+        String generationId = generationIds.get(0).toString();
 
         log.info("Advisory in QE status with RPMs - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         final Response response = getManifestsForGeneration(generationId);
 

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/AdvisoryGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/AdvisoryGenerationRequestIT.java
@@ -75,7 +75,7 @@ class AdvisoryGenerationRequestIT extends E2EStageBase {
         waitForRequest(requestId);
         List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
-        String generationId = generationIds.get(0).toString();
+        String generationId = generationIds.get(0);
 
         log.info("Advisory in QE status with RPMs - Generation Request created: {}", generationId);
 

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/ContainerImageGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/ContainerImageGenerationRequestIT.java
@@ -65,15 +65,14 @@ class ContainerImageGenerationRequestIT extends E2EStageBase {
     @Test
     void testMultiArchImage() throws IOException {
         String requestBody = Files.readString(sbomPath("mandrel-image.json"));
-        List<String> generationIds = requestGeneration(requestBody);
-
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
 
         String generationId = generationIds.get(0);
 
         log.info("Mandrel container image - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         // TODO: UMB check disabled, because we do not add product coordinates anymore which control if we should send
         // UMB message
@@ -104,7 +103,9 @@ class ContainerImageGenerationRequestIT extends E2EStageBase {
     @ParameterizedTest
     @MethodSource("requestBodies")
     void testSkinnyManifests(JsonObject requestBody) {
-        List<String> generationIds = requestGeneration(requestBody.toString());
+        String requestId = requestGeneration(requestBody.toString());
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
 
@@ -112,8 +113,6 @@ class ContainerImageGenerationRequestIT extends E2EStageBase {
                 "{} container image - Generation Request created: {}",
                 requestBody.getValue("/image").toString(),
                 generationId);
-
-        waitForGeneration(generationId);
 
         final Response response = getManifestsForGeneration(generationId);
         assertTrue((response.body().jsonPath().getInt("totalHits") > 0));

--- a/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
+++ b/e2e/src/test/java/org/jboss/sbomer/test/e2e/rw/StageGenerationRequestIT.java
@@ -52,12 +52,12 @@ class StageGenerationRequestIT extends E2EStageBase {
     @Execution(ExecutionMode.CONCURRENT)
     void testSuccessfulGenerationMavenBuild() throws IOException {
         String requestBody = Files.readString(sbomPath("pnc-build-" + MAVEN_BUILD_ID + ".json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
         log.info("Maven build - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         log.info("Maven build finished, waiting for UMB message");
 
@@ -75,13 +75,13 @@ class StageGenerationRequestIT extends E2EStageBase {
     @Execution(ExecutionMode.CONCURRENT)
     void testSuccessfulGenerationGradle5Build() throws IOException {
         String requestBody = Files.readString(sbomPath("pnc-build-" + GRADLE_5_BUILD_ID + ".json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
 
         log.info("Gradle 5 build - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         // log.info("Gradle 5 build finished, waiting for UMB message");
 
@@ -99,13 +99,13 @@ class StageGenerationRequestIT extends E2EStageBase {
     @Execution(ExecutionMode.CONCURRENT)
     void testSuccessfulGenerationGradle4Build() throws IOException {
         String requestBody = Files.readString(sbomPath("pnc-build-" + GRADLE_4_BUILD_ID + ".json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
 
         log.info("Gradle 4 build - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         // log.info("Gradle 4 build finished, waiting for UMB message");
 
@@ -126,13 +126,13 @@ class StageGenerationRequestIT extends E2EStageBase {
     @Execution(ExecutionMode.CONCURRENT)
     void testSuccessfulGenerationNodeJsNpmBuild() throws IOException {
         String requestBody = Files.readString(sbomPath("pnc-build-" + NODEJS_NPM_BUILD_ID + ".json"));
-        List<String> generationIds = requestGeneration(requestBody);
+        String requestId = requestGeneration(requestBody);
+        waitForRequest(requestId);
+        List<String> generationIds = generationIdsFromRequest(requestId);
         assertEquals(1, generationIds.size());
         String generationId = generationIds.get(0);
 
         log.info("NodeJs NPM build - Generation Request created: {}", generationId);
-
-        waitForGeneration(generationId);
 
         // log.info("Node.js NPM build finished, waiting for UMB message");
 

--- a/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/api/v1beta1/GenerationsV1Beta1.java
@@ -269,7 +269,7 @@ public class GenerationsV1Beta1 {
          *
          * The request handle can be used by the client to track the gneration progress
          */
-        return Response.accepted(request).build();
+        return Response.accepted(mapper.toRecord(request)).build();
     }
 
     @GET

--- a/service/src/main/java/org/jboss/sbomer/service/rest/mapper/V1Beta1Mapper.java
+++ b/service/src/main/java/org/jboss/sbomer/service/rest/mapper/V1Beta1Mapper.java
@@ -18,12 +18,14 @@
 package org.jboss.sbomer.service.rest.mapper;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.jboss.sbomer.core.dto.BaseSbomRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1BaseGenerationRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1BaseManifestRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1GenerationRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1ManifestRecord;
+import org.jboss.sbomer.core.dto.v1beta1.V1Beta1RequestRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord.V1Beta1StatsDeploymentRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord.V1Beta1StatsMessagingRecord;
@@ -31,6 +33,7 @@ import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord.V1Beta1StatsResource
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord.V1Beta1StatsResourceManifestsRecord;
 import org.jboss.sbomer.core.dto.v1beta1.V1Beta1StatsRecord.V1Beta1StatsResourceRecord;
 import org.jboss.sbomer.core.features.sbom.rest.Page;
+import org.jboss.sbomer.service.feature.sbom.model.RequestEvent;
 import org.jboss.sbomer.service.feature.sbom.model.Sbom;
 import org.jboss.sbomer.service.feature.sbom.model.SbomGenerationRequest;
 import org.jboss.sbomer.service.feature.sbom.model.Stats;
@@ -43,12 +46,12 @@ import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(config = MapperConfig.class)
+@Mapper(config = MapperConfig.class, imports = Collections.class)
 public interface V1Beta1Mapper extends EntityMapper<V1Beta1ManifestRecord, V1Beta1GenerationRecord> {
 
     @Override
     @Mapping(target = "generation", source = "sbom.generationRequest")
-    @BeanMapping(ignoreUnmappedSourceProperties = "persistent")
+    @BeanMapping(ignoreUnmappedSourceProperties = { "persistent", "releaseMetadata" })
     V1Beta1ManifestRecord toRecord(Sbom sbom);
 
     Page<V1Beta1ManifestRecord> sbomsToBaseRecordPage(Page<Sbom> sboms);
@@ -63,6 +66,11 @@ public interface V1Beta1Mapper extends EntityMapper<V1Beta1ManifestRecord, V1Bet
 
     @Mapping(target = "generation", source = "generationRequest")
     V1Beta1BaseManifestRecord toRecord(BaseSbomRecord baseSbom);
+
+    // We will never have manifests when this DTO is returned, instead have an empty list
+    @Mapping(target = "manifests", expression = "java(Collections.emptyList())")
+    @BeanMapping(ignoreUnmappedSourceProperties = "persistent")
+    V1Beta1RequestRecord toRecord(RequestEvent requestEvent);
 
     Page<V1Beta1BaseManifestRecord> toRecord(Page<BaseSbomRecord> sboms);
 


### PR DESCRIPTION
Previously the E2E tests relied upon the generation endpoint returning a generation, this has been changed to return a request to allow asynchronous calling (we cannot wait for a generation to start before responding to client).

These fixes will result in more calls as we also lookup the generations rather than just using the manifest objects referenced in the request payload, this isn't how we expect the API to be used but resulted in minimal changes to the E2E tests 