### PR TITLE
fix(SBOMER-541): Set bomref to be re-adjusted purl

### DIFF
--- a/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/AbstractAdjuster.java
+++ b/cli/src/main/java/org/jboss/sbomer/cli/feature/sbom/adjuster/AbstractAdjuster.java
@@ -126,10 +126,10 @@ public abstract class AbstractAdjuster implements Adjuster {
         // Read feature flag from environment variable set by Tekton Task parameter
         String envValue = System.getenv("SBOMER_FEATURE_GENERIC_COMPONENT_PURL_VERSION_REGEX_ENABLED");
         boolean featureFlagEnabled = Boolean.parseBoolean(envValue != null ? envValue : "false");
-        SbomUtils.setPurlVersionFromGeneric(metadataComponent, featureFlagEnabled);
+        SbomUtils.setPurlVersionFromGeneric(bom, metadataComponent, featureFlagEnabled);
 
         // Also update the main component that will be added to the components list
-        SbomUtils.setPurlVersionFromGeneric(mainComponent, featureFlagEnabled);
+        SbomUtils.setPurlVersionFromGeneric(bom, mainComponent, featureFlagEnabled);
 
         // Set main component
         bom.getMetadata().setComponent(metadataComponent);

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1780,6 +1780,17 @@ public class SbomUtils {
      * @param updateComponentPurl if true, also update the component.purl field (controlled by feature flag)
      */
     public static void setPurlVersionFromGeneric(Component c, boolean updateComponentPurl) {
+        setPurlVersionFromGeneric(null, c, updateComponentPurl);
+    }
+
+    /**
+     * Set the version of a generic PURL by extracting it from the filename.
+     *
+     * @param bom the BOM containing the component (optional, for dependency updates)
+     * @param c the component to update
+     * @param updateComponentPurl if true, also update the component.purl field (controlled by feature flag)
+     */
+    public static void setPurlVersionFromGeneric(Bom bom, Component c, boolean updateComponentPurl) {
         // Grab toplevel and evidence purls
         final Optional<PackageURL> topLevelPurl = Optional.ofNullable(c.getPurl()).map(purl -> {
             try {
@@ -1856,16 +1867,34 @@ public class SbomUtils {
                         GenericPurlWrapperUtil componentPurlWrapper = new GenericPurlWrapperUtil(topLevel);
                         PackageURL versionedComponentPurl = componentPurlWrapper.getVersionedPurl();
                         if (versionedComponentPurl != null) {
-                            String oldPurl = topLevel.canonicalize();
+                            String oldPurl = c.getPurl();
                             String newPurl = versionedComponentPurl.canonicalize();
                             c.setPurl(newPurl);
-                            // Also update bomRef to match the new purl, but only if bomRef exists and matches the old
-                            // purl
-                            if (c.getBomRef() != null && oldPurl.equals(c.getBomRef())) {
-                                c.setBomRef(newPurl);
+                            log.debug("Updated component purl from {} to {}", oldPurl, newPurl);
+
+                            // Check if bomRef should be updated
+                            boolean bomRefMatches = false;
+                            String bomRef = c.getBomRef();
+
+                            if (bomRef != null) {
+                                try {
+                                    // Try to parse bomRef as a PURL and compare canonicalized versions
+                                    bomRefMatches = topLevel.isCanonicalEquals(new PackageURL(bomRef));
+                                } catch (MalformedPackageURLException e) {
+                                    // bomRef is not a valid PURL, compare with old purl string
+                                    bomRefMatches = bomRef.equals(oldPurl);
+                                }
+                            }
+
+                            if (bomRefMatches) {
+                                if (bom != null) {
+                                    // Use updateBomRef to propagate changes to dependencies
+                                    SbomUtils.updateBomRef(bom, c, bomRef, newPurl);
+                                } else {
+                                    // Fallback: just update the component's bomRef
+                                    c.setBomRef(newPurl);
+                                }
                                 log.debug("Updated component purl and bomRef from {} to {}", oldPurl, newPurl);
-                            } else {
-                                log.debug("Updated component purl from {} to {}", oldPurl, newPurl);
                             }
                         }
                     } catch (MalformedPackageURLException e) {

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1859,7 +1859,8 @@ public class SbomUtils {
                             String oldPurl = topLevel.canonicalize();
                             String newPurl = versionedComponentPurl.canonicalize();
                             c.setPurl(newPurl);
-                            // Also update bomRef to match the new purl, but only if bomRef exists and matches the old purl
+                            // Also update bomRef to match the new purl, but only if bomRef exists and matches the old
+                            // purl
                             if (c.getBomRef() != null && oldPurl.equals(c.getBomRef())) {
                                 c.setBomRef(newPurl);
                                 log.debug("Updated component purl and bomRef from {} to {}", oldPurl, newPurl);

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1856,11 +1856,16 @@ public class SbomUtils {
                         GenericPurlWrapperUtil componentPurlWrapper = new GenericPurlWrapperUtil(topLevel);
                         PackageURL versionedComponentPurl = componentPurlWrapper.getVersionedPurl();
                         if (versionedComponentPurl != null) {
-                            c.setPurl(versionedComponentPurl.canonicalize());
-                            log.debug(
-                                    "Updated component purl from {} to {}",
-                                    topLevel.canonicalize(),
-                                    versionedComponentPurl.canonicalize());
+                            String oldPurl = topLevel.canonicalize();
+                            String newPurl = versionedComponentPurl.canonicalize();
+                            c.setPurl(newPurl);
+                            // Also update bomRef to match the new purl
+                            if (oldPurl.equals(c.getBomRef())) {
+                                c.setBomRef(newPurl);
+                                log.debug("Updated component purl and bomRef from {} to {}", oldPurl, newPurl);
+                            } else {
+                                log.debug("Updated component purl from {} to {}", oldPurl, newPurl);
+                            }
                         }
                     } catch (MalformedPackageURLException e) {
                         log.warn("Can't extract version from component generic purl: {}", e.getMessage());

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1859,8 +1859,8 @@ public class SbomUtils {
                             String oldPurl = topLevel.canonicalize();
                             String newPurl = versionedComponentPurl.canonicalize();
                             c.setPurl(newPurl);
-                            // Also update bomRef to match the new purl
-                            if (oldPurl.equals(c.getBomRef())) {
+                            // Also update bomRef to match the new purl, but only if bomRef exists and matches the old purl
+                            if (c.getBomRef() != null && oldPurl.equals(c.getBomRef())) {
                                 c.setBomRef(newPurl);
                                 log.debug("Updated component purl and bomRef from {} to {}", oldPurl, newPurl);
                             } else {

--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1869,12 +1869,14 @@ public class SbomUtils {
                         if (versionedComponentPurl != null) {
                             String oldPurl = c.getPurl();
                             String newPurl = versionedComponentPurl.canonicalize();
-                            c.setPurl(newPurl);
-                            log.debug("Updated component purl from {} to {}", oldPurl, newPurl);
-
-                            // Check if bomRef should be updated
-                            boolean bomRefMatches = false;
                             String bomRef = c.getBomRef();
+
+                            // Check if bomRef matches the old purl before proceeding
+                            // If bomRef exists but doesn't match, we should abort to avoid breaking dependency
+                            // references
+                            // If bomRef is null, we can proceed with the update
+                            boolean bomRefMatches = false;
+                            boolean shouldAbort = false;
 
                             if (bomRef != null) {
                                 try {
@@ -1884,8 +1886,28 @@ public class SbomUtils {
                                     // bomRef is not a valid PURL, compare with old purl string
                                     bomRefMatches = bomRef.equals(oldPurl);
                                 }
+
+                                // If bomRef exists but doesn't match the old purl, abort
+                                if (!bomRefMatches) {
+                                    shouldAbort = true;
+                                }
                             }
 
+                            // Abort if bomRef exists but doesn't match
+                            if (shouldAbort) {
+                                log.warn(
+                                        "Skipping purl update for component {} because bomRef '{}' does not match old purl '{}'",
+                                        c.getName(),
+                                        bomRef,
+                                        oldPurl);
+                                return;
+                            }
+
+                            // Update the component purl
+                            c.setPurl(newPurl);
+                            log.debug("Updated component purl from {} to {}", oldPurl, newPurl);
+
+                            // Update bomRef and dependencies if bomRef was set
                             if (bomRefMatches) {
                                 if (bom != null) {
                                     // Use updateBomRef to propagate changes to dependencies

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
@@ -937,4 +937,133 @@ class SbomUtilsTest {
                 component.getEvidence().getIdentities().get(0).getConcludedValue(),
                 "Evidence identity should still be updated with versioned purl even when feature flag is disabled");
     }
+
+    @Test
+    void testSetBomRef() {
+        String oldPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+        Component c = new Component();
+        c.setName("jboss-eap");
+        c.setType(Type.FILE);
+        c.setPurl(oldPurl);
+        c.setBomRef(oldPurl);
+        Bom bom = new Bom();
+        bom.addComponent(c);
+        Dependency d = SbomUtils.createDependency(c.getBomRef());
+        bom.addDependency(d);
+        SbomUtils.setPurlVersionFromGeneric(bom, c, true);
+        assertEquals(newPurl, c.getPurl());
+        assertEquals(c.getPurl(), c.getBomRef());
+        assertEquals(c.getBomRef(), bom.getDependencies().get(0).getRef());
+    }
+
+    @Test
+    void testSetBomRefWithNonPurlBomRef() {
+        String oldPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+        String nonPurlBomRef = "some-custom-bomref-id";
+
+        Component c = new Component();
+        c.setName("jboss-eap");
+        c.setType(Type.FILE);
+        c.setPurl(oldPurl);
+        c.setBomRef(nonPurlBomRef);
+
+        Bom bom = new Bom();
+        bom.addComponent(c);
+        Dependency d = SbomUtils.createDependency(c.getBomRef());
+        bom.addDependency(d);
+
+        SbomUtils.setPurlVersionFromGeneric(bom, c, true);
+
+        // Purl should be updated
+        assertEquals(newPurl, c.getPurl());
+        // BomRef should NOT be updated since it doesn't match the old purl
+        assertEquals(nonPurlBomRef, c.getBomRef());
+        // Dependency ref should remain unchanged
+        assertEquals(nonPurlBomRef, bom.getDependencies().get(0).getRef());
+    }
+
+    @Test
+    void testSetBomRefWithCanonicalization() {
+        // Use non-canonicalized PURL as bomRef
+        // Non-canonical PURL: qualifiers in reverse alphabetical order
+        String oldPurlNonCanonical = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip?type=zip&arch=noarch";
+        // Canonical PURL: qualifiers in alphabetical order
+        String oldPurlCanonical = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip?arch=noarch&type=zip";
+        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22?arch=noarch&type=zip";
+
+        Component c = new Component();
+        c.setName("jboss-eap");
+        c.setType(Type.FILE);
+        c.setPurl(oldPurlCanonical);
+        // Set bomRef to non-canonicalized version (should still match via canonicalization)
+        c.setBomRef(oldPurlNonCanonical);
+
+        Bom bom = new Bom();
+        bom.addComponent(c);
+        Dependency d = SbomUtils.createDependency(c.getBomRef());
+        bom.addDependency(d);
+
+        SbomUtils.setPurlVersionFromGeneric(bom, c, true);
+
+        // Both purl and bomRef should be updated
+        assertEquals(newPurl, c.getPurl());
+        assertEquals(newPurl, c.getBomRef());
+        // Dependency ref should be updated to new purl
+        assertEquals(newPurl, bom.getDependencies().get(0).getRef());
+    }
+
+    @Test
+    void testSetBomRefWithNestedDependencies() {
+        String oldPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+
+        Component c = new Component();
+        c.setName("jboss-eap");
+        c.setType(Type.FILE);
+        c.setPurl(oldPurl);
+        c.setBomRef(oldPurl);
+
+        Bom bom = new Bom();
+        bom.addComponent(c);
+
+        // Create nested dependency structure
+        Dependency mainDep = SbomUtils.createDependency("main-component");
+        Dependency nestedDep = SbomUtils.createDependency(c.getBomRef());
+        mainDep.addDependency(nestedDep);
+        bom.addDependency(mainDep);
+        bom.addDependency(SbomUtils.createDependency(c.getBomRef()));
+
+        SbomUtils.setPurlVersionFromGeneric(bom, c, true);
+
+        // Verify component updates
+        assertEquals(newPurl, c.getPurl());
+        assertEquals(newPurl, c.getBomRef());
+
+        // Verify top-level dependency was updated
+        assertEquals(newPurl, bom.getDependencies().get(1).getRef());
+
+        // Verify nested dependency was updated
+        assertEquals(newPurl, bom.getDependencies().get(0).getDependencies().get(0).getRef());
+    }
+
+    @Test
+    void testSetBomRefWithoutBom() {
+        String oldPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+
+        Component c = new Component();
+        c.setName("jboss-eap");
+        c.setType(Type.FILE);
+        c.setPurl(oldPurl);
+        c.setBomRef(oldPurl);
+
+        // Call without Bom (backward compatibility - using overloaded method)
+        SbomUtils.setPurlVersionFromGeneric(c, true);
+
+        // Both purl and bomRef should be updated
+        assertEquals(newPurl, c.getPurl());
+        assertEquals(newPurl, c.getBomRef());
+    }
 }

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
@@ -766,8 +766,8 @@ class SbomUtilsTest {
                 expectedVersionedPurl,
                 c.getEvidence().getIdentities().get(0).getConcludedValue(),
                 "Evidence identity purl should still be updated");
-        
-        //If we do not alter the purl then we shouldn't touch the bomref either
+
+        // If we do not alter the purl then we shouldn't touch the bomref either
         assertNull(c.getBomRef(), "BomRef should not be updated");
     }
 

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
@@ -829,7 +829,6 @@ class SbomUtilsTest {
     void testSetPurlVersionFromGenericDoesNotUpdateMismatchedBomRef() {
         String inputPurl = "pkg:generic/jboss-eap-7.4-runtime-maven-repository.zip";
         String differentBomRef = "pkg:generic/some-other-component.zip";
-        String expectedVersionedPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4";
 
         Component c = new Component();
         c.setPurl(inputPurl);
@@ -839,17 +838,18 @@ class SbomUtilsTest {
         // Call with feature flag enabled
         SbomUtils.setPurlVersionFromGeneric(c, true);
 
-        // Verify component.purl was updated
+        // When bomRef doesn't match the original purl, the method should abort
+        // and NOT update either the purl or bomRef to avoid breaking dependency references
         assertEquals(
-                expectedVersionedPurl,
+                inputPurl,
                 c.getPurl(),
-                "Component purl should be updated when feature flag is enabled");
+                "Component purl should NOT be updated when bomRef doesn't match the original purl");
 
-        // Verify bomRef was NOT updated since it didn't match the original purl
+        // Verify bomRef remains unchanged
         assertEquals(
                 differentBomRef,
                 c.getBomRef(),
-                "Component bomRef should NOT be updated when it doesn't match the original purl");
+                "Component bomRef should remain unchanged when it doesn't match the original purl");
     }
 
     @Test
@@ -960,7 +960,6 @@ class SbomUtilsTest {
     @Test
     void testSetBomRefWithNonPurlBomRef() {
         String oldPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
-        String newPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
         String nonPurlBomRef = "some-custom-bomref-id";
 
         Component c = new Component();
@@ -976,17 +975,15 @@ class SbomUtilsTest {
 
         SbomUtils.setPurlVersionFromGeneric(bom, c, true);
 
-        // Purl should be updated
-        assertEquals(newPurl, c.getPurl());
-        // BomRef should NOT be updated since it doesn't match the old purl
-        assertEquals(nonPurlBomRef, c.getBomRef());
-        // Dependency ref should remain unchanged
-        assertEquals(nonPurlBomRef, bom.getDependencies().get(0).getRef());
+        // When bomRef doesn't match the old purl, the method should abort
+        // and NOT update the purl to avoid breaking dependency references
+        assertEquals(oldPurl, c.getPurl(), "Purl should NOT be updated when bomRef doesn't match");
+        assertEquals(nonPurlBomRef, c.getBomRef(), "BomRef should remain unchanged");
+        assertEquals(nonPurlBomRef, bom.getDependencies().get(0).getRef(), "Dependency ref should remain unchanged");
     }
 
     @Test
     void testSetBomRefWithCanonicalization() {
-        // Use non-canonicalized PURL as bomRef
         // Non-canonical PURL: qualifiers in reverse alphabetical order
         String oldPurlNonCanonical = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip?type=zip&arch=noarch";
         // Canonical PURL: qualifiers in alphabetical order

--- a/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
+++ b/core/src/test/java/org/jboss/sbomer/core/test/unit/SbomUtilsTest.java
@@ -766,6 +766,9 @@ class SbomUtilsTest {
                 expectedVersionedPurl,
                 c.getEvidence().getIdentities().get(0).getConcludedValue(),
                 "Evidence identity purl should still be updated");
+        
+        //If we do not alter the purl then we shouldn't touch the bomref either
+        assertNull(c.getBomRef(), "BomRef should not be updated");
     }
 
     @Test
@@ -797,5 +800,141 @@ class SbomUtilsTest {
                 expectedEvidencePurl,
                 c.getEvidence().getIdentities().get(1).getConcludedValue(),
                 "Evidence identity should be updated with the longer purl");
+    }
+
+    @Test
+    void testSetPurlVersionFromGenericUpdatesBomRef() {
+        String inputPurl = "pkg:generic/jboss-eap-7.4-runtime-maven-repository.zip";
+        String expectedVersionedPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4";
+
+        Component c = new Component();
+        c.setPurl(inputPurl);
+        // Set bomRef to match the original purl (as would be done in createComponent)
+        c.setBomRef(inputPurl);
+
+        // Call with feature flag enabled
+        SbomUtils.setPurlVersionFromGeneric(c, true);
+
+        // Verify component.purl was updated
+        assertEquals(
+                expectedVersionedPurl,
+                c.getPurl(),
+                "Component purl should be updated when feature flag is enabled");
+
+        // Verify bomRef was also updated to match the new purl
+        assertEquals(expectedVersionedPurl, c.getBomRef(), "Component bomRef should be updated to match the new purl");
+    }
+
+    @Test
+    void testSetPurlVersionFromGenericDoesNotUpdateMismatchedBomRef() {
+        String inputPurl = "pkg:generic/jboss-eap-7.4-runtime-maven-repository.zip";
+        String differentBomRef = "pkg:generic/some-other-component.zip";
+        String expectedVersionedPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4";
+
+        Component c = new Component();
+        c.setPurl(inputPurl);
+        // Set bomRef to a different value (edge case where bomRef != purl)
+        c.setBomRef(differentBomRef);
+
+        // Call with feature flag enabled
+        SbomUtils.setPurlVersionFromGeneric(c, true);
+
+        // Verify component.purl was updated
+        assertEquals(
+                expectedVersionedPurl,
+                c.getPurl(),
+                "Component purl should be updated when feature flag is enabled");
+
+        // Verify bomRef was NOT updated since it didn't match the original purl
+        assertEquals(
+                differentBomRef,
+                c.getBomRef(),
+                "Component bomRef should NOT be updated when it doesn't match the original purl");
+    }
+
+    @Test
+    void testSetPurlVersionFromGenericWithCreateComponentAndFeatureFlagEnabled() {
+        // Setup: Create component using createComponent helper with EAP-style PURL
+        String inputPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String expectedVersionedPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+
+        Component component = createComponent(
+                "jboss-eap",
+                "7.4.22",
+                "runtime-maven-repository.zip",
+                "EAP runtime maven repository",
+                inputPurl,
+                Type.FILE);
+
+        // Verify initial state: createComponent sets bomRef to match purl
+        assertEquals(inputPurl, component.getPurl(), "Initial purl should match input");
+        assertEquals(inputPurl, component.getBomRef(), "Initial bomRef should match purl (set by createComponent)");
+
+        // Act: Call setPurlVersionFromGeneric with feature flag enabled
+        SbomUtils.setPurlVersionFromGeneric(component, true);
+
+        // Assert: Component purl should be updated with version extracted from filename
+        assertEquals(
+                expectedVersionedPurl,
+                component.getPurl(),
+                "Component purl should be updated to versioned purl when feature flag is enabled");
+
+        // Assert: BomRef should be updated to match the new versioned purl
+        assertEquals(
+                expectedVersionedPurl,
+                component.getBomRef(),
+                "Component bomRef should be updated to match the new versioned purl");
+
+        // Assert: Evidence identities should contain the versioned purl
+        assertNotNull(component.getEvidence(), "Evidence should be created");
+        assertNotNull(component.getEvidence().getIdentities(), "Evidence identities should be created");
+        assertTrue(component.getEvidence().getIdentities().size() > 0, "Should have at least one identity");
+        assertEquals(
+                expectedVersionedPurl,
+                component.getEvidence().getIdentities().get(0).getConcludedValue(),
+                "Evidence identity should contain the versioned purl");
+    }
+
+    @Test
+    void testSetPurlVersionFromGenericWithCreateComponentAndFeatureFlagDisabled() {
+        // Setup: Create component using createComponent helper with EAP-style PURL
+        String inputPurl = "pkg:generic/jboss-eap-7.4.22-runtime-maven-repository.zip";
+        String expectedVersionedPurl = "pkg:generic/jboss-eap-runtime-maven-repository.zip@7.4.22";
+
+        Component component = createComponent(
+                "jboss-eap",
+                "7.4.22",
+                "runtime-maven-repository.zip",
+                "EAP runtime maven repository",
+                inputPurl,
+                Type.FILE);
+
+        // Verify initial state
+        assertEquals(inputPurl, component.getPurl(), "Initial purl should match input");
+        assertEquals(inputPurl, component.getBomRef(), "Initial bomRef should match purl (set by createComponent)");
+
+        // Act: Call setPurlVersionFromGeneric with feature flag disabled
+        SbomUtils.setPurlVersionFromGeneric(component, false);
+
+        // Assert: Component purl should NOT be updated when feature flag is disabled
+        assertEquals(
+                inputPurl,
+                component.getPurl(),
+                "Component purl should NOT be updated when feature flag is disabled");
+
+        // Assert: BomRef should NOT be updated when feature flag is disabled
+        assertEquals(
+                inputPurl,
+                component.getBomRef(),
+                "Component bomRef should NOT be updated when feature flag is disabled");
+
+        // Assert: Evidence identities should still be updated (existing behavior preserved)
+        assertNotNull(component.getEvidence(), "Evidence should be created");
+        assertNotNull(component.getEvidence().getIdentities(), "Evidence identities should be created");
+        assertTrue(component.getEvidence().getIdentities().size() > 0, "Should have at least one identity");
+        assertEquals(
+                expectedVersionedPurl,
+                component.getEvidence().getIdentities().get(0).getConcludedValue(),
+                "Evidence identity should still be updated with versioned purl even when feature flag is disabled");
     }
 }


### PR DESCRIPTION
 It was found that the bomref diverged from the purl and this causes problems for some tooling that expects these to be identical
     
In this commit:
     * `SbomUtils` update `setPurlVersionFromGeneric` to set bomref for a component where the bomref and previous purl matched
