### PR TITLE
chore(SBOMER-500): Increase Atlas backoff time

### DIFF
--- a/core/src/main/java/org/jboss/sbomer/core/rest/faulttolerance/Constants.java
+++ b/core/src/main/java/org/jboss/sbomer/core/rest/faulttolerance/Constants.java
@@ -30,7 +30,8 @@ public class Constants {
     public static final long ERRATA_CLIENT_DELAY = 1;
     public static final long PYXIS_CLIENT_DELAY = 1;
     public static final long ATLAS_CLIENT_DELAY = 60;
-    public static final long ATLAS_CLIENT_MAX_DURATION = 18000; //5hrs
+    public static final long ATLAS_CLIENT_MAX_DURATION = 18000; // (in seconds) - 5hrs
+    public static final long ATLAS_CLIENT_BACKOFF_MAX_DELAY = 3600; // (in seconds) - 1 hour
     public static final long KOJI_DOWNLOAD_CLIENT_DELAY = 1;
     public static final long SBOMER_CLIENT_DELAY = 1;
 

--- a/service/src/main/java/org/jboss/sbomer/service/feature/sbom/atlas/AtlasClient.java
+++ b/service/src/main/java/org/jboss/sbomer/service/feature/sbom/atlas/AtlasClient.java
@@ -17,9 +17,10 @@
  */
 package org.jboss.sbomer.service.feature.sbom.atlas;
 
+import static org.jboss.sbomer.core.rest.faulttolerance.Constants.ATLAS_CLIENT_BACKOFF_MAX_DELAY;
 import static org.jboss.sbomer.core.rest.faulttolerance.Constants.ATLAS_CLIENT_DELAY;
-import static org.jboss.sbomer.core.rest.faulttolerance.Constants.ATLAS_CLIENT_MAX_RETRIES;
 import static org.jboss.sbomer.core.rest.faulttolerance.Constants.ATLAS_CLIENT_MAX_DURATION;
+import static org.jboss.sbomer.core.rest.faulttolerance.Constants.ATLAS_CLIENT_MAX_RETRIES;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -48,8 +49,13 @@ import jakarta.ws.rs.core.MediaType;
 public interface AtlasClient {
 
     @POST
-    @Retry(maxRetries = ATLAS_CLIENT_MAX_RETRIES, delay = ATLAS_CLIENT_DELAY, delayUnit = ChronoUnit.SECONDS, maxDuration = ATLAS_CLIENT_MAX_DURATION, durationUnit = ChronoUnit.SECONDS)
-    @ExponentialBackoff
+    @Retry(
+            maxRetries = ATLAS_CLIENT_MAX_RETRIES,
+            delay = ATLAS_CLIENT_DELAY,
+            delayUnit = ChronoUnit.SECONDS,
+            maxDuration = ATLAS_CLIENT_MAX_DURATION,
+            durationUnit = ChronoUnit.SECONDS)
+    @ExponentialBackoff(maxDelay = ATLAS_CLIENT_BACKOFF_MAX_DELAY, maxDelayUnit = ChronoUnit.SECONDS)
     @BeforeRetry(RetryLogger.class)
     void upload(@QueryParam("labels") Map<String, String> labels, JsonNode bom);
 


### PR DESCRIPTION
See #1823, setting the delay (initial delay) to 60 seconds meant the expo backoff delay max delay was > initial delay (+/- jitter) and a runtime exception was thrown. Setting this to 1 hour max delay should resolve the issue

In this commit:
 * Introduce ATLAS_CLIENT_BACKOFF_MAX_DELAY