### PR TITLE
feat: Prevent orphaned exemplars

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -177,6 +177,10 @@
       <artifactId>quarkus-micrometer-opentelemetry</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-jdbc</artifactId>
     </dependency>

--- a/service/src/main/resources/application-prod.yaml
+++ b/service/src/main/resources/application-prod.yaml
@@ -76,10 +76,9 @@ quarkus:
     traces:
       enabled: true
       sampler: always_on
+      suppress-non-application-uris: false
     metrics:
       enabled: true
-      exemplar:
-        filter: always_on
     logs:
       enabled: false
 


### PR DESCRIPTION
Enable Prometheus registry for scraping metrics via /q/metrics endpoint.
Remove redundant config.

Related to #1793