### PR TITLE
fix(SBOMER-536): incorrect header and content pair

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/ConfigReader.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/ConfigReader.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.sbomer.cli.feature.sbom;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -32,7 +33,6 @@ import org.jboss.sbomer.core.errors.ClientException;
 import org.jboss.sbomer.core.features.sbom.config.Config;
 import org.jboss.sbomer.core.features.sbom.utils.ObjectMapperProvider;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -170,8 +170,6 @@ public class ConfigReader {
 
         log.debug("Found GitHub repository: '{}/{}'", owner, repo);
 
-        String base64Config;
-
         log.debug(
                 "Fetching file '{}' from the '{}/{}' GitHub repository with tag '{}'",
                 CONFIG_PATH,
@@ -180,12 +178,9 @@ public class ConfigReader {
                 scmTag);
 
         try {
-            String jsonResponse = gitHubEnterpriseClient.fetchFile(owner, repo, CONFIG_PATH, scmTag);
-
-            // GitHub API returns JSON with base64 encoded content
-            // Parse the JSON to extract the content field
-            JsonNode jsonNode = jsonObjectMapper.readTree(jsonResponse);
-            base64Config = jsonNode.get("content").asText();
+            String rawContent = gitHubEnterpriseClient.fetchFile(owner, repo, CONFIG_PATH, scmTag);
+            log.debug("Successfully fetched the config file content from GitHub, length: {}", rawContent.length());
+            return rawContent.getBytes(StandardCharsets.UTF_8);
         } catch (Exception e) {
             log.debug(
                     "SBOMer configuration file could not be retrieved in the '{}/{}' repository with '{}' tag, ignoring",
@@ -193,11 +188,9 @@ public class ConfigReader {
                     repo,
                     scmTag,
                     e);
-
             return new byte[0];
         }
 
-        return Base64.getDecoder().decode(base64Config);
     }
 
     public Config getConfig(Build build) {

--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/GitHubEnterpriseClient.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/client/GitHubEnterpriseClient.java
@@ -24,6 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 
 /**
@@ -47,6 +48,7 @@ public interface GitHubEnterpriseClient {
      */
     @GET
     @Path("/repos/{owner}/{repo}/contents/{path}")
+    @Produces("application/vnd.github.raw+json")
     String fetchFile(
             @PathParam("owner") String owner,
             @PathParam("repo") String repo,

--- a/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/ConfigReaderIT.java
+++ b/cli/src/test/java/org/jboss/sbomer/cli/test/integ/feature/sbom/ConfigReaderIT.java
@@ -362,9 +362,7 @@ class ConfigReaderIT {
 
         @Test
         void testConfigMultipleProducts() throws IOException {
-            // GitHub API returns JSON with base64 encoded content
-            String base64Content = Base64.getEncoder().encodeToString(getTestConfigAsBytes("multi-product.yaml"));
-            String jsonResponse = String.format("{\"content\":\"%s\",\"encoding\":\"base64\"}", base64Content);
+            String rawContent = new String(getTestConfigAsBytes("multi-product.yaml"));
 
             Mockito.when(
                     gitHubEnterpriseClient.fetchFile(
@@ -372,7 +370,7 @@ class ConfigReaderIT {
                             "hibernate-hibernate-orm-product",
                             ".sbomer/config.yaml",
                             "1.1.0.redhat-00008"))
-                    .thenReturn(jsonResponse);
+                    .thenReturn(rawContent);
 
             assertNotNull(configReader.getConfig(build));
         }
@@ -392,20 +390,19 @@ class ConfigReaderIT {
                     .scmTag("0.3.0.redhat-00003")
                     .build();
 
-            String base64Content = Base64.getEncoder().encodeToString(getTestConfigAsBytes("multi-product.yaml"));
-            String jsonResponse = String.format("{\"content\":\"%s\",\"encoding\":\"base64\"}", base64Content);
+            String rawContent = new String(getTestConfigAsBytes("multi-product.yaml"));
 
             Mockito.when(
                     gitHubEnterpriseClient
                             .fetchFile("platform", "requirements", ".sbomer/config.yaml", "1.3.0.redhat-00013"))
-                    .thenReturn(jsonResponse);
+                    .thenReturn(rawContent);
 
             assertNotNull(configReader.getConfig(build2));
 
             Mockito.when(
                     gitHubEnterpriseClient
                             .fetchFile("platform", "requirements", ".sbomer/config.yaml", "0.3.0.redhat-00003"))
-                    .thenReturn(jsonResponse);
+                    .thenReturn(rawContent);
 
             assertNotNull(configReader.getConfig(build3));
         }


### PR DESCRIPTION
Switched from using "application/vnd.github.object" as this provided unnecessary metadata and parsing to "application/vnd.github.raw+json", which directly gets the file contents.