### PR TITLE
fix: fix error message when extracting version from generic PURL

### DIFF
--- a/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
+++ b/core/src/main/java/org/jboss/sbomer/core/features/sbom/utils/SbomUtils.java
@@ -1925,7 +1925,7 @@ public class SbomUtils {
                 }
             }
         } catch (MalformedPackageURLException e) {
-            log.warn("Can't extract version from generic purl with error: {}", e);
+            log.warn("Can't extract version from generic purl with error", e);
         }
     }
 


### PR DESCRIPTION
@jonathanchristison Is `e` preferred here or just `e.getMessage()`? Not the log message right before that uses `e.getMessage()` but we should probably make the text unique in that case to distinguish which one it is.